### PR TITLE
Add use_no_compression option

### DIFF
--- a/src/port1.0/portextract.tcl
+++ b/src/port1.0/portextract.tcl
@@ -74,7 +74,7 @@ proc portextract::disttagclean {list} {
 }
 
 proc portextract::extract_start {args} {
-    global UI_PREFIX extract.dir extract.mkdir use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg
+    global UI_PREFIX extract.dir extract.mkdir use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg use_no_compression
 
     ui_notice "$UI_PREFIX [format [msgcat::mc "Extracting %s"] [option subport]]"
 
@@ -82,6 +82,9 @@ proc portextract::extract_start {args} {
     handle_add_users
 
     # should the distfiles be extracted to worksrcpath instead?
+    if {[tbool use_no_compression]} {
+        option extract.mkdir yes
+    }
     if {[tbool extract.mkdir]} {
         global worksrcpath
         ui_debug "Extracting to subdirectory worksrcdir"
@@ -116,6 +119,12 @@ proc portextract::extract_start {args} {
         option extract.cmd [findBinary hdiutil ${portutil::autoconf::hdiutil_path}]
         option extract.pre_args attach
         option extract.post_args "-private -readonly -nobrowse -mountpoint \\\"${dmg_mount}\\\" && cd \\\"${dmg_mount}\\\" && [findBinary find ${portutil::autoconf::find_path}] . -depth -perm -+r -print0 | [findBinary cpio ${portutil::autoconf::cpio_path}] -0 -p -d -m -u \\\"${extract.dir}/${distname}\\\"; status=\$?; cd / && ${extract.cmd} detach \\\"${dmg_mount}\\\" && [findBinary rmdir ${portutil::autoconf::rmdir_path}] \\\"${dmg_mount}\\\"; exit \$status"
+    } elseif {[tbool use_no_compression]} {
+        global worksrcpath
+        option extract.suffix ""
+        option extract.cmd cp
+        option extract.pre_args ""
+        option extract.post_args ${worksrcpath}
     }
 }
 

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -46,7 +46,7 @@ namespace eval portfetch {
 }
 
 # define options: distname master_sites
-options master_sites patch_sites extract.suffix distfiles patchfiles use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg dist_subdir \
+options master_sites patch_sites extract.suffix distfiles patchfiles use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg use_no_compression dist_subdir \
     fetch.type fetch.user fetch.password fetch.use_epsv fetch.ignore_sslcert \
     master_sites.mirror_subdir patch_sites.mirror_subdir \
     bzr.url bzr.revision \
@@ -120,13 +120,14 @@ default mirror_sites.listfile {"mirror_sites.tcl"}
 default mirror_sites.listpath {"port1.0/fetch"}
 
 # Option-executed procedures
-option_proc use_bzip2 portfetch::set_extract_type
-option_proc use_lzma  portfetch::set_extract_type
-option_proc use_xz    portfetch::set_extract_type
-option_proc use_zip   portfetch::set_extract_type
-option_proc use_7z    portfetch::set_extract_type
-option_proc use_lzip  portfetch::set_extract_type
-option_proc use_dmg   portfetch::set_extract_type
+option_proc use_bzip2          portfetch::set_extract_type
+option_proc use_lzma           portfetch::set_extract_type
+option_proc use_xz             portfetch::set_extract_type
+option_proc use_zip            portfetch::set_extract_type
+option_proc use_7z             portfetch::set_extract_type
+option_proc use_lzip           portfetch::set_extract_type
+option_proc use_dmg            portfetch::set_extract_type
+option_proc use_no_compression portfetch::set_extract_type
 
 option_proc fetch.type portfetch::set_fetch_type
 
@@ -162,6 +163,9 @@ proc portfetch::set_extract_type {option action args} {
             }
             use_dmg {
                 set extract.suffix .dmg
+            }
+            use_no_compression {
+                set extract.suffix ""
             }
         }
     }


### PR DESCRIPTION
`use_no_compression` configures the fetch and the extract phases to deal with a non-compressed file with no extract extension.

When creating the port for Amazon AWS `ecs-cli`, I had to deal with the case in which the port has to download an uncompressed binary file (see https://github.com/aws/amazon-ecs-cli).

The port (submitted in https://github.com/macports/macports-ports/pull/1089), works with the following configuration:

```
extract.suffix
extract.cmd             cp
extract.pre_args
extract.post_args       ${worksrcpath}
extract.mkdir           yes
```

Basically, the extract suffix is set to an empty string and the downloaded file is just copied into `${worksrcpath}`, which gets created by setting `extract.mkdir` to `yes`.

I thought it may be useful to deal with this case natively, and I added the `use_no_compression` option.