### PR TITLE
Use a 'catch' wrapper that can ignore signals

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,7 +17,7 @@ include Mk/macports.autoconf.mk
 
 all:: Mk/macports.autoconf.mk
 
-Mk/macports.autoconf.mk: Mk/macports.autoconf.mk.in src/config.h.in Makefile.in doc/Makefile.in src/Makefile.in src/cflib1.0/Makefile.in src/cregistry/Makefile.in src/darwintracelib1.0/Makefile.in src/machista1.0/Makefile.in src/macports1.0/Makefile.in src/package1.0/Makefile.in src/pextlib1.0/Makefile.in src/port/Makefile.in src/port1.0/Makefile.in src/programs/Makefile.in src/programs/daemondo/Makefile.in src/registry2.0/Makefile.in tests/Makefile.in config.status
+Mk/macports.autoconf.mk: Mk/macports.autoconf.mk.in src/config.h.in Makefile.in doc/Makefile.in src/Makefile.in src/cflib1.0/Makefile.in src/cregistry/Makefile.in src/darwintracelib1.0/Makefile.in src/machista1.0/Makefile.in src/macports1.0/Makefile.in src/mpcommon1.0/Makefile.in src/package1.0/Makefile.in src/pextlib1.0/Makefile.in src/port/Makefile.in src/port1.0/Makefile.in src/programs/Makefile.in src/programs/daemondo/Makefile.in src/registry2.0/Makefile.in tests/Makefile.in config.status
 	./config.status
 	${MAKE} clean
 

--- a/configure.ac
+++ b/configure.ac
@@ -430,6 +430,7 @@ AC_CONFIG_FILES([
 	src/macports1.0/Makefile
 	src/macports1.0/macports_autoconf.tcl
 	src/macports1.0/macports_test_autoconf.tcl
+	src/mpcommon1.0/Makefile
 	src/package1.0/Makefile
 	src/package1.0/package_test_autoconf.tcl
 	src/pextlib1.0/Makefile

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -7,7 +7,8 @@ TCLPKG=		cregistry \
 			port1.0 \
 			package1.0 \
 			pextlib1.0 \
-			machista1.0
+			machista1.0 \
+			mpcommon1.0
 SUBDIR=		${TCLPKG} port programs
 
 ifeq (@TRACEMODE_SUPPORT@,1)

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -41,6 +41,9 @@ package require reclaim 1.0
 package require selfupdate 1.0
 package require Tclx
 
+# catch wrapper shared with port1.0
+package require mpcommon 1.0
+
 namespace eval macports {
     namespace export bootstrap_options user_options portinterp_options open_mports ui_priorities
     variable bootstrap_options "\

--- a/src/macports1.0/macports_util.tcl
+++ b/src/macports1.0/macports_util.tcl
@@ -378,8 +378,10 @@ proc try {args} {
         }
     }
 
-    # at this point, we've processed all args
-    if {[set err [catch {uplevel 1 $body} result]] == 1} {
+    # at this point, we've processed all args'
+    # builtin_catch is the normal Tcl catch command, rather than the wrapper
+    # defined in common/catch.tcl and sourced by macports.tcl
+    if {[set err [builtin_catch {uplevel 1 $body} result]] == 1} {
         set savedErrorCode $::errorCode
         set savedErrorInfo $::errorInfo
         # rip out the last "invoked from within" - we want to hide our internals
@@ -410,7 +412,7 @@ proc try {args} {
                 if {[set infovar [lshift elem]] ne ""} {
                     uplevel 1 set [list $infovar] [list $savedErrorInfo]
                 }
-                if {[set err [catch {uplevel 1 $catchBody} result]] == 1} {
+                if {[set err [builtin_catch {uplevel 1 $catchBody} result]] == 1} {
                     # error in the catch block, save it
                     set savedErrorCode $::errorCode
                     set savedErrorInfo $::errorInfo
@@ -433,7 +435,7 @@ proc try {args} {
         # catch errors here so we can strip our uplevel
         set savedErr $err
         set savedResult $result
-        if {[set err [catch {uplevel 1 $finallyBody} result]] == 1} {
+        if {[set err [builtin_catch {uplevel 1 $finallyBody} result]] == 1} {
             set savedErrorCode $::errorCode
             set savedErrorInfo $::errorInfo
             # rip out the last "invoked from within" - we want to hide our internals

--- a/src/mpcommon1.0/Makefile.in
+++ b/src/mpcommon1.0/Makefile.in
@@ -1,0 +1,28 @@
+srcdir = @srcdir@
+VPATH  = @srcdir@
+
+include ../../Mk/macports.autoconf.mk
+
+SRCS = mpcommon.tcl signalcatch.tcl
+
+INSTALLDIR= ${DESTDIR}${TCL_PACKAGE_PATH}/mpcommon1.0
+
+all:: pkgIndex.tcl
+
+pkgIndex.tcl: $(SRCS)
+	$(SILENT) ../pkg_mkindex.sh .
+
+clean::
+	rm -f pkgIndex.tcl
+
+distclean:: clean
+	rm -f Makefile
+
+install:: all
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(SILENT) set -x; for file in ${SRCS}; do \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${INSTALLDIR}/$$file"; \
+	done
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"
+
+test:: ;

--- a/src/mpcommon1.0/mpcommon.tcl
+++ b/src/mpcommon1.0/mpcommon.tcl
@@ -1,0 +1,2 @@
+package provide mpcommon 1.0
+package require signalcatch 1.0

--- a/src/mpcommon1.0/signalcatch.tcl
+++ b/src/mpcommon1.0/signalcatch.tcl
@@ -1,0 +1,27 @@
+package provide signalcatch 1.0
+
+# Wrap the 'catch' command so that we can decide whether to catch signals
+# or propagate them as an error. Default is to propagate; to catch them use
+# 'catch -signal ...'
+if {[info commands builtin_catch] eq {}} {
+    rename catch builtin_catch
+
+    proc catch {args} {
+        set catch_signal no
+        if {[lindex $args 0] eq "-signal"} {
+            set catch_signal yes
+            set args [lrange $args 1 end]
+        }
+        set err [uplevel 1 [list builtin_catch {*}$args]]
+        if {$err == 1 && !$catch_signal} {
+            set savedErrorCode $::errorCode
+            set savedErrorInfo $::errorInfo
+            set sigstring "POSIX SIG "
+            set len [string length $sigstring]
+            if {[string equal -length $len $sigstring $savedErrorCode]} {
+                return -code error -errorinfo $savedErrorInfo -errorcode $savedErrorCode "Aborted: [lindex $savedErrorCode end] signal received"
+            }
+        }
+        return $err
+    }
+}

--- a/src/port1.0/port.tcl
+++ b/src/port1.0/port.tcl
@@ -32,6 +32,10 @@
 # standard package load
 package provide port 1.0
 
+# catch wrapper shared with macports1.0
+# aliasing it in doesn't work right because of uplevel use
+package require mpcommon 1.0
+
 # Provide a callback registration mechanism for port subpackages. This needs to
 # be done _before_ loading the subpackages.
 namespace eval port {


### PR DESCRIPTION
The addition of Tclx signal handlers means that SIGINT and SIGTERM
now result in an error being raised. In most places where the catch
command is used, we don't actually check if the error is a signal, and
in most of those cases can't do anything sensible except re-raise the
error anyway.

Thus we replace 'catch' with our own version which encapsulates
checking if the error is a signal and (by default) re-raises it if so.
The -signal flag can be passed as the first argument to the new catch
to make it catch signals too.

The code is sourced from its own file in both the main interpreter
and the slave interpreters that execute Portfiles. It can't simply be
aliased in to the slaves like we normally do for shared commands
because it uses uplevel and aliases add an extra call level.