### PR TITLE
startupitem.type: finish removing obsolete code

### DIFF
--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -385,27 +385,6 @@ T}
 .sp 1
 .RE
 .PP
-startupitem_type
-.RS 4
-Set the default type of startupitems to be generated, overridable by Portfiles that explicitly state a startupitem\&.type key\&. If set to "default", then a type will be selected that\(cqs appropriate to the OS\&.
-.TS
-tab(:);
-lt lt
-lt lt.
-T{
-\fBSupported types:\fR
-T}:T{
-none, launchd, default\&.
-T}
-T{
-\fBDefault:\fR
-T}:T{
-default
-T}
-.TE
-.sp 1
-.RE
-.PP
 destroot_umask
 .RS 4
 Umask value to use during the destrooting of a port\&.

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -135,13 +135,6 @@ universal_archs::
     *Default (10.6):*;; x86_64 i386
     *Default (10.5 and earlier):*;; i386 ppc
 
-startupitem_type::
-    Set the default type of startupitems to be generated, overridable by
-    Portfiles that explicitly state a startupitem.type key. If set to "default",
-    then a type will be selected that's appropriate to the OS.
-    *Supported types:*;; none, launchd, default.
-    *Default:*;; default
-
 destroot_umask::
     Umask value to use during the destrooting of a port.
     *Default:*;; 022

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -119,14 +119,6 @@ universal_archs     	@UNIVERSAL_ARCHS@
 # Options to pass to rsync when fetching MacPorts base and the ports tree.
 #rsync_options       	-rtzvl --delete-after
 
-# Type of generated StartupItems.
-# - launchd: Create StartupItems for use with launchd.
-# - default: Create StartupItems for launchd on OS X and none on
-#   other platforms.
-# - none: Disable creation of StartupItems.
-# This setting only applies when building ports from source.
-#startupitem_type    	default
-
 # Create system-level symlinks to generated StartupItems. If set to
 # "no", symlinks will not be created; otherwise, symlinks will be placed
 # in /Library/LaunchDaemons or /Library/LaunchAgents as appropriate.

--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1496,23 +1496,6 @@ Choose whether or not to generate a startup item.
 .br
 .Sy Example:
 .Dl startupitem.create yes
-.It Ic startupitem.type
-Select the type of startupitem to generate. By default, a startupitem
-will be generated that is of the appropriate type for the OS. For
-instance, launchd is used on system 10.4, while SystemStarter is used
-on prior Mac OS X systems. A global default may be specified with the startupitem_type preference in ports.conf.
-.br
-.Sy Type:
-.Em optional
-.br
-.Sy Default:
-.Em default
-.br
-.Sy Values:
-.Em launchd default
-.br
-.Sy Example
-.Dl startupitem.type launchd
 .It Ic startupitem.name
 Displayed name of the startup item.
 .br

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -49,7 +49,7 @@ namespace eval macports {
         portdbpath binpath auto_path extra_env sources_conf prefix portdbformat \
         portarchivetype portautoclean \
         porttrace portverbose keeplogs destroot_umask variants_conf rsync_server rsync_options \
-        rsync_dir startupitem_type startupitem_install place_worksymlink xcodeversion xcodebuildcmd \
+        rsync_dir startupitem_install place_worksymlink xcodeversion xcodebuildcmd \
         configureccache ccache_dir ccache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
         applications_dir frameworks_dir developer_dir universal_archs build_arch macosx_sdk_version macosx_deployment_target \
         macportsuser proxy_override_env proxy_http proxy_https proxy_ftp proxy_rsync proxy_skip \
@@ -62,7 +62,7 @@ namespace eval macports {
         portdbpath porturl portpath portbuildpath auto_path prefix prefix_frozen portsharepath \
         registry.path registry.format user_home user_path user_ssh_auth_sock \
         portarchivetype archivefetch_pubkeys portautoclean porttrace keeplogs portverbose destroot_umask \
-        rsync_server rsync_options rsync_dir startupitem_type startupitem_install place_worksymlink macportsuser \
+        rsync_server rsync_options rsync_dir startupitem_install place_worksymlink macportsuser \
         configureccache ccache_dir ccache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
         applications_dir current_phase frameworks_dir developer_dir universal_archs build_arch \
         os_arch os_endian os_version os_major os_minor os_platform macosx_version macosx_sdk_version macosx_deployment_target \
@@ -946,11 +946,6 @@ match macports.conf.default."
         set env(PATH) ${prefix}/bin:${prefix}/sbin:/bin:/sbin:/usr/bin:/usr/sbin
     } else {
         set env(PATH) $binpath
-    }
-
-    # Set startupitem default type (can be overridden by portfile)
-    if {![info exists macports::startupitem_type]} {
-        set macports::startupitem_type default
     }
 
     # Set whether startupitems are symlinked into system directories

--- a/src/port1.0/portdestroot.tcl
+++ b/src/port1.0/portdestroot.tcl
@@ -53,7 +53,7 @@ options destroot.target destroot.destdir destroot.clean destroot.keepdirs destro
         startupitem.logevents startupitem.logfile startupitem.name \
         startupitem.netchange startupitem.pidfile startupitem.plist \
         startupitem.requires startupitem.restart startupitem.start \
-        startupitem.stop startupitem.type startupitem.uniquename
+        startupitem.stop startupitem.uniquename
 commands destroot
 
 # Set defaults
@@ -86,7 +86,6 @@ default startupitem.requires    ""
 default startupitem.restart     ""
 default startupitem.start       ""
 default startupitem.stop        ""
-default startupitem.type        {$system_options(startupitem_type)}
 default startupitem.uniquename  {org.macports.${startupitem.name}}
 
 set_ui_prefix

--- a/src/port1.0/portload.tcl
+++ b/src/port1.0/portload.tcl
@@ -48,7 +48,7 @@ default load.asroot yes
 set_ui_prefix
 
 proc portload::load_main {args} {
-    global startupitem.type startupitem.name startupitem.location startupitem.plist
+    global startupitem.name startupitem.location startupitem.plist
     set launchctl_path ${portutil::autoconf::launchctl_path}
 
     foreach { path } "/Library/${startupitem.location}/${startupitem.plist}" {

--- a/src/port1.0/portreload.tcl
+++ b/src/port1.0/portreload.tcl
@@ -47,7 +47,7 @@ default reload.asroot yes
 set_ui_prefix
 
 proc portreload::reload_main {args} {
-    global startupitem.type startupitem.name startupitem.location startupitem.plist
+    global startupitem.name startupitem.location startupitem.plist
     set launchctl_path ${portutil::autoconf::launchctl_path}
 
     foreach { path } "/Library/${startupitem.location}/${startupitem.plist}" {

--- a/src/port1.0/portstartupitem.tcl
+++ b/src/port1.0/portstartupitem.tcl
@@ -308,30 +308,12 @@ proc portstartupitem::startupitem_create_darwin_launchd {args} {
 }
 
 proc portstartupitem::startupitem_create {args} {
-    global UI_PREFIX startupitem.type os.platform
-    
-    set startupitem.type [string tolower ${startupitem.type}]
-    
-    # Calculate a default value for startupitem.type
-    if {${startupitem.type} eq "default" || ${startupitem.type} eq ""} {
-        switch -exact ${os.platform} {
-            darwin {
-                set startupitem.type "launchd"
-            }
-            default {
-                set startupitem.type "none"
-            }
-        }
-    }
+    global UI_PREFIX os.platform
 
-    if { ${startupitem.type} eq "none" } {
-        ui_notice "$UI_PREFIX [msgcat::mc "Skipping creation of control script"]"
+    if {${os.platform} eq "darwin"} {
+        ui_notice "$UI_PREFIX [msgcat::mc "Creating launchd control script"]"
+        startupitem_create_darwin_launchd
     } else {
-        ui_notice "$UI_PREFIX [msgcat::mc "Creating ${startupitem.type} control script"]"
-
-        switch -- ${startupitem.type} {
-            launchd         { startupitem_create_darwin_launchd }
-            default         { ui_error "$UI_PREFIX [msgcat::mc "Unrecognized startupitem type %s" ${startupitem.type}]" }
-        }
+        ui_notice "$UI_PREFIX [msgcat::mc "Skipping creation of control script"]"
     }
 }

--- a/src/port1.0/portunload.tcl
+++ b/src/port1.0/portunload.tcl
@@ -48,7 +48,7 @@ default unload.asroot yes
 set_ui_prefix
 
 proc portunload::unload_main {args} {
-    global startupitem.type startupitem.name startupitem.location startupitem.plist
+    global startupitem.name startupitem.location startupitem.plist
     set launchctl_path ${portutil::autoconf::launchctl_path}
 
     foreach { path } "/Library/${startupitem.location}/${startupitem.plist}" {


### PR DESCRIPTION
Remove all remaining code dealing with startupitem.type

If anyone modified their macports.conf to adjust startupitem.type,
it is silently ignored.  There's only one port (denyhost) using
startupitem.type; I'll fix that shortly.

closes https://trac.macports.org/ticket/36770