### PR TITLE
Use sig_atomic_t instead of int for signal handler

### DIFF
--- a/src/pextlib1.0/system.c
+++ b/src/pextlib1.0/system.c
@@ -112,7 +112,7 @@ static int check_sandboxing(Tcl_Interp *interp, char **sandbox_exec_path, char *
     return 1;
 }
 
-static volatile int interrupted_by = 0;
+static volatile sig_atomic_t interrupted_by = 0;
 static void handle_sigint(int s) {
     interrupted_by = s;
 }


### PR DESCRIPTION
Strictly speaking sig_atomic_t does not have to be `int` though any
system this code targets is unlikely to be affected.