### PR TITLE
startupitem_type: remove SystemStarter

### DIFF
--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -395,7 +395,7 @@ lt lt.
 T{
 \fBSupported types:\fR
 T}:T{
-none, SystemStarter, launchd, default, rcNG\&.
+none, launchd, default, rcNG\&.
 T}
 T{
 \fBDefault:\fR

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -139,7 +139,7 @@ startupitem_type::
     Set the default type of startupitems to be generated, overridable by
     Portfiles that explicitly state a startupitem.type key. If set to "default",
     then a type will be selected that's appropriate to the OS.
-    *Supported types:*;; none, SystemStarter, launchd, default, rcNG.
+    *Supported types:*;; none, launchd, default, rcNG.
     *Default:*;; default
 
 destroot_umask::

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -121,7 +121,6 @@ universal_archs     	@UNIVERSAL_ARCHS@
 
 # Type of generated StartupItems.
 # - launchd: Create StartupItems for use with launchd.
-# - systemstarter: Create StartupItems for use with SystemStarter.
 # - rcng: Create StartupItems for use with the rc.d system.
 # - default: Create StartupItems for launchd on OS X and for rc.d on
 #   other platforms.

--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1509,7 +1509,7 @@ on prior Mac OS X systems. A global default may be specified with the startupite
 .Em default
 .br
 .Sy Values:
-.Em SystemStarter launchd default rcNG
+.Em launchd default rcNG
 .br
 .Sy Example
 .Dl startupitem.type launchd


### PR DESCRIPTION
Tiger introduced launchd and is the earliest OS that macports supports.
This removes the obsolete startupitem_type SystemStarter.

see https://trac.macports.org/ticket/36770