### PR TITLE
portlint: add warning(s) about modeline

### DIFF
--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -197,9 +197,20 @@ proc portlint::lint_main {args} {
             incr warnings
         }
 
-        if {($lineno == $topline_number) && [string match "*-\*- *" $line]} {
-            ui_info "OK: Line $lineno has emacs/vim Mode"
-            incr topline_number
+        if {($lineno == $topline_number)} {
+            if {$line eq "# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4"} {
+                ui_info "OK: Line $lineno has the standard MacPort's modeline"
+            } elseif {[string match "#\* -\*- coding:*" $line]} {
+                ui_info "OK: Line $lineno has a modeline"
+            } else {
+                ui_info "OK: Line $lineno does not have a modeline; consider adding a modeline, preferability the standard MacPort's modeline"
+            }
+        } else {
+            # Find any modelines not on top line
+            if {[string match "#\* -\*- coding:*" $line]} {
+                ui_warn "Line $lineno appears to have a modeline; only the first line should have a modeline"
+                incr warnings
+            }
         }
 
         if {[string match "*\$Id*\$" $line]} {


### PR DESCRIPTION
Only warn if a modeline is found that is not on the first line.
The guide has conflicting info as to whether a modeline is required
and what it should be.

"This should be the first line of a Portfile. It sets the correct editing options for vim and emacs. See Port Style for more information. Its use is optional and up to the port maintainer."
"By default, the top line of all Portfiles should use a modeline that defines soft tabs for the vim and emacs editors as shown."

closes https://trac.macports.org/ticket/52767