### PR TITLE
Never run installing user's profile code as root

### DIFF
--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -126,7 +126,7 @@ function delete_old_tcl_package_link {
     # delete old link if present
     if [[ -e "${OLD_TCL_PACKAGE_DIR}/macports1.0" ]]; then
         rm -vrf "${OLD_TCL_PACKAGE_DIR}/macports1.0"
-	fi
+    fi
 
     # delete old macports1.0 link from new tcl package dir if present
     if [[ -L "${TCL_PACKAGE_PATH}/macports1.0" ]]; then
@@ -251,40 +251,34 @@ case "${USHELL}" in
         ;;
 esac
 
-
 # Adding our setting to the PATH variable if not already there:
-if "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv PATH" | tr ":" "\n" | grep "^${BINPATH}$" > /dev/null; then
+# Run as the $USER: /usr/bin/su $USER -l
+# Run a command in the shell: -c "/usr/bin/printenv PATH"
+# Only process the last line output (profile may print info): tail -n 1
+# Output each path on its own line: tr ":" "\n"
+# Look for exactly the BINPATH: grep "^${BINPATH}$"
+if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv PATH" | tail -n 1 | tr ":" "\n" | grep "^${BINPATH}$" > /dev/null; then
     echo "Your shell already has the right PATH environment variable for use with MacPorts!"
 else
     write_setting PATH "\"${BINPATH}:${SBINPATH}:\$PATH\""
 fi
 
-# We gather the path into a variable of our own for faster operation:
-ORIGINAL_MANPATH="$("${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/printenv MANPATH")"
 # Adding our setting to the MANPATH variable only if it exists:
-if ! "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep MANPATH" > /dev/null || \
-# and following that, if it's not empty:
-  [[ -z "${ORIGINAL_MANPATH}" ]] || \
-# or if it doesn't already contain our path:
-  echo "${ORIGINAL_MANPATH}" | grep "${MANPAGES}" > /dev/null || \
-# or if there's no empty component somewhere in the middle of it:
-  echo "${ORIGINAL_MANPATH}" | grep :: > /dev/null || \
-# or at the start of it:
-  [[ -z "$(echo "${ORIGINAL_MANPATH}" | awk -F : '{print $1}')" ]] || \
-# or at the end of it:
-  [[ -z "$(echo "${ORIGINAL_MANPATH}" | awk -F : '{print $NF}')" ]]; then
-    echo "Your shell already has the right MANPATH environment variable for use with MacPorts!"
-else
-    write_setting MANPATH "\"${MANPAGES}:\$MANPATH\""
+if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" > /dev/null; then
+    # check for MANPAGES already in MANPATH
+    if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" | tail -n 1 | tr ":" "\n" | grep "^${MANPAGES}$" >/dev/null; then
+        echo "Your shell already has the right MANPATH environment variable for use with MacPorts!"
+    else
+        write_setting MANPATH "\"${MANPAGES}:\$MANPATH\""
+    fi
 fi
 
 # Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
-if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || "${USHELL}" ${LOGIN_FLAG} -c "/usr/bin/env | grep DISPLAY" > /dev/null; then
+if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || /usr/bin/su "${USER}" -l -c "/usr/bin/printenv DISPLAY" > /dev/null > /dev/null; then
     echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
 else
     write_setting DISPLAY ":0"
 fi
-
 
 # Postflight script is done with its job, update MacPorts and exit gracefully!
 update_macports


### PR DESCRIPTION
Replace all cases of ${USHELL} -l with /usr/bin/su commands.
First use is commented explaining each steps purpose.

Use printenv VAR | tail -n 1 to make sure that only the VAR's value is passed on.
It is not uncommon for profiles to print information to stdout.

Refactor the MANPATH logic to use su and the tr|grep idium to look at for a path.

Delete all the logic for DISPLAY as its not required in any supported macOS
version that MacPorts supports.

Replace hardtab with spaces