### PR TITLE
Remove svn.macports.org as fallback for distfiles

### DIFF
--- a/src/package1.0/portarchivefetch.tcl
+++ b/src/package1.0/portarchivefetch.tcl
@@ -209,7 +209,7 @@ proc portarchivefetch::fetchfiles {args} {
                 return -code error [format [msgcat::mc "%s must be writable"] $incoming_path]
             }
             if {!$sorted} {
-                portfetch::sortsites archivefetch_urls {} archive_sites
+                portfetch::sortsites archivefetch_urls archive_sites
                 set sorted yes
             }
             if {![info exists urlmap($url_var)]} {

--- a/src/port1.0/fetch_common.tcl
+++ b/src/port1.0/fetch_common.tcl
@@ -84,15 +84,14 @@ proc portfetch::assemble_url {site distfile} {
 # For a given mirror site type, e.g. "gnu" or "x11", check to see if there's a
 # pre-registered set of sites, and if so, return them.
 proc portfetch::mirror_sites {mirrors tag subdir mirrorfile} {
-    global UI_PREFIX name dist_subdir \
-           global_mirror_site fallback_mirror_site
+    global UI_PREFIX name dist_subdir global_mirror_site
 
     if {[file exists $mirrorfile]} {
         source $mirrorfile
     }
 
     if {![info exists portfetch::mirror_sites::sites($mirrors)]} {
-        if {$mirrors != $global_mirror_site && $mirrors != $fallback_mirror_site} {
+        if {$mirrors != $global_mirror_site} {
             ui_warn "[format [msgcat::mc "No mirror sites on file for class %s"] $mirrors]"
         }
         return {}
@@ -162,10 +161,10 @@ proc portfetch::checksites {sitelists mirrorfile} {
             continue
         }
         global ${listname}.mirror_subdir
-        # add the specified global, fallback and user-defined mirrors
-        set sglobal [lindex $extras 0]; set sfallback [lindex $extras 1]; set senv [lindex $extras 2]
+        # add the specified global and user-defined mirrors
+        set sglobal [lindex $extras 0]; set senv [lindex $extras 2]
         set full_list [set $listname]
-        append full_list " $sglobal $sfallback"
+        append full_list " $sglobal"
         if {[info exists env($senv)]} {
             set full_list [concat $env($senv) $full_list]
         }
@@ -189,14 +188,11 @@ proc portfetch::checksites {sitelists mirrorfile} {
             }
         }
 
-        # add in the global, fallback and user-defined mirrors for each tag
+        # add in the global and user-defined mirrors for each tag
         foreach site $site_list {
             if {[regexp {([a-zA-Z]+://.+/?):([0-9A-Za-z_-]+)$} $site match site tag] && ![info exists extras_added($tag)]} {
                 if {$sglobal ne ""} {
                     set site_list [concat $site_list [mirror_sites $sglobal $tag "" $mirrorfile]]
-                }
-                if {$sfallback ne ""} {
-                    set site_list [concat $site_list [mirror_sites $sfallback $tag "" $mirrorfile]]
                 }
                 if {[info exists env($senv)]} {
                     set site_list [concat [list $env($senv)] $site_list]
@@ -216,7 +212,7 @@ proc portfetch::checksites {sitelists mirrorfile} {
 }
 
 # sorts fetch_urls in order of ping time
-proc portfetch::sortsites {urls fallback_mirror_list default_listvar} {
+proc portfetch::sortsites {urls default_listvar} {
     global $default_listvar
     upvar $urls fetch_urls
     variable urlmap
@@ -234,7 +230,7 @@ proc portfetch::sortsites {urls fallback_mirror_list default_listvar} {
         set hosts {}
         set hostregex {[a-zA-Z]+://([a-zA-Z0-9\.\-_]+)}
 
-        if {[llength $urllist] - [llength $fallback_mirror_list] <= 1} {
+        if {[llength $urllist] <= 1} {
             # there is only one mirror, no need to ping or sort
             continue
         }
@@ -257,15 +253,6 @@ proc portfetch::sortsites {urls fallback_mirror_list default_listvar} {
             if { [info exists seen($host)] } {
                 continue
             }
-            foreach fallback $fallback_mirror_list {
-                if {[string match ${fallback}* $site]} {
-                    # don't bother pinging fallback mirrors
-                    set seen($host) yes
-                    # and make them sort to the very end of the list
-                    set pingtimes($host) 20000
-                    break
-                }
-            }
             if { ![info exists seen($host)] } {
                 # first check the persistent cache
                 set pingtimes($host) [get_pingtime $host]
@@ -285,7 +272,7 @@ proc portfetch::sortsites {urls fallback_mirror_list default_listvar} {
         foreach host $hosts {
             gets $fds($host) pingtimes($host)
             if { [catch { close $fds($host) }] || ![string is double -strict $pingtimes($host)] } {
-                # ping failed, so put it last in the list (but before the fallback mirrors)
+                # ping failed, so put it last in the list
                 set pingtimes($host) 10000
             }
             # cache it

--- a/src/port1.0/fetch_common.tcl
+++ b/src/port1.0/fetch_common.tcl
@@ -162,7 +162,7 @@ proc portfetch::checksites {sitelists mirrorfile} {
         }
         global ${listname}.mirror_subdir
         # add the specified global and user-defined mirrors
-        set sglobal [lindex $extras 0]; set senv [lindex $extras 2]
+        set sglobal [lindex $extras 0]; set senv [lindex $extras 1]
         set full_list [set $listname]
         append full_list " $sglobal"
         if {[info exists env($senv)]} {

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -116,7 +116,6 @@ default fetch.ignore_sslcert "no"
 # Use remote timestamps
 default fetch.remote_time "no"
 
-default fallback_mirror_site "macports"
 default global_mirror_site "macports_distfiles"
 default mirror_sites.listfile {"mirror_sites.tcl"}
 default mirror_sites.listpath {"port1.0/fetch"}
@@ -274,11 +273,11 @@ proc portfetch::get_full_mirror_sites_path {} {
 # Perform the full checksites/checkpatchfiles/checkdistfiles sequence.
 # This method is used by distcheck target.
 proc portfetch::checkfiles {urls} {
-    global global_mirror_site fallback_mirror_site
+    global global_mirror_site
     upvar $urls fetch_urls
 
-    checksites [list patch_sites [list $global_mirror_site $fallback_mirror_site PATCH_SITE_LOCAL] \
-                master_sites [list $global_mirror_site $fallback_mirror_site MASTER_SITE_LOCAL]] \
+    checksites [list patch_sites [list $global_mirror_site PATCH_SITE_LOCAL] \
+                master_sites [list $global_mirror_site MASTER_SITE_LOCAL]] \
                [get_full_mirror_sites_path]
     checkpatchfiles fetch_urls
     checkdistfiles fetch_urls
@@ -485,7 +484,7 @@ proc portfetch::hgfetch {args} {
 proc portfetch::fetchfiles {args} {
     global distpath all_dist_files UI_PREFIX \
            fetch.user fetch.password fetch.use_epsv fetch.ignore_sslcert fetch.remote_time \
-           fallback_mirror_site portverbose usealtworkpath altprefix
+           portverbose usealtworkpath altprefix
     variable fetch_urls
     variable urlmap
 
@@ -527,7 +526,7 @@ proc portfetch::fetchfiles {args} {
                 continue
             }
             if {!$sorted} {
-                sortsites fetch_urls [mirror_sites $fallback_mirror_site {} {} [get_full_mirror_sites_path]] master_sites
+                sortsites fetch_urls master_sites
                 set sorted yes
             }
             if {![info exists urlmap($url_var)]} {


### PR DESCRIPTION
If a port really still needs to use this, they can specify this
explicitly with `master_sites macports`.

Closes: https://trac.macports.org/ticket/52626

Review request: @ryandesign