### PR TITLE
Never run installing user's code as root 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,17 @@
 # This is a log of major user-visible changes in each MacPorts release.
 ###
 
+Release 2.4.1 (unreleased)
+    - Avoid an infinite loop when livecheck.regex is empty.
+      (raimue in d33a8a0)
+
+    - Fixed detection of /opt/local/bin already in the user's PATH in the
+      installer postflight script. (barry-scott in dcb0788)
+
+    - Fixed the display of default variants by 'port variants' when the
+      defaults are affected by variants present in variants.conf.
+      (jmr in 9e63a61)
+
 Release 2.4 (2017-01-27 by jmr)
     - New action 'port reclaim' to clean inactive ports and unnecessary
       distfiles to get back disk space, developed during GSoC 2014.

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release 2.4.1 (unreleased)
       defaults are affected by variants present in variants.conf.
       (jmr in 9e63a61)
 
+    - Fixed 'port reclaim' deleting a file installed by the MacPorts installer
+      for technical reasons.
+      (cal in b0c0957, #53436)
+
 Release 2.4 (2017-01-27 by jmr)
     - New action 'port reclaim' to clean inactive ports and unnecessary
       distfiles to get back disk space, developed during GSoC 2014.

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -209,13 +209,16 @@ delete_old_tcl_packages
 
 # Determine the user's shell, in order to choose an appropriate configuration file we'll be tweaking.
 # Exit nicely if the shell is any other than bash or tcsh, as that's considered non-standard.
-USHELL=$(${DSCL} . -read "/Users/${USER}" shell | awk -F'/' '{print $NF}') || {
+USHELL=$(${DSCL} . -read "/Users/${USER}" shell) || {
     echo "An attempt to determine your shell name failed! Please set your MacPorts compatible environment manually."
     update_macports
     exit 1
 }
+# leave full path to shell
+USHELL=${USHELL#*shell: }
+
 case "${USHELL}" in
-    tcsh)
+    */tcsh)
         echo "Detected the tcsh shell."
         LOGIN_FLAG=""
         ENV_COMMAND="setenv"
@@ -228,7 +231,7 @@ case "${USHELL}" in
             CONF_FILE=tcshrc
         fi
         ;;
-    bash)
+    */bash)
         echo "Detected the bash shell."
         LOGIN_FLAG="-l"
         ENV_COMMAND="export"

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -273,6 +273,13 @@ if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" > /dev/null; then
     fi
 fi
 
+# Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
+if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || /usr/bin/su "${USER}" -l -c "/usr/bin/printenv DISPLAY" > /dev/null; then
+    echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
+else
+    write_setting DISPLAY ":0"
+fi
+
 # Postflight script is done with its job, update MacPorts and exit gracefully!
 update_macports
 echo "You have successfully installed the MacPorts system. Launch a terminal and try it out!"

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -250,16 +250,16 @@ esac
 
 
 # Adding our setting to the PATH variable if not already there:
-if "${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv PATH" | grep "${PREFIX}" > /dev/null; then
+if "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv PATH" | tr ":" "\n" | grep "^${BINPATH}$" > /dev/null; then
     echo "Your shell already has the right PATH environment variable for use with MacPorts!"
 else
     write_setting PATH "\"${BINPATH}:${SBINPATH}:\$PATH\""
 fi
 
 # We gather the path into a variable of our own for faster operation:
-ORIGINAL_MANPATH="$("${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv MANPATH")"
+ORIGINAL_MANPATH="$("${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv MANPATH")"
 # Adding our setting to the MANPATH variable only if it exists:
-if ! "${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep MANPATH" > /dev/null || \
+if ! "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep MANPATH" > /dev/null || \
 # and following that, if it's not empty:
   [[ -z "${ORIGINAL_MANPATH}" ]] || \
 # or if it doesn't already contain our path:
@@ -276,7 +276,7 @@ else
 fi
 
 # Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
-if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || "${SHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep DISPLAY" > /dev/null; then
+if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep DISPLAY" > /dev/null; then
     echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
 else
     write_setting DISPLAY ":0"

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -126,7 +126,7 @@ function delete_old_tcl_package_link {
     # delete old link if present
     if [[ -e "${OLD_TCL_PACKAGE_DIR}/macports1.0" ]]; then
         rm -vrf "${OLD_TCL_PACKAGE_DIR}/macports1.0"
-	fi
+    fi
 
     # delete old macports1.0 link from new tcl package dir if present
     if [[ -L "${TCL_PACKAGE_PATH}/macports1.0" ]]; then
@@ -251,40 +251,27 @@ case "${USHELL}" in
         ;;
 esac
 
-
 # Adding our setting to the PATH variable if not already there:
-if "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv PATH" | tr ":" "\n" | grep "^${BINPATH}$" > /dev/null; then
+# Run as the $USER: /usr/bin/su $USER -l
+# Run a command in the shell: -c "/usr/bin/printenv PATH"
+# Only process the last line output (profile may print info): tail -n 1
+# Output each path on its own line: tr ":" "\n"
+# Look for exactly the BINPATH: grep "^${BINPATH}$"
+if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv PATH" | tail -n 1 | tr ":" "\n" | grep "^${BINPATH}$" > /dev/null; then
     echo "Your shell already has the right PATH environment variable for use with MacPorts!"
 else
     write_setting PATH "\"${BINPATH}:${SBINPATH}:\$PATH\""
 fi
 
-# We gather the path into a variable of our own for faster operation:
-ORIGINAL_MANPATH="$("${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv MANPATH")"
 # Adding our setting to the MANPATH variable only if it exists:
-if ! "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep MANPATH" > /dev/null || \
-# and following that, if it's not empty:
-  [[ -z "${ORIGINAL_MANPATH}" ]] || \
-# or if it doesn't already contain our path:
-  echo "${ORIGINAL_MANPATH}" | grep "${MANPAGES}" > /dev/null || \
-# or if there's no empty component somewhere in the middle of it:
-  echo "${ORIGINAL_MANPATH}" | grep :: > /dev/null || \
-# or at the start of it:
-  [[ -z "$(echo "${ORIGINAL_MANPATH}" | awk -F : '{print $1}')" ]] || \
-# or at the end of it:
-  [[ -z "$(echo "${ORIGINAL_MANPATH}" | awk -F : '{print $NF}')" ]]; then
-    echo "Your shell already has the right MANPATH environment variable for use with MacPorts!"
-else
-    write_setting MANPATH "\"${MANPAGES}:\$MANPATH\""
+if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" > /dev/null; then
+    # check for MANPAGES already in MANPATH
+    if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" | tail -n 1 | tr ":" "\n" | grep "^${MANPAGES}$" >/dev/null; then
+        echo "Your shell already has the right MANPATH environment variable for use with MacPorts!"
+    else
+        write_setting MANPATH "\"${MANPAGES}:\$MANPATH\""
+    fi
 fi
-
-# Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
-if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep DISPLAY" > /dev/null; then
-    echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
-else
-    write_setting DISPLAY ":0"
-fi
-
 
 # Postflight script is done with its job, update MacPorts and exit gracefully!
 update_macports

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -4285,9 +4285,7 @@ proc mportselect {command {group ""} {version {}}} {
 
             # Update the selected version.
             set selected_version ${conf_path}/current
-            if {[file exists $selected_version]} {
-                file delete $selected_version
-            }
+            file delete $selected_version
             symlink $version $selected_version
             return
         }

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -3563,6 +3563,15 @@ proc action_variants { action portlist opts } {
         }
 
         if {!([info exists options(ports_variants_index)] && $options(ports_variants_index) eq "yes")} {
+            # Add any global_variations to the variations specified for
+            # the port (default variants may change based on this)
+            array unset merged_variations
+            array set merged_variations [array get variations]
+            foreach {variation value} [array get global_variations] {
+                if {![info exists merged_variations($variation)]} {
+                    set merged_variations($variation) $value
+                }
+            }
             if {![info exists options(subport)]} {
                 if {[info exists portinfo(name)]} {
                     set options(subport) $portinfo(name)
@@ -3570,7 +3579,7 @@ proc action_variants { action portlist opts } {
                     set options(subport) $portname
                 }
             }
-            if {[catch {set mport [mportopen $porturl [array get options] [array get variations]]} result]} {
+            if {[catch {set mport [mportopen $porturl [array get options] [array get merged_variations]]} result]} {
                 ui_debug "$::errorInfo"
                 break_softcontinue "Unable to open port: $result" 1 status
             }


### PR DESCRIPTION
Replace all cases of ${USHELL} -l with /usr/bin/su commands.
First use is commented explaining each steps purpose.

Use printenv VAR | tail -n 1 to make sure that only the VAR's value is passed on.
It is not uncommon for profiles to print information to stdout.

Refactor the MANPATH logic to use su and the tr|grep idium to look at for a path.

Delete all the logic for DISPLAY as its not required in any supported macOS
version that MacPorts supports.

Replace hardtab with spaces
