### PR TITLE
Abort on unknown subport

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1761,6 +1761,29 @@ proc mportopen {porturl {options {}} {variations {}} {nocache {}}} {
 
     $workername eval {source Portfile}
 
+    set subport [$workername eval {set subport}]
+    set name [$workername eval {set name}]
+
+    ui_debug "name=$name; subport=$subport"
+    # Verify subport is actually a 'subport' of port
+    if {$name ne $subport} {
+        if {[catch {mportlookup $name} result]} {
+            ui_debug "$::errorInfo"
+            error "lookup of portname $name failed: $result"
+        }
+        if {[llength $result] < 2} {
+            error "$name not found"
+        }
+        array set portinfo [lindex $result 1]
+        if {[info exists portinfo(subports)]} {
+            if {[lsearch $portinfo(subports) $subport] < 0} {
+                error "$name does not have a subport $subport"
+            }
+        } else {
+            error "$name does not have any subports"
+        }
+    }
+
     # add the default universal variant if appropriate, and set up flags that
     # are conditional on whether universal is set
     $workername eval {universal_setup}

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -4178,12 +4178,6 @@ proc action_target { action portlist opts } {
             } else {
                 set options(subport) $portname
             }
-        } else {
-            set subportname $options(subport)
-            if {![info exists portinfo(subports)] ||
-                 [lsearch $portinfo(subports) $subportname] < 0} {
-                break_softcontinue "Port $portname does not have a subport $subportname" 1 status
-            }
         }
         if {[catch {set workername [mportopen $porturl [array get options] [array get requested_variations]]} result]} {
             ui_debug $::errorInfo

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -4178,6 +4178,12 @@ proc action_target { action portlist opts } {
             } else {
                 set options(subport) $portname
             }
+        } else {
+            set subportname $options(subport)
+            if {![info exists portinfo(subports)] ||
+                 [lsearch $portinfo(subports) $subportname] < 0} {
+                break_softcontinue "Port $portname does not have a subport $subportname" 1 status
+            }
         }
         if {[catch {set workername [mportopen $porturl [array get options] [array get requested_variations]]} result]} {
             ui_debug $::errorInfo


### PR DESCRIPTION
Check that given command line subport exists, otherwise abort.

Example: sudo port install zlib subport=foo
         Error: Port zlib does not have a subport foo

closes https://trac.macports.org/ticket/34619