### PR TITLE
Fix version detection with Apple Git, adjust tests

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2433,7 +2433,9 @@ proc macports::GetVCSUpdateCmd portDir {
         }
         # regular git repository
         set autostash ""
-        if {![catch {exec $git --version} gitversion] && [vercmp [lindex [split $gitversion] end] 1.8.4] >= 0} {
+        if {![catch {exec $git --version} git_version_string] && \
+            [regexp -nocase "git version (\[^ ]+)" $git_version_string -> gitversion] && \
+            [vercmp $gitversion 1.8.4] >= 0} {
             set autostash " --autostash"
         }
         return [list Git "$git pull --rebase${autostash}" $portDir]

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -738,43 +738,44 @@ test GetVCSUpdateCmd-svn {
 
 
 testConstraint hasGit [expr {![catch {macports::findBinary git} git]}]
-testConstraint hasGitAutostash [expr {
-    ![catch {macports::findBinary git} git] &&
-    ![catch {exec $git --version} gitversion] &&
-    [package vcompare [lindex [split $gitversion] end] 1.8.4] >= 0}]
-testConstraint hasNoGitAutostash [expr {
-    ![catch {macports::findBinary git} git] &&
-    ![catch {exec $git --version} gitversion] &&
-    [package vcompare [lindex [split $gitversion] end] 1.8.4] < 0}]
+set git_vcsupdate_fixture {
+    set repo [makeDirectory macports-test-git-repo $tempdir]
+    exec $git init $repo
+    rename exec _save_exec
+
+    proc exec {cmd args} {
+        global gitversion
+        if {$cmd ne [macports::findBinary git] || [lindex $args 0] ne "--version"} {
+            return [_save_exec $cmd {*}$args]
+        }
+        return "git version $gitversion (Apple Git-23)"
+    }
+}
+set git_vcsupdate_cleanup {
+    removeDirectory macports-test-git-repo $tempdir
+    rename exec ""
+    rename _save_exec exec
+}
 
 test GetVCSUpdateCmd-git {
     Tests GetVCSUpdateCmd on a valid Git repository with Git >= 1.8.4
 } -constraints {
     hasGit
-    hasGitAutostash
-} -setup {
-    set repo [makeDirectory macports-test-git-repo $tempdir]
-    exec $git init $repo
-} -body {
+} -setup $git_vcsupdate_fixture -body {
+    global gitversion
+    set gitversion "1.8.6"
     string map [list $git GIT $repo REPO] [macports::GetVCSUpdateCmd $repo]
-} -cleanup {
-    removeDirectory macports-test-git-repo $tempdir
-} -result {Git {GIT pull --rebase --autostash} REPO}
+} -cleanup $git_vcsupdate_cleanup -result {Git {GIT pull --rebase --autostash} REPO}
 
 test GetVCSUpdateCmd-git-noautostash {
     Tests GetVCSUpdateCmd on a valid Git repository with Git < 1.8.4
 } -constraints {
     hasGit
-    hasNoGitAutostash
-} -setup {
-    set repo [makeDirectory macports-test-git-repo $tempdir]
-    exec $git init $repo
-} -body {
+} -setup $git_vcsupdate_fixture -body {
+    global giversion
+    set gitversion "1.8.2"
     string map [list $git GIT $repo REPO] [macports::GetVCSUpdateCmd $repo]
-} -cleanup {
-    removeDirectory macports-test-git-repo $tempdir
-} -result {Git {GIT pull --rebase} REPO}
-
+} -cleanup $git_vcsupdate_cleanup -result {Git {GIT pull --rebase} REPO}
 
 testConstraint hasGitSvn [expr {
     ![catch {macports::findBinary git} git] &&


### PR DESCRIPTION
Apple's /usr/bin/git returns additional information at the end of the
standard Git version string, so that splitting at whitespace and using
the last component does not yield the expected version number.

Fix this by using a regex instead and adjust the tests to test both
cases.

For reference: The string returned by /usr/bin/git looks similar to
| git version 2.9.3 (Apple Git-75)