### PR TITLE
misc: let 'port provides' and trace mode honor the FS case-sensitivity.

### DIFF
--- a/src/cregistry/entry.c
+++ b/src/cregistry/entry.c
@@ -1,7 +1,7 @@
 /*
  * entry.c
  *
- * Copyright (c) 2010-2011, 2014 The MacPorts Project
+ * Copyright (c) 2010-2011, 2014, 2017 The MacPorts Project
  * Copyright (c) 2007 Chris Pickel <sfiera@macports.org>
  * All rights reserved.
  *
@@ -39,6 +39,7 @@
 #include <sqlite3.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 /*
  * TODO: possibly, allow reg_entry_search to take different matching strategies
@@ -517,16 +518,31 @@ int reg_entry_installed(reg_registry* reg, char* name, reg_entry*** entries,
  *
  * @param [in] reg     registry to search in
  * @param [in] path    path of the file to check ownership of
+ * @param [in] cs      false if check should be performed case-insensitive,
+ *                     true otherwise
  * @param [out] entry  the owner, or NULL if no active port owns the file
  * @param [out] errPtr on error, a description of the error that occurred
  * @return             true if success; false if failure
  */
-int reg_entry_owner(reg_registry* reg, char* path, reg_entry** entry,
+int reg_entry_owner(reg_registry* reg, char* path, int cs, reg_entry** entry,
         reg_error* errPtr) {
     int result = 0;
     sqlite3_stmt* stmt = NULL;
-    char* query = "SELECT id FROM registry.files WHERE actual_path=? AND active";
     int lower_bound = 0;
+
+    /* Make sure query_template is as big as the buffer might get. */
+    const char* query_template = "SELECT id FROM registry.files WHERE (actual_path = ? COLLATE NOCASE) AND active";
+    const int query_max_size = strlen(query_template) + 1;
+
+    char* query = malloc(query_max_size);
+
+    if (!query) {
+        return 0;
+    }
+
+    snprintf(query, query_max_size, "SELECT id FROM registry.files WHERE (actual_path = ? %s) AND active",
+             cs ? "" : "COLLATE NOCASE");
+
     if ((sqlite3_prepare_v2(reg->db, query, -1, &stmt, NULL) == SQLITE_OK)
             && (sqlite3_bind_text(stmt, 1, path, -1, SQLITE_STATIC)
                 == SQLITE_OK)) {
@@ -555,6 +571,7 @@ int reg_entry_owner(reg_registry* reg, char* path, reg_entry** entry,
     if (stmt) {
         sqlite3_finalize(stmt);
     }
+    free(query);
     return result;
 }
 
@@ -568,12 +585,27 @@ int reg_entry_owner(reg_registry* reg, char* path, reg_entry** entry,
  *
  * @param [in] reg  registry to find file in
  * @param [in] path path of file to get owner of
+ * @param [in] cs   false if check should be performed case-insensitive,
+ *                  true otherwise
  * @return          id of owner, or 0 for none
  */
-sqlite_int64 reg_entry_owner_id(reg_registry* reg, char* path) {
+sqlite_int64 reg_entry_owner_id(reg_registry* reg, char* path, int cs) {
     sqlite3_stmt* stmt = NULL;
     sqlite_int64 result = 0;
-    char* query = "SELECT id FROM registry.files WHERE actual_path=? AND active";
+
+    /* Make sure query_template is as big as the buffer might get. */
+    const char* query_template = "SELECT id FROM registry.files WHERE (actual_path = ? COLLATE NOCASE) AND active";
+    const int query_max_size = strlen(query_template) + 1;
+
+    char* query = malloc(query_max_size);
+
+    if (!query) {
+        return 0;
+    }
+
+    snprintf(query, query_max_size, "SELECT id FROM registry.files WHERE (actual_path = ? %s) AND active",
+             cs ? "" : "COLLATE NOCASE");
+
     if ((sqlite3_prepare_v2(reg->db, query, -1, &stmt, NULL) == SQLITE_OK)
             && (sqlite3_bind_text(stmt, 1, path, -1, SQLITE_STATIC)
                 == SQLITE_OK)) {
@@ -588,6 +620,7 @@ sqlite_int64 reg_entry_owner_id(reg_registry* reg, char* path) {
     if (stmt) {
         sqlite3_finalize(stmt);
     }
+    free(query);
     return result;
 }
 

--- a/src/cregistry/entry.h
+++ b/src/cregistry/entry.h
@@ -61,9 +61,9 @@ int reg_entry_imaged(reg_registry* reg, const char* name, const char* version,
 int reg_entry_installed(reg_registry* reg, char* name, reg_entry*** entries,
         reg_error* errPtr);
 
-sqlite_int64 reg_entry_owner_id(reg_registry* reg, char* path);
-int reg_entry_owner(reg_registry* reg, char* path, reg_entry** entry,
-        reg_error* errPtr);
+sqlite_int64 reg_entry_owner_id(reg_registry* reg, char* path, int cs);
+int reg_entry_owner(reg_registry* reg, char* path, int cs,
+        reg_entry** entry, reg_error* errPtr);
 
 int reg_entry_propget(reg_entry* entry, char* key, char** value,
         reg_error* errPtr);

--- a/src/pextlib1.0/Pextlib.h
+++ b/src/pextlib1.0/Pextlib.h
@@ -36,8 +36,13 @@ void ui_notice(Tcl_Interp *interp, const char *format, ...) __attribute__((forma
 void ui_info(Tcl_Interp *interp, const char *format, ...) __attribute__((format(printf, 2, 3)));
 void ui_debug(Tcl_Interp *interp, const char *format, ...) __attribute__((format(printf, 2, 3)));
 
+/* Mount point file system case-sensitivity caching infrastructure. */
+typedef struct _mount_cs_cache mount_cs_cache_t;
+mount_cs_cache_t* new_mount_cs_cache();
+void reset_mount_cs_cache(mount_cs_cache_t *cache);
+
 #ifdef __APPLE__
-int fs_case_sensitive_darwin(const char *path);
+int fs_case_sensitive_darwin(Tcl_Interp *interp, const char *path, mount_cs_cache_t *cache);
 #endif /* __APPLE__ */
 
-int fs_case_sensitive_fallback(const char *path);
+int fs_case_sensitive_fallback(Tcl_Interp *interp, const char *path, mount_cs_cache_t *cache);

--- a/src/pextlib1.0/Pextlib.h
+++ b/src/pextlib1.0/Pextlib.h
@@ -1,7 +1,7 @@
 /*
  * Pextlib.h
  *
- * Copyright (c) 2009 The MacPorts Project
+ * Copyright (c) 2009, 2017 The MacPorts Project
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,3 +35,9 @@ void ui_msg(Tcl_Interp *interp, const char *format, ...) __attribute__((format(p
 void ui_notice(Tcl_Interp *interp, const char *format, ...) __attribute__((format(printf, 2, 3)));
 void ui_info(Tcl_Interp *interp, const char *format, ...) __attribute__((format(printf, 2, 3)));
 void ui_debug(Tcl_Interp *interp, const char *format, ...) __attribute__((format(printf, 2, 3)));
+
+#ifdef __APPLE__
+int fs_case_sensitive_darwin(const char *path);
+#endif /* __APPLE__ */
+
+int fs_case_sensitive_fallback(const char *path);

--- a/src/registry2.0/entry.c
+++ b/src/registry2.0/entry.c
@@ -437,22 +437,32 @@ static int entry_installed(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]){
 
 
 /*
- * registry::entry owner filename
+ * registry::entry owner filename [cs = true]
  *
  * Returns the port that owns the given filename (empty string if none).
  */
 static int entry_owner(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
-    if (objc != 3) {
-        Tcl_WrongNumArgs(interp, 2, objv, "path");
+    int cs = 1;
+
+    if ((objc < 3) || (objc > 4)) {
+        Tcl_WrongNumArgs(interp, 2, objv, "path ?cs?");
         return TCL_ERROR;
-    } else if (reg == NULL) {
+    }
+
+    if (objc == 4) {
+        if (Tcl_GetBooleanFromObj(interp, objv[3], &cs) != TCL_OK) {
+            return TCL_ERROR;
+        }
+    }
+
+    if (reg == NULL) {
         return TCL_ERROR;
     } else {
         char* path = Tcl_GetString(objv[2]);
         reg_entry* entry;
         reg_error error;
-        if (reg_entry_owner(reg, path, &entry, &error)) {
+        if (reg_entry_owner(reg, path, cs, &entry, &error)) {
             if (entry == NULL) {
                 return TCL_OK;
             } else {

--- a/src/registry2.0/receipt_flat.tcl
+++ b/src/registry2.0/receipt_flat.tcl
@@ -600,12 +600,17 @@ proc open_file_map {{readonly 0}} {
 # open the file map if required.
 #
 # - file	the file to test
+# - cs		boolean value indicating a case-sensitive search
 # return the 0 if the file is not registered, the name of the port otherwise.
 #
-proc file_registered {file} {
+proc file_registered {file cs} {
 	variable file_map
 
 	open_file_map 1
+
+	if {$cs} {
+		ui_warn "Case-sensitive search not implemented."
+	}
 
 	if {[::filemap exists file_map $file]} {
 		return [::filemap get file_map $file]

--- a/src/registry2.0/receipt_sqlite.tcl
+++ b/src/registry2.0/receipt_sqlite.tcl
@@ -123,10 +123,12 @@ proc entry_exists_for_name {name} {
 #
 # @param file
 #        The full path to the file to be tested.
+# @param cs
+#        Boolean value indicating a case-sensitive check.
 # @return 0 if the file is not registered to any port. The name of the port
 #         otherwise.
-proc file_registered {file} {
-    set port [registry::entry owner $file]
+proc file_registered {file cs} {
+    set port [registry::entry owner $file $cs]
     if {$port ne ""} {
         return [$port name]
     } else {

--- a/src/registry2.0/registry.tcl
+++ b/src/registry2.0/registry.tcl
@@ -38,6 +38,7 @@ package require receipt_sqlite 1.0
 package require portimage 2.0
 package require registry_uninstall 2.0
 package require msgcat
+package require Pextlib 1.0
 
 namespace eval registry {
     variable lockfd
@@ -236,7 +237,14 @@ proc open_file_map {args} {
 
 proc file_registered {file} {
 	global macports::registry.format
-	return [${macports::registry.format}::file_registered $file]
+
+	set cs false
+	if {[catch {fs_case_sensitive $file} cs]} {
+		ui_debug "Unable to get file system case-sensitivity of file $file, assuming worst case (case-insensitive.)"
+		set cs false
+	}
+
+	return [${macports::registry.format}::file_registered $file $cs]
 }
 
 proc port_registered {name} {


### PR DESCRIPTION
While updating `ghc` in trace mode, I noticed it failing while including `"GC.h"`. `ghc` actually meant to include a file named `GC.h` from its own source tree, but due to providing `-I${prefix}` before include directives for its own source tree, `/opt/local/include/gc.h` was picked by the compiler.

On a case-sensitive system, this wouldn't have happened.

Ultimately, the build process was able to read `/opt/local/include/GC.h`, even though `ghc` did *not* depend upon `boehmgc`, but eventually failed to build as it wasn't able to read `/opt/local/include/gc/gc.h`. Curiously, both files *should* have belonged to the same port (`bohemgc`.) However, `port provides /opt/local/include/GC.h` returned no registered port for this file - which was also queried as such by trace mode and thus allowed access. Checking `port provided /opt/local/include/gc.h` correctly returned `boehmgc`.

This PR tried to fix up this shortcoming by respecting the FS's underlying case-sensitivity.

`ghc` built fine for my in trace mode with it.

Because this changeset is a bit bigger than others and there's breaking potential, please review.