### PR TITLE
Improve description of -N switch

### DIFF
--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -199,4 +199,4 @@ universal_archs     	@UNIVERSAL_ARCHS@
 #pkg_post_unarchive_deletions	include share/doc share/man
 
 # Whether the user interface should ask interactive questions
-#ui_interactive         yes
+#ui_interactive_questions  yes

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -129,7 +129,7 @@ The port command recognizes several global flags and options.
     Quiet mode, suppress informational messages to a minimum, implies -N
 
 -N::
-    Non-interactive mode, interactive questions are not asked 
+    Non-question mode, interactive questions are not asked (avoid typing yes)
 
 .Installation and upgrade
 -n::

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -129,7 +129,7 @@ The port command recognizes several global flags and options.
     Quiet mode, suppress informational messages to a minimum, implies -N
 
 -N::
-    Non-question mode, interactive questions are not asked (avoid typing yes)
+    No-questions mode, interactive questions are not asked (avoid typing yes)
 
 .Installation and upgrade
 -n::

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -56,7 +56,7 @@ namespace eval macports {
         master_site_local patch_site_local archive_site_local buildfromsource \
         revupgrade_autorun revupgrade_mode revupgrade_check_id_loadcmds \
         host_blacklist preferred_hosts sandbox_enable delete_la_files cxx_stdlib \
-        packagemaker_path default_compilers pkg_post_unarchive_deletions ui_interactive"
+        packagemaker_path default_compilers pkg_post_unarchive_deletions ui_interactive_questions"
     variable user_options {}
     variable portinterp_options "\
         portdbpath porturl portpath portbuildpath auto_path prefix prefix_frozen portsharepath \
@@ -894,7 +894,7 @@ proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
     }
 
     # Set noninteractive mode if specified in config
-    if {[info exists ui_interactive] && !$ui_interactive} {
+    if {[info exists ui_interactive_questions] && !$ui_interactive_questions} {
         set macports::ui_options(ports_noninteractive) yes
         unset -nocomplain macports::ui_options(questions_yesno) \
                             macports::ui_options(questions_singlechoice) \


### PR DESCRIPTION
Note that the use of the phrase "non-interactive mode" for the -N switch is in contradiction to the documentation of the command argument, which it claims if I give the command argument, then I am not in interactive mode already...  Also, searching for "yes" in the man page yields nothing.  I am here providing a pull request with my suggestion for improvements to the description of this switch.