### PR TITLE
Fix `make install DESTDIR=/foobar`

### DIFF
--- a/vendor/Makefile.in
+++ b/vendor/Makefile.in
@@ -90,7 +90,7 @@ install-tcllib:
 	rm -rf $(DESTDIR)$(TCL_PACKAGE_PATH)/tcllib1.1{5,7}
 	@echo ===\> making $(@:%-tcllib=%) in ${DIRPRFX}@VENDOR_TCLLIB_SUBDIR@
 	@umask 0022; $(MAKE) -C @VENDOR_TCLLIB_SUBDIR@ @VENDOR_TCLLIB_INSTALL@
-	@chmod -R ugo+rX ${PREFIX}/libexec/macports/lib/tcllib*
+	@chmod -R ugo+rX $(DESTDIR)${PREFIX}/libexec/macports/lib/tcllib*
 
 test:
 


### PR DESCRIPTION
In the current version, trying to running `make install DESTDIR=/foobar` as a normal user (with write permissions to /foobar) results in permission errors.

The DESTDIR approach is used in my [Arch Linux personal package](https://aur.archlinux.org/packages/macports-base-git/). I'm going to run version checks as a daily cron job on my Linux server.