### PR TITLE
Improve use of UpdateVCS with git

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2449,6 +2449,7 @@ proc macports::GetVCSUpdateCmd portDir {
 # This proc could probably be generalized and used elsewhere.
 #
 proc macports::UpdateVCS {cmd portDir} {
+    global env
     if {[getuid] == 0} {
         # Must change egid before dropping root euid.
         set oldEGID [getegid]
@@ -2459,6 +2460,10 @@ proc macports::UpdateVCS {cmd portDir} {
         set newEUID [name_to_uid [file attributes $portDir -owner]]
         seteuid $newEUID
         ui_debug "Changed effective user ID from $oldEUID to $newEUID"
+        set oldHOME $env(HOME)
+        set newHOME [getpwuid $newEUID dir]
+        set env(HOME) $newHOME
+        ui_debug "Changed HOME to $newHOME"
     }
     ui_debug $cmd
     catch {system $cmd} result options
@@ -2467,6 +2472,8 @@ proc macports::UpdateVCS {cmd portDir} {
         ui_debug "Changed effective user ID from $newEUID to $oldEUID"
         setegid $oldEGID
         ui_debug "Changed effective group ID from $newEGID to $oldEGID"
+        set env(HOME) $oldHOME
+        ui_debug "Changed HOME to $oldHOME"
     }
     return -options $options $result
 }

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2424,14 +2424,14 @@ proc macports::GetVCSUpdateCmd portDir {
     } then {
         if {![catch {exec $git config --local --get svn-remote.svn.url}]} {
             # git-svn repository
-            return [list git-svn "$git svn rebase || true" $portDir]
+            return [list git-svn "$git svn rebase" $portDir]
         }
         # regular git repository
         set autostash ""
         if {![catch {exec $git --version} gitversion] && [vercmp [lindex [split $gitversion] end] 1.8.4] >= 0} {
             set autostash " --autostash"
         }
-        return [list Git "$git pull --rebase${autostash} || true" $portDir]
+        return [list Git "$git pull --rebase${autostash}" $portDir]
     }
 
     # Add new VCSes here!

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2455,25 +2455,21 @@ proc macports::UpdateVCS {cmd portDir} {
         set oldEGID [getegid]
         set newEGID [name_to_gid [file attributes $portDir -group]]
         setegid $newEGID
-        ui_debug "Changed effective group ID from $oldEGID to $newEGID"
         set oldEUID [geteuid]
         set newEUID [name_to_uid [file attributes $portDir -owner]]
         seteuid $newEUID
-        ui_debug "Changed effective user ID from $oldEUID to $newEUID"
         set oldHOME $env(HOME)
         set newHOME [getpwuid $newEUID dir]
         set env(HOME) $newHOME
-        ui_debug "Changed HOME to $newHOME"
+        ui_debug "euid/egid changed to: $newEUID/$newEGID, HOME changed to: $newHOME"
     }
     ui_debug $cmd
     catch {system $cmd} result options
     if {[getuid] == 0} {
         seteuid $oldEUID
-        ui_debug "Changed effective user ID from $newEUID to $oldEUID"
         setegid $oldEGID
-        ui_debug "Changed effective group ID from $newEGID to $oldEGID"
         set env(HOME) $oldHOME
-        ui_debug "Changed HOME to $oldHOME"
+        ui_debug "euid/egid restored to: $oldEUID/$oldEGID, HOME restored to: $oldHOME"
     }
     return -options $options $result
 }

--- a/src/pextlib1.0/Pextlib.c
+++ b/src/pextlib1.0/Pextlib.c
@@ -660,6 +660,7 @@ int Pextlib_Init(Tcl_Interp *interp)
     Tcl_CreateObjCommand(interp, "seteuid", seteuidCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "setgid", setgidCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "setegid", setegidCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "getpwuid", getpwuidCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "name_to_uid", name_to_uidCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "uid_to_name", uid_to_nameCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "uname_to_gid", uname_to_gidCmd, NULL, NULL);

--- a/src/pextlib1.0/uid.c
+++ b/src/pextlib1.0/uid.c
@@ -202,6 +202,107 @@ int setegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
     return TCL_OK;
 }
 
+/**
+ * wrapper around getpwuid(3)
+ *
+ * getpwuid <uid> [<field>]
+ *
+*/
+int getpwuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+    uid_t uid;
+    const char *field = NULL;
+    struct passwd *pw;
+    Tcl_Obj *result;
+
+    /* Check the arg count */
+    if (objc < 2 || objc > 3) {
+        Tcl_WrongNumArgs(interp, 1, objv, "getpwuid uid ?field?");
+        return TCL_ERROR;
+    }
+
+    /* Need to cast uid from int to unsigned int */
+    if (Tcl_GetIntFromObj(interp, objv[1], (int *) &uid) != TCL_OK) {
+        Tcl_SetResult(interp, "invalid uid", TCL_STATIC);
+        return TCL_ERROR;
+    }
+
+    if (objc == 3) {
+        field = Tcl_GetString(objv[2]);
+    }
+
+    pw = getpwuid(uid);
+    if (pw == NULL) {
+        result = Tcl_NewStringObj("getpwuid failed for ", -1);
+        Tcl_AppendObjToObj(result, Tcl_NewIntObj(uid));
+        Tcl_SetObjResult(interp, result);
+        return TCL_ERROR;
+    }
+
+    if (field == NULL) {
+        Tcl_Obj *reslist;
+        reslist = Tcl_NewListObj(0, NULL);
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("name", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj(pw->pw_name, -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("passwd", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj(pw->pw_passwd, -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("uid", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewIntObj(pw->pw_uid));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("gid", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewIntObj(pw->pw_gid));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("change", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewLongObj(pw->pw_change));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("class", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj(pw->pw_class, -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("gecos", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj(pw->pw_gecos, -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("dir", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj(pw->pw_dir, -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("shell", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj(pw->pw_shell, -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewStringObj("expire", -1));
+        Tcl_ListObjAppendElement(interp, reslist, Tcl_NewLongObj(pw->pw_expire));
+        Tcl_SetObjResult(interp, reslist);
+        return TCL_OK;
+    }
+
+    if (strcmp(field, "name") == 0) {
+        Tcl_SetResult(interp, pw->pw_name, TCL_VOLATILE);
+        return TCL_OK;
+    } else if (strcmp(field, "passwd") == 0) {
+        Tcl_SetResult(interp, pw->pw_passwd, TCL_VOLATILE);
+        return TCL_OK;
+    } else if (strcmp(field, "uid") == 0) {
+        Tcl_SetObjResult(interp, Tcl_NewIntObj(pw->pw_uid));
+        return TCL_OK;
+    } else if (strcmp(field, "gid") == 0) {
+        Tcl_SetObjResult(interp, Tcl_NewIntObj(pw->pw_gid));
+        return TCL_OK;
+    } else if (strcmp(field, "change") == 0) {
+        Tcl_SetObjResult(interp, Tcl_NewLongObj(pw->pw_change));
+        return TCL_OK;
+    } else if (strcmp(field, "class") == 0) {
+        Tcl_SetResult(interp, pw->pw_class, TCL_VOLATILE);
+        return TCL_OK;
+    } else if (strcmp(field, "gecos") == 0) {
+        Tcl_SetResult(interp, pw->pw_gecos, TCL_VOLATILE);
+        return TCL_OK;
+    } else if (strcmp(field, "dir") == 0) {
+        Tcl_SetResult(interp, pw->pw_dir, TCL_VOLATILE);
+        return TCL_OK;
+    } else if (strcmp(field, "shell") == 0) {
+        Tcl_SetResult(interp, pw->pw_shell, TCL_VOLATILE);
+        return TCL_OK;
+    } else if (strcmp(field, "expire") == 0) {
+        Tcl_SetObjResult(interp, Tcl_NewLongObj(pw->pw_expire));
+        return TCL_OK;
+    }
+
+    result = Tcl_NewStringObj("invalid field ", -1);
+    Tcl_AppendObjToObj(result, Tcl_NewStringObj(field, -1));
+    Tcl_SetObjResult(interp, result);
+    return TCL_ERROR;
+}
+
 /*
 	name_to_uid
 	

--- a/src/pextlib1.0/uid.h
+++ b/src/pextlib1.0/uid.h
@@ -43,6 +43,7 @@ int setuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONS
 int seteuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
 int setgidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
 int setegidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int getpwuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
 int name_to_uidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
 int uid_to_nameCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
 int uname_to_gidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);


### PR DESCRIPTION
These changes improve handling of a ports tree with git. Exporting HOME and SSH_AUTH_SOCK ensures that git can read its configuration and is able to access SSH keys if necessary.

Review-Request: @jmroot @neverpanic 