### PR TITLE
Fix the detection of /opt/local/bin in user's PATH

### DIFF
--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -209,13 +209,16 @@ delete_old_tcl_packages
 
 # Determine the user's shell, in order to choose an appropriate configuration file we'll be tweaking.
 # Exit nicely if the shell is any other than bash or tcsh, as that's considered non-standard.
-USHELL=$(${DSCL} . -read "/Users/${USER}" shell | awk -F'/' '{print $NF}') || {
+USHELL=$(${DSCL} . -read "/Users/${USER}" shell) || {
     echo "An attempt to determine your shell name failed! Please set your MacPorts compatible environment manually."
     update_macports
     exit 1
 }
+# leave full path to shell
+USHELL=${USHELL#*shell: }
+
 case "${USHELL}" in
-    tcsh)
+    */tcsh)
         echo "Detected the tcsh shell."
         LOGIN_FLAG=""
         ENV_COMMAND="setenv"
@@ -228,7 +231,7 @@ case "${USHELL}" in
             CONF_FILE=tcshrc
         fi
         ;;
-    bash)
+    */bash)
         echo "Detected the bash shell."
         LOGIN_FLAG="-l"
         ENV_COMMAND="export"

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -250,16 +250,16 @@ esac
 
 
 # Adding our setting to the PATH variable if not already there:
-if "${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv PATH" | grep "${PREFIX}" > /dev/null; then
+if "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv PATH" | tr ":" "\n" | grep "^${BINPATH}$" > /dev/null; then
     echo "Your shell already has the right PATH environment variable for use with MacPorts!"
 else
     write_setting PATH "\"${BINPATH}:${SBINPATH}:\$PATH\""
 fi
 
 # We gather the path into a variable of our own for faster operation:
-ORIGINAL_MANPATH="$("${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv MANPATH")"
+ORIGINAL_MANPATH="$("${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv MANPATH")"
 # Adding our setting to the MANPATH variable only if it exists:
-if ! "${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep MANPATH" > /dev/null || \
+if ! "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep MANPATH" > /dev/null || \
 # and following that, if it's not empty:
   [[ -z "${ORIGINAL_MANPATH}" ]] || \
 # or if it doesn't already contain our path:
@@ -276,7 +276,7 @@ else
 fi
 
 # Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
-if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || "${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep DISPLAY" > /dev/null; then
+if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep DISPLAY" > /dev/null; then
     echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
 else
     write_setting DISPLAY ":0"


### PR DESCRIPTION
The postflight script was using the SHELL variable, which is root's shell
and not USHELL, which is the user's shell.

The test for MacPorts paths in the users PATH can be made more robust.
The old code will match on /opt/locale for example.

Spit the PATH into one path per line with tr and then grep for an exact match
with /opt/local/bin.