### PR TITLE
Fix 'port info' output for maintainers and long_description

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -1981,23 +1981,23 @@ proc action_info { action portlist opts } {
         }
         array unset options ports_info_index
 
-        # Understand which info items are actually lists
-        # (this could be overloaded to provide a generic formatting code to
-        # allow us to, say, split off the prefix on libs)
+        # Understand which info items are actually lists by specifying
+        # separators for the output. The list items correspond to the
+        # normal, --pretty, and --line output formats.
         array set list_map {
-            categories      ", "
-            depends_fetch   ", "
-            depends_extract ", "
-            depends_build   ", "
-            depends_lib     ", "
-            depends_run     ", "
-            depends_test    ", "
-            maintainers     "\n"
-            platforms       ", "
-            variants        ", "
-            conflicts       ", "
-            subports        ", "
-            patchfiles      ", "
+            categories      {", "  ", "  ","}
+            depends_fetch   {", "  ", "  ","}
+            depends_extract {", "  ", "  ","}
+            depends_build   {", "  ", "  ","}
+            depends_lib     {", "  ", "  ","}
+            depends_run     {", "  ", "  ","}
+            depends_test    {", "  ", "  ","}
+            maintainers     {", "  "\n"  ","}
+            platforms       {", "  ", "  ","}
+            variants        {", "  ", "  ","}
+            conflicts       {", "  ", "  ","}
+            subports        {", "  ", "  ","}
+            patchfiles      {", "  ", "  ","}
         }
 
         # Label map for pretty printing
@@ -2059,14 +2059,16 @@ proc action_info { action portlist opts } {
         # Set up our field separators
         set show_label 1
         set field_sep "\n"
-        set subfield_sep ", "
         set pretty_print 0
+        set list_map_index 0
 
         # For human-readable summary, which is the default with no options
         if {[llength [array get options ports_info_*]] == 0} {
             set pretty_print 1
+            set list_map_index 1
         } elseif {[info exists options(ports_info_pretty)]} {
             set pretty_print 1
+            set list_map_index 1
             array unset options ports_info_pretty
         }
 
@@ -2076,7 +2078,7 @@ proc action_info { action portlist opts } {
             set noseparator 1
             set show_label 0
             set field_sep "\t"
-            set subfield_sep ","
+            set list_map_index 2
         }
 
         # Figure out whether to show field name
@@ -2232,7 +2234,7 @@ proc action_info { action portlist opts } {
             }
             #End of special pretty-print formatting for certain fields
             if {[info exists list_map($ropt)]} {
-                set field [join $inf $list_map($ropt)]
+                set field [join $inf [lindex $list_map($ropt) $list_map_index]]
             } else {
                 set field $inf
             }

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2171,24 +2171,30 @@ proc action_info { action portlist opts } {
                     array set maintainer $serialized
 
                     if {[info exists maintainer(email)]} {
-                        lappend parts "Email: $maintainer(email)"
+                        set item [expr {$pretty_print ? "Email: " : ""}]
+                        append item $maintainer(email)
+                        lappend parts $item
                     }
                     if {[info exists maintainer(github)]} {
-                        lappend parts "GitHub: $maintainer(github)"
+                        set item [expr {$pretty_print ? "GitHub: " : ""}]
+                        append item $maintainer(github)
+                        lappend parts $item
                     }
                     if {[info exists maintainer(keyword)]} {
                         switch $maintainer(keyword) {
                             nomaintainer {
-                                lappend parts "none"
+                                lappend parts [expr {$pretty_print ? "none" : ""}]
                             }
                             openmaintainer {
-                                lappend parts "Policy: openmaintainer"
+                                set item [expr {$pretty_print ? "Policy: " : ""}]
+                                append item "openmaintainer"
+                                lappend parts $item
                             }
                         }
                     }
 
                     array unset maintainer
-                    lappend infresult [join $parts ", "]
+                    lappend infresult [join $parts [expr {$pretty_print ? ", " : " "}]]
                 }
                 set inf $infresult
             }

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2163,8 +2163,8 @@ proc action_info { action portlist opts } {
                 set inf [join $inf]
             }
 
-            # Format the data
-            if { $ropt eq "maintainers" } {
+            # Format list of maintainers
+            if {$ropt eq "maintainers"} {
                 set infresult {}
                 foreach serialized [macports::unobscure_maintainers $inf] {
                     set parts {}

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2202,47 +2202,48 @@ proc action_info { action portlist opts } {
                 }
                 set inf $infresult
             }
-            #     ... special formatting for certain fields when prettyprinting
-            if {$pretty_print} {
-                if {$ropt eq "variants"} {
-                    # Use the new format for variants iff it exists in
-                    # PortInfo. This key currently does not exist outside of
-                    # trunk (1.8.0).
-                    array unset vinfo
-                    if {[info exists portinfo(vinfo)]} {
-                        array set vinfo $portinfo(vinfo)
-                    }
 
-                    set pi_vars $inf
-                    set inf {}
-                    foreach v [lsort $pi_vars] {
-                        set varmodifier ""
-                        if {[info exists variations($v)]} {
-                            # selected by command line, prefixed with +/-
-                            set varmodifier $variations($v)
-                        } elseif {[info exists global_variations($v)]} {
-                            # selected by variants.conf, prefixed with (+)/(-)
-                            set varmodifier "($global_variations($v))"
-                            # Retrieve additional information from the new key.
-                        } elseif {[info exists vinfo]} {
-                            array unset variant
-                            array set variant $vinfo($v)
-                            if {[info exists variant(is_default)]} {
-                                set varmodifier "\[$variant(is_default)]"
-                            }
+            # Format variants
+            if {$pretty_print && $ropt eq "variants"} {
+                array unset vinfo
+                if {[info exists portinfo(vinfo)]} {
+                    array set vinfo $portinfo(vinfo)
+                }
+
+                set pi_vars $inf
+                set inf {}
+                foreach v [lsort $pi_vars] {
+                    set varmodifier ""
+                    if {[info exists variations($v)]} {
+                        # selected by command line, prefixed with +/-
+                        set varmodifier $variations($v)
+                    } elseif {[info exists global_variations($v)]} {
+                        # selected by variants.conf, prefixed with (+)/(-)
+                        set varmodifier "($global_variations($v))"
+                        # Retrieve additional information from the new key.
+                    } elseif {[info exists vinfo]} {
+                        array unset variant
+                        array set variant $vinfo($v)
+                        if {[info exists variant(is_default)]} {
+                            set varmodifier "\[$variant(is_default)]"
                         }
-                        lappend inf "$varmodifier$v"
                     }
-                } elseif {[string match "depend*" $ropt]
-                          && ![macports::ui_isset ports_verbose]} {
-                    set pi_deps $inf
-                    set inf {}
-                    foreach d $pi_deps {
-                        lappend inf [lindex [split $d :] end]
-                    }
+                    lappend inf "$varmodifier$v"
                 }
             }
-            #End of special pretty-print formatting for certain fields
+
+            # Show full depspec only in verbose mode
+            if {[string match "depend*" $ropt]
+                        && ![macports::ui_isset ports_verbose]} {
+                set pi_deps $inf
+                set inf {}
+                foreach d $pi_deps {
+                    lappend inf [lindex [split $d :] end]
+                }
+            }
+
+            # End of special pretty-print formatting for certain fields
+
             if {[info exists list_map($ropt)]} {
                 set field [join $inf [lindex $list_map($ropt) $list_map_index]]
             } else {

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2161,6 +2161,10 @@ proc action_info { action portlist opts } {
                 # These fields support newlines, we need to [join ...] to make
                 # them newlines
                 set inf [join $inf]
+                # Flatten value to a single line unless we are pretty printing
+                if {!$pretty_print} {
+                    set inf [string map {"\n" {\n}} $inf]
+                }
             }
 
             # Format list of maintainers


### PR DESCRIPTION
After 30c27d5d3ad169ffa5f55465cf9663dbd1ff7537, the output of `port info` for maintainers is broken for some cases. This tries to resemble the old output of 2.3.4 as closely as possible.

While I am at it, also fix the output for long_description that should not contain multiple lines unless the output is pretty-printed.

See: https://trac.macports.org/ticket/52928
Review-Request: @neverpanic