### PR TITLE
Expand license output by adding '(' 'or' ')' 'and' between licenses

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2228,8 +2228,8 @@ proc action_info { action portlist opts } {
                 }
             }
 
-            # Add "and" and "or"
-            if {$ropt eq "license"} {
+            # Add "(" "or" ")" "and" for human-readable output
+            if {$pretty_print && $ropt eq "license"} {
                 set infresult {}
                 foreach {e} $inf {
                     if {[llength $e] > 1} {

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2228,6 +2228,21 @@ proc action_info { action portlist opts } {
                 }
             }
 
+            # Add "and" and "or"
+            if {$ropt eq "license"} {
+                set infresult {}
+                foreach {e} $inf {
+                    if {[llength $e] > 1} {
+                        if {[llength $infresult] > 0} { lappend infresult " and " }
+                        lappend infresult "([join $e " or "])"
+                    } else {
+                        if {[llength $infresult] > 0} { lappend infresult " and " }
+                        lappend infresult $e
+                    }
+                }
+                set inf [concat {*}$infresult]
+            }
+
             # Format list of maintainers
             if {$ropt eq "maintainers"} {
                 set infresult {}


### PR DESCRIPTION
Add conjunctions to allow easier understanding of license info.  This
avoids the issue of having to remember what licenses in {} and those
without {} mean.

Examples listed below: top line is current, 2nd line is with patch

cfitsio license: zlib MIT {LGPL Noncommercial}
cfitsio license: zlib and MIT and (LGPL or Noncommercial)

rust license: {MIT Apache-2} BSD zlib NCSA Permissive
rust license: (MIT or Apache-2) and BSD and zlib and NCSA and Permissive

edb license: BSD BSD-old Sleepycat
edb license: BSD and BSD-old and Sleepycat

qt55 license: {LGPL-2.1 LGPL-3 GPL-3 OpenSSLException}
qt55 license: (LGPL-2.1 or LGPL-3 or GPL-3 or OpenSSLException)

Others to look at: itext, dmd-bootstrap, libgdiplus