### PR TITLE
New argument port fetch --no-mirrors

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -4450,6 +4450,7 @@ array set cmd_opts_array {
     rev-upgrade {id-loadcmd-check}
     diagnose    {quiet}
     reclaim     {enable-reminders disable-reminders}
+    fetch       {no-mirrors}
 }
 
 ##

--- a/src/port1.0/fetch_common.tcl
+++ b/src/port1.0/fetch_common.tcl
@@ -160,12 +160,17 @@ proc portfetch::checksites {sitelists mirrorfile} {
             continue
         }
         global ${listname}.mirror_subdir
-        # add the specified global and user-defined mirrors
-        set sglobal [lindex $extras 0]; set senv [lindex $extras 1]
         set full_list [set $listname]
-        append full_list " $sglobal"
-        if {[info exists env($senv)]} {
-            set full_list [concat $env($senv) $full_list]
+        # add the specified global and user-defined mirrors
+        set sglobal ""
+        set senv ""
+        if {[llength $extras] >= 2} {
+            set sglobal [lindex $extras 0]
+            set senv [lindex $extras 1]
+            append full_list " $sglobal"
+            if {[info exists env($senv)]} {
+                set full_list [concat $env($senv) $full_list]
+            }
         }
 
         set site_list [list]

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -272,12 +272,17 @@ proc portfetch::get_full_mirror_sites_path {} {
 # Perform the full checksites/checkpatchfiles/checkdistfiles sequence.
 # This method is used by distcheck target.
 proc portfetch::checkfiles {urls} {
-    global global_mirror_site
+    global global_mirror_site ports_fetch_no-mirrors
     upvar $urls fetch_urls
 
-    checksites [list patch_sites [list $global_mirror_site PATCH_SITE_LOCAL] \
-                master_sites [list $global_mirror_site MASTER_SITE_LOCAL]] \
-               [get_full_mirror_sites_path]
+    set sites [list patch_sites {} \
+                    master_sites {}]
+    if {![info exists ports_fetch_no-mirrors] || ${ports_fetch_no-mirrors} eq "no"} {
+        set sites [list patch_sites [list $global_mirror_site PATCH_SITE_LOCAL] \
+                        master_sites [list $global_mirror_site MASTER_SITE_LOCAL]]
+    }
+
+    checksites $sites [get_full_mirror_sites_path]
     checkpatchfiles fetch_urls
     checkdistfiles fetch_urls
 }


### PR DESCRIPTION
This flag avoids adding the mirrors defined by global_mirror_site to the
list of fetch URLs. This is meant to aid in development of port updates.
No mirror will have a distfile for a new port version, so there is no
need to try.