### PR TITLE
Fix prototype for new_mount_cs_cache

### DIFF
--- a/src/pextlib1.0/Pextlib.c
+++ b/src/pextlib1.0/Pextlib.c
@@ -665,7 +665,7 @@ struct _mount_cs_cache {
 /**
  * Returns a new pre-allocated mount_cs_cache_t object.
  */
-mount_cs_cache_t* new_mount_cs_cache() {
+mount_cs_cache_t* new_mount_cs_cache(void) {
     mount_cs_cache_t *ret = malloc(sizeof(mount_cs_cache_t));
 
     if (ret) {

--- a/src/pextlib1.0/Pextlib.h
+++ b/src/pextlib1.0/Pextlib.h
@@ -38,7 +38,7 @@ void ui_debug(Tcl_Interp *interp, const char *format, ...) __attribute__((format
 
 /* Mount point file system case-sensitivity caching infrastructure. */
 typedef struct _mount_cs_cache mount_cs_cache_t;
-mount_cs_cache_t* new_mount_cs_cache();
+mount_cs_cache_t* new_mount_cs_cache(void);
 void reset_mount_cs_cache(mount_cs_cache_t *cache);
 
 #ifdef __APPLE__


### PR DESCRIPTION
A function written like `void foo()` is actually a C89 style
non-protoype declaration. Change this to ensure that the function is
only called with zero arguments.