### PR TITLE
Ports cannot set setuid bit on High Sierra

### DIFF
--- a/src/port1.0/portsandbox.tcl
+++ b/src/port1.0/portsandbox.tcl
@@ -88,12 +88,19 @@ proc portsandbox::set_profile {target} {
 (regex #\"^/dev/fd/\")) (allow file-write* \
 (regex #\"^(/private)?(/var)?/tmp/\" #\"^(/private)?/var/folders/\"))"
 
+    set perms [list file-write*]
+    if {${os.major} >= 17} {
+        lappend perms file-write-setugid
+    }
+
     foreach dir $allow_dirs {
-        append portsandbox_profile " (allow file-write* ("
-        if {${os.major} > 9} {
-            append portsandbox_profile "subpath \"${dir}\"))"
-        } else {
-            append portsandbox_profile "regex #\"^${dir}/\"))"
+        foreach perm $perms {
+            append portsandbox_profile " (allow $perm ("
+            if {${os.major} > 9} {
+                append portsandbox_profile "subpath \"${dir}\"))"
+            } else {
+                append portsandbox_profile "regex #\"^${dir}/\"))"
+            }
         }
     }
 }

--- a/tests/test.tcl.in
+++ b/tests/test.tcl.in
@@ -7,6 +7,7 @@ set test_suite {
     dependencies-d
     dependencies-e
     envvariables
+    setuid
     site-tags
     statefile-unknown-version
     statefile-version1

--- a/tests/test/setuid/DESCRIPTION
+++ b/tests/test/setuid/DESCRIPTION
@@ -1,0 +1,4 @@
+This test checks for successfully setting setuid bits in the port build phase.
+This was initially broken on macOS 10.13 High Sierra.
+
+https://trac.macports.org/ticket/54963

--- a/tests/test/setuid/Portfile
+++ b/tests/test/setuid/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                setuid
+version             0
+categories          test
+maintainers         nomaintainer
+homepage            https://www.macports.org/
+platforms           darwin
+
+description         Test for the setuid bit
+long_description    ${description}
+
+distfiles
+use_configure       no
+
+extract {
+    file mkdir ${worksrcpath}
+    file copy ${filespath}/test.sh ${worksrcpath}
+}
+
+build.cmd ${worksrcpath}/test.sh
+
+destroot {
+    touch ${destroot}${prefix}/lib/${name}
+}
+
+test {
+    # test is actually running build target
+}

--- a/tests/test/setuid/files/test.sh
+++ b/tests/test/setuid/files/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+touch foo
+chmod u+s,a+x foo
+
+stat -f "perms: %p" foo
+
+exec test $(stat -f %p foo) == 104755

--- a/tests/test/setuid/test.tcl
+++ b/tests/test/setuid/test.tcl
@@ -1,0 +1,20 @@
+package require tcltest 2
+namespace import tcltest::*
+
+source [file dirname $argv0]/../library.tcl
+set path [file dirname [file normalize $argv0]]
+
+initial_setup
+
+test setuid {
+    Regression test for setuid permission bit.
+} -body {
+    global output_file path
+
+    set str "perms: *"
+    set line [get_line $path/$output_file $str]
+    return $line
+} -result "perms: 104755"
+
+cleanup
+cleanupTests


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/54963

After merging this, we should also cherry-pick these commits to release-2.4 and release 2.4.2 for High Sierra.