### PR TITLE
Check that tclsh is built before using it

### DIFF
--- a/vendor/tclsh.in
+++ b/vendor/tclsh.in
@@ -16,4 +16,8 @@ else
     export LD_LIBRARY_PATH="$LIB_PATH:$LD_LIBRARY_PATH"
 fi
 
-exec "@TCL_BIN_DIR@/tclsh" "$@"
+# Check that tclsh is built; after './configure', 'make clean'
+# will display errors in doc/ while attempting to build .dep
+if [ -x "@TCL_BIN_DIR@/tclsh" ]; then
+    exec "@TCL_BIN_DIR@/tclsh" "$@"
+fi


### PR DESCRIPTION
After './configure', 'make clean' will display errors while trying to
clean doc due to the building of the .dep file.

No messages can be displayed as those will end up in doc/.dep and cause
errors.

closes https://trac.macports.org/ticket/54660