### PR TITLE
Support multi-valued maintainers

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -5142,3 +5142,16 @@ proc macports::shellescape {arg} {
     # Add a single quote at the start, escape all single quotes in the argument, and add a single quote at the end
     return "'[string map $mapping $arg]'"
 }
+
+##
+# Given a list of maintainers as recorded in a Portfile, return a list of lists
+# in [key value ...] format describing all maintainers. Valid keys are 'email'
+# which denotes a maintainer's email address, 'github', which preceeds the
+# GitHub username of the maintainer and 'keyword', which contains a special
+# maintainer keyword such as 'openmaintainer' or 'nomaintainer'.
+#
+# @param list A list of obscured maintainers
+# @return A list of associative arrays in serialized list format
+proc macports::unobscure_maintainers {list} {
+    return [macports_util::unobscure_maintainers $list]
+}

--- a/src/macports1.0/macports_util.tcl
+++ b/src/macports1.0/macports_util.tcl
@@ -38,6 +38,56 @@ namespace eval macports_util {
     ###################
     # Private methods #
     ###################
+
+    ##
+    # Given a list of maintainers as recorded in a Portfile, return a list of
+    # lists in [key value ...] format describing all maintainers. Valid keys
+    # are 'email' which denotes a maintainer's email address, 'github', which
+    # preceeds the GitHub username of the maintainer and 'keyword', which
+    # contains a special maintainer keyword such as 'openmaintainer' or
+    # 'nomaintainer'.
+    #
+    # @param list A list of obscured maintainers
+    # @return A list of associative arrays in serialized list format
+    proc unobscure_maintainers {list} {
+        set result {}
+        foreach sublist $list {
+            array set maintainer {}
+            foreach token $sublist {
+                if {[string index $token 0] eq "@"} {
+                    # Strings starting with @ are GitHub usernames
+                    set maintainer(github) [string range $token 1 end]
+                } elseif {[string first "@" $token] >= 0} {
+                    # Other strings that contain @ are plain email addresses
+                    set maintainer(email) $token
+                    continue
+                } elseif {[string first ":" $token] >= 0} {
+                    # Strings that contain a colon are obfuscated email
+                    # addresses
+
+                    # Split at :, assign the first part to $domain, re-assemble
+                    # the rest and assign it to $localpart
+                    set localpart [join [lassign [split $token ":"] domain] ":"]
+                    set maintainer(email) "${localpart}@${domain}"
+                } elseif {$token in {"openmaintainer" "nomaintainer"}} {
+                    # Filter openmaintainer and nomaintainer
+                    set maintainer(keyword) $token
+                } else {
+                    # All other entries must be MacPorts handles
+                    set maintainer(email) "${token}@macports.org"
+                }
+            }
+            set serialized [array get maintainer]
+            array unset maintainer
+            if {[llength $serialized]} {
+                # Filter empty maintainers
+                lappend result $serialized
+            }
+        }
+
+        return $result
+    }
+
     proc method_wrap {name} {
         variable argdefault
     

--- a/src/macports1.0/tests/macports_util.test
+++ b/src/macports1.0/tests/macports_util.test
@@ -30,6 +30,49 @@ test method_wrap {
 } -result "Method wrap successful."
 
 
+test unobscure_maintainers_github {
+    Test macports::unobscure_maintainers with a GitHub handle
+} -body {
+    return [macports::unobscure_maintainers {@github-user}]
+} -result {{github github-user}}
+
+test unobscure_maintainers_email {
+    Test macports::unobscure_maintainers with unobfuscated email addresses
+} -body {
+    return [macports::unobscure_maintainers {localpart@example.com}]
+} -result {{email localpart@example.com}}
+
+test unobscure_maintainers_obfuscated_email {
+    Test macports::unobscure_maintainers with obfuscated email addresses
+} -body {
+    return [macports::unobscure_maintainers {example.com:localpart}]
+} -result {{email localpart@example.com}}
+
+test unobscure_maintainers_handle {
+    Test macports::unobscure_maintainers with MacPorts handles
+} -body {
+    return [macports::unobscure_maintainers {handle}]
+} -result {{email handle@macports.org}}
+
+test unobscure_maintainers_keywords {
+    Test macports::unobscure_maintainers with nomaintainer and openmaintainer keywords
+} -body {
+    return [macports::unobscure_maintainers {nomaintainer openmaintainer}]
+} -result {{keyword nomaintainer} {keyword openmaintainer}}
+
+test unobscure_maintainers_multiple {
+    Test macports::unobscure_maintainers with multiple maintainers
+} -body {
+    return [macports::unobscure_maintainers {@github-user example.com:localpart}]
+} -result {{github github-user} {email localpart@example.com}}
+
+test unobscure_maintainers_multivalue {
+    Test macports::unobscure_maintainers with multi-value maintainers
+} -body {
+    return [macports::unobscure_maintainers {{handle @github-user}}]
+} -result {{email handle@macports.org github github-user}}
+
+
 test ldindex {
     Ldindex unit test.
 } -body {

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -629,22 +629,6 @@ proc wraplabel {label string maxlen {indent ""}} {
     return "$label[wrap $string $maxlen $indent 0]"
 }
 
-proc unobscure_maintainers { list } {
-    set result {}
-    foreach m $list {
-        if {[string first "@" $m] < 0} {
-            if {[string first ":" $m] >= 0} {
-                set m [regsub -- "(.*):(.*)" $m "\\2@\\1"]
-            } elseif {$m ne "openmaintainer" && $m ne "nomaintainer"} {
-                set m "$m@macports.org"
-            }
-        }
-        lappend result $m
-    }
-    return $result
-}
-
-
 ##########################################
 # Port selection
 ##########################################
@@ -2000,21 +1984,21 @@ proc action_info { action portlist opts } {
         # Understand which info items are actually lists
         # (this could be overloaded to provide a generic formatting code to
         # allow us to, say, split off the prefix on libs)
-        array set list_map "
-            categories      1
-            depends_fetch   1
-            depends_extract 1
-            depends_build   1
-            depends_lib     1
-            depends_run     1
-            depends_test    1
-            maintainers     1
-            platforms       1
-            variants        1
-            conflicts       1
-            subports        1
-            patchfiles      1
-        "
+        array set list_map {
+            categories      ", "
+            depends_fetch   ", "
+            depends_extract ", "
+            depends_build   ", "
+            depends_lib     ", "
+            depends_run     ", "
+            depends_test    ", "
+            maintainers     "\n"
+            platforms       ", "
+            variants        ", "
+            conflicts       ", "
+            subports        ", "
+            patchfiles      ", "
+        }
 
         # Label map for pretty printing
         array set pretty_label {
@@ -2155,7 +2139,7 @@ proc action_info { action portlist opts } {
                 if {![info exists portinfo($ropt)]} {
                     set inf ""
                 } else {
-                    set inf [join $portinfo($ropt)]
+                    set inf $portinfo($ropt)
                 }
             }
 
@@ -2171,9 +2155,40 @@ proc action_info { action portlist opts } {
                 set label "$opt: "
             }
 
+            if {$ropt in {"description" "long_description"}} {
+                # These fields support newlines, we need to [join ...] to make
+                # them newlines
+                set inf [join $inf]
+            }
+
             # Format the data
             if { $ropt eq "maintainers" } {
-                set inf [unobscure_maintainers $inf]
+                set infresult {}
+                foreach serialized [macports::unobscure_maintainers $inf] {
+                    set parts {}
+                    array set maintainer $serialized
+
+                    if {[info exists maintainer(email)]} {
+                        lappend parts "Email: $maintainer(email)"
+                    }
+                    if {[info exists maintainer(github)]} {
+                        lappend parts "GitHub: $maintainer(github)"
+                    }
+                    if {[info exists maintainer(keyword)]} {
+                        switch $maintainer(keyword) {
+                            nomaintainer {
+                                lappend parts "none"
+                            }
+                            openmaintainer {
+                                lappend parts "Policy: openmaintainer"
+                            }
+                        }
+                    }
+
+                    array unset maintainer
+                    lappend infresult [join $parts ", "]
+                }
+                set inf $infresult
             }
             #     ... special formatting for certain fields when prettyprinting
             if {$pretty_print} {
@@ -2217,7 +2232,7 @@ proc action_info { action portlist opts } {
             }
             #End of special pretty-print formatting for certain fields
             if {[info exists list_map($ropt)]} {
-                set field [join $inf $subfield_sep]
+                set field [join $inf $list_map($ropt)]
             } else {
                 set field $inf
             }

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1308,32 +1308,6 @@ proc lipo {} {
     }
 }
 
-
-# unobscure maintainer addresses as used in Portfiles
-# We allow two obscured forms:
-#   (1) User name only with no domain:
-#           foo implies foo@macports.org
-#   (2) Mangled name:
-#           subdomain.tld:username implies username@subdomain.tld
-#
-proc unobscure_maintainers { list } {
-    set result {}
-    foreach m $list {
-        if {[string first "@" $m] < 0} {
-            if {[string first ":" $m] >= 0} {
-                set m [regsub -- "(.*):(.*)" $m "\\2@\\1"]
-            } else {
-                set m "$m@macports.org"
-            }
-        }
-        lappend result $m
-    }
-    return $result
-}
-
-
-
-
 ########### Internal Dependency Manipulation Procedures ###########
 global ports_dry_last_skipped
 set ports_dry_last_skipped ""

--- a/src/port1.0/tests/portutil.test
+++ b/src/port1.0/tests/portutil.test
@@ -470,26 +470,6 @@ test makeuserproc {
 # test lipo -
 
 
-test unobscure_maintainers {
-    Unobscure maintainers unit test.
-} -body {
-    set list { port }
-    if { [unobscure_maintainers $list] != "port@macports.org" } {
-        return "FAIL: invalid maintainer name"
-    }
-    set list { google.com:port }
-    if { [unobscure_maintainers $list] != "port@google.com" } {
-        return "FAIL: invalid maintainer name"
-    }
-
-    set list { port@google.com }
-    if { [unobscure_maintainers $list] != "port@google.com" } {
-        return "FAIL: invalid maintainer name"
-    }
-    return "unobscure_maintainers successful."
-} -result "unobscure_maintainers successful."
-
-
 # test target_run
 # test recursive_collect_deps
 


### PR DESCRIPTION
We have two equal implementations of unobscure_maintainers, but only
a single one should exist. Move the implementation to the macports_util
package where it can be used by port(1) and port1.0, adjust uses in
port(1), drop the implementation from port1.0, because it is unused.

Additionally, add a test that verifies that @github-username works as
expected in base. Note that no changes in the code are required to
support this.

Review request: @macports/portmgr, @mojca, @larryv.