### PR TITLE
Remove rcng startupitem type

### DIFF
--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -395,7 +395,7 @@ lt lt.
 T{
 \fBSupported types:\fR
 T}:T{
-none, launchd, default, rcNG\&.
+none, launchd, default\&.
 T}
 T{
 \fBDefault:\fR

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -139,7 +139,7 @@ startupitem_type::
     Set the default type of startupitems to be generated, overridable by
     Portfiles that explicitly state a startupitem.type key. If set to "default",
     then a type will be selected that's appropriate to the OS.
-    *Supported types:*;; none, launchd, default, rcNG.
+    *Supported types:*;; none, launchd, default.
     *Default:*;; default
 
 destroot_umask::

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -121,8 +121,7 @@ universal_archs     	@UNIVERSAL_ARCHS@
 
 # Type of generated StartupItems.
 # - launchd: Create StartupItems for use with launchd.
-# - rcng: Create StartupItems for use with the rc.d system.
-# - default: Create StartupItems for launchd on OS X and for rc.d on
+# - default: Create StartupItems for launchd on OS X and none on
 #   other platforms.
 # - none: Disable creation of StartupItems.
 # This setting only applies when building ports from source.

--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1509,7 +1509,7 @@ on prior Mac OS X systems. A global default may be specified with the startupite
 .Em default
 .br
 .Sy Values:
-.Em launchd default rcNG
+.Em launchd default
 .br
 .Sy Example
 .Dl startupitem.type launchd

--- a/src/port1.0/portstartupitem.tcl
+++ b/src/port1.0/portstartupitem.tcl
@@ -72,52 +72,6 @@ namespace eval portstartupitem {
 
 set_ui_prefix
 
-proc portstartupitem::startupitem_create_rcng {args} {
-    global prefix destroot os.platform \
-           startupitem.name startupitem.requires \
-           startupitem.start startupitem.stop startupitem.restart \
-           startupitem.type
-
-    set scriptdir ${destroot}${prefix}/etc/rc.d
-
-    if { ![exists startupitem.requires] } {
-        set startupitem.requires ""
-    }
-
-    # XXX We can't share defaults with startupitem_create_darwin
-    foreach item {startupitem.start startupitem.stop startupitem.restart} {
-        if {![info exists $item]} {
-            return -code error "Missing required option $item"
-        }
-    }
-
-    file mkdir ${destroot} ${scriptdir}
-    set fd [open [file join ${scriptdir} ${startupitem.name}.sh] w 0755]
-
-    puts ${fd} "#!/bin/sh"
-    puts ${fd} "#"
-    puts ${fd} "# MacPorts generated RCng Script"
-    puts ${fd} "#"
-    puts ${fd} ""
-    puts ${fd} "# PROVIDE: ${startupitem.name}"
-    puts ${fd} "# REQUIRE: ${startupitem.requires}"
-    # TODO: Implement BEFORE support
-    puts ${fd} "# BEFORE:"
-    puts ${fd} "# KEYWORD: MacPorts"
-    puts ${fd} ""
-    puts ${fd} ". ${prefix}/etc/rc.subr"
-    puts ${fd} ""
-    puts ${fd} "name=\"${startupitem.name}\""
-    puts ${fd} "start_cmd=\"${startupitem.start}\""
-    puts ${fd} "stop_cmd=\"${startupitem.stop}\""
-    puts ${fd} "restart_cmd=\"${startupitem.restart}\""
-    puts ${fd} ""
-    puts ${fd} "load_rc_config \"${startupitem.name}\""
-    puts ${fd} ""
-    puts ${fd} "run_rc_command \"\$1\""
-    close ${fd}
-}
-
 proc portstartupitem::startupitem_create_darwin_launchd {args} {
     global UI_PREFIX prefix destroot destroot.keepdirs subport macosx_deployment_target \
            startupitem.name startupitem.uniquename startupitem.plist startupitem.location \
@@ -365,7 +319,7 @@ proc portstartupitem::startupitem_create {args} {
                 set startupitem.type "launchd"
             }
             default {
-                set startupitem.type "rcng"
+                set startupitem.type "none"
             }
         }
     }
@@ -377,7 +331,6 @@ proc portstartupitem::startupitem_create {args} {
 
         switch -- ${startupitem.type} {
             launchd         { startupitem_create_darwin_launchd }
-            rcng            { startupitem_create_rcng }
             default         { ui_error "$UI_PREFIX [msgcat::mc "Unrecognized startupitem type %s" ${startupitem.type}]" }
         }
     }


### PR DESCRIPTION
Remove non-darwin startupitem_type rcng.  As far as I can tell, it hasn't worked in a long time since it was committed in 2005.    It is missing the etc/rc.subr which contains the script needed for the rc scripts to run.  If this is needed later, it would be better to start from scratch using a new version of rc scripts.

see https://trac.macports.org/ticket/36770