### PR TITLE
Add missing quotes around some Makefile variables

### DIFF
--- a/Mk/macports.tea.mk
+++ b/Mk/macports.tea.mk
@@ -21,6 +21,6 @@ clean::
 distclean:: clean
 
 install:: all
-	$(INSTALL) -d -o ${DSTUSR} -g ${DSTGRP} -m ${DSTMODE} ${INSTALLDIR}
-	$(INSTALL) -o ${DSTUSR} -g ${DSTGRP} -m 444 ${SHLIB_NAME} ${INSTALLDIR}
-	$(INSTALL) -o ${DSTUSR} -g ${DSTGRP} -m 444 pkgIndex.tcl ${INSTALLDIR}
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 ${SHLIB_NAME} "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"


### PR DESCRIPTION
Put quotes around some variables which can contain special characters. These are quoted in other makefiles.