### PR TITLE
Make uninstalling unnecessary ports easy

### DIFF
--- a/doc/port-reclaim.1
+++ b/doc/port-reclaim.1
@@ -1,5 +1,5 @@
 '\" t
-.TH "PORT\-RECLAIM" "1" "2017\-01\-28" "MacPorts 2\&.4\&.99" "MacPorts Manual"
+.TH "PORT\-RECLAIM" "1" "2017\-01\-27" "MacPorts 2\&.4\&.99" "MacPorts Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -29,7 +29,7 @@ port-reclaim \- Reclaims disk space\&.
 .fi
 .SH "DESCRIPTION"
 .sp
-\fBport reclaim\fR will find files that can be removed to reclaim disk space by uninstalling inactive ports on your system, and removing unneeded or unused installation files\&. The user is then provided interactive options for files to remove\&. No files are removed initially, until the user selects them from the provided list\&.
+\fBport reclaim\fR will find files that can be removed to reclaim disk space by uninstalling inactive ports on your system as well as unnecessary unrequested ports, and removing unneeded or unused installation files\&. The user is then provided interactive options for files to remove\&. No files are removed initially, until the user selects them from the provided list\&.
 .SH "OPTIONS"
 .PP
 \fB\-\-enable\-reminders\fR

--- a/doc/port-reclaim.1.txt
+++ b/doc/port-reclaim.1.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 *port reclaim* will find files that can be removed to reclaim disk space by uninstalling inactive ports on your
-system, and removing unneeded or unused installation files.  The user is then provided interactive options for files to remove.  No files are removed initially, until the user selects them from the provided list.
+system as well as unnecessary unrequested ports, and removing unneeded or unused installation files.  The user is then provided interactive options for files to remove.  No files are removed initially, until the user selects them from the provided list.
 
 OPTIONS
 -------

--- a/doc/port.1
+++ b/doc/port.1
@@ -162,6 +162,17 @@ When passing \fIportnames\fR to an \fIaction\fR, \fBport\fR recognizes various \
 \fIleaves\fR: installed ports that are unrequested and have no dependents
 .RE
 .sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIrleaves\fR: installed ports that are unrequested and that no requested ports depend on
+.RE
+.sp
 Sets of ports can also be specified with \fIpseudo\-portname selectors\fR, which expand to the ports in which the value of the \fIPortfile\fR option corresponding to the selector\(cqs name (in either singular or plural form where applicable) matches the given regular expression\&. Usage is: selector:regex
 .PP
 \fBThe \fR\fB\fIpseudo\-portname selectors\fR\fR\fB are:\fR

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -52,6 +52,8 @@ available port tree(s). These may be used in the same way as a 'portname'.
     - 'unrequested': installed ports that were installed only to satisfy
       dependencies
     - 'leaves': installed ports that are unrequested and have no dependents
+    - 'rleaves': installed ports that are unrequested and that no
+      requested ports depend on
 
 Sets of ports can also be specified with 'pseudo-portname selectors', which
 expand to the ports in which the value of the 'Portfile' option corresponding

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -76,6 +76,7 @@ namespace eval reclaim {
             return
         }
 
+        uninstall_unrequested
         uninstall_inactive
         remove_distfiles
 
@@ -472,6 +473,77 @@ namespace eval reclaim {
                     }
                 } else {
                     ui_msg "Not uninstalling ports."
+                }
+            }
+        }
+        return 0
+    }
+
+
+    proc uninstall_unrequested {} {
+
+        # Attempts to uninstall unrequested ports no requested ports depend on
+        #
+        # Args:
+        #           None
+        # Returns:
+        #           0 if execution was successful. Errors (for now) if execution wasn't.
+
+        set unnecessary_ports  [list]
+        set unnecessary_names  [list]
+        set unnecessary_count  0
+
+        array set isrequested {}
+
+        ui_msg "$macports::ui_prefix Checking for unnecessary unrequested ports"
+
+        array set ports {}
+
+        foreach port [sort_portlist_by_dependendents [registry::entry imaged]] {
+            set isrequested([$port name]) [registry::property_retrieve $port requested]
+            set ports([$port name]) $port
+            if {$isrequested([$port name]) == 0} {
+                foreach dependent [$port dependents] {
+                    if {$isrequested([$dependent name]) != 0} {
+                        ui_debug "[$port name] is requested by [$dependent name]"
+                        set isrequested([$port name]) 1
+                        break
+                    }
+                }
+
+                if {$isrequested([$port name]) == 0} {
+                    lappend unnecessary_ports $port
+                    lappend unnecessary_names [$port name]
+                    incr unnecessary_count
+                }
+            }
+        }
+
+        if { $unnecessary_count == 0 } {
+            ui_msg "Found no unrequested ports without requested dependents."
+
+        } else {
+
+            ui_msg "Found unrequested ports without requested dependents: [join $unnecessary_names {, }]."
+            if {[info exists macports::ui_options(questions_multichoice)]} {
+                set retstring [$macports::ui_options(questions_multichoice) "Would you like to uninstall these ports?" "" $unnecessary_names]
+
+                if {[llength $retstring] > 0} {
+                    foreach i $retstring {
+                        set name [lindex $unnecessary_names $i]
+                        set port $ports($name)
+
+                        ui_msg "Uninstalling: $name"
+
+                        # Note: 'uninstall' takes a name, version, revision, variants and an options list. 
+                        try -pass_signal {
+                            registry_uninstall::uninstall [$port name] [$port version] [$port revision] [$port variants] {}
+                        } catch {{*} eCode eMessage} {
+                            ui_error "Error uninstalling $name: $eMessage"
+                        }
+                    }
+                } else {
+                    ui_msg "Not uninstalling ports; use 'port setrequested' mark a port as explicitly requested."
                 }
             }
         }

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -934,6 +934,26 @@ proc get_leaves_ports {} {
     return [portlist_sort [opIntersection $results [get_unrequested_ports]]]
 }
 
+proc get_rleaves_ports {} {
+    if { [catch {set ilist [get_unrequested_ports]} result] } {
+        if {$result ne "Registry error: No ports registered as installed."} {
+            ui_debug $::errorInfo
+            fatal "port installed failed: $result"
+        }
+    }
+    registry::open_dep_map
+    set requested [get_requested_ports]
+    set results {}
+    foreach i $ilist {
+        set iname [lindex $i 9]
+        set deplist [get_dependent_ports $iname 1]
+        if {$deplist eq "" || [opIntersection $deplist $requested] eq ""} {
+            add_to_portlist results $i
+        }
+    }
+    return [portlist_sort $results]
+}
+
 proc get_dependent_ports {portname recursive} {
     registry::open_dep_map
     set deplist [registry::list_dependents $portname]
@@ -1295,6 +1315,7 @@ proc element { resname } {
         ^(inactive)(@.*)?$    -
         ^(actinact)(@.*)?$    -
         ^(leaves)(@.*)?$      -
+        ^(rleaves)(@.*)?$      -
         ^(outdated)(@.*)?$    -
         ^(obsolete)(@.*)?$    -
         ^(requested)(@.*)?$   -

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2789,7 +2789,15 @@ proc action_reclaim { action portlist opts } {
     if {[prefix_unwritable]} {
         return 1
     }
-    return [macports::reclaim_main $opts]
+
+    set status [macports::reclaim_main $opts]
+
+    if {$status == 0 &&
+        ![info exists options(ports_upgrade_no-rev-upgrade)] &&
+        ${macports::revupgrade_autorun}} {
+        return [action_revupgrade $action $portlist $opts]
+    }
+
 }
 
 


### PR DESCRIPTION
`port reclaim` is quite nice for cleaning up waste, but it doesn't do anything about ports you no longer need, such as build dependancies — like `apt-get` and its `autoremove`. To work around this, I'd occasionally do repeated `port uninstall leaves` until no such leaves were left — which is a bit silly…

This pull request attempts to address this in two different ways. The first commit adds an `rleaves` alias which identifies all unrequested ports. The seconds commit achieves the same within `port reclaim`.

I considered extending `leaves` to list _all_ proper leaves — but opted not to, in the interest of backwards compatibility.