### PR TITLE
Further assume we're on a POSIX system

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1083,34 +1083,6 @@ AC_DEFUN([MP_PATH_SCAN],[
 	prefix=$oldprefix
 ])
 
-dnl This macro tests for sed support of -E (BSD) or -r (GNU)
-AC_DEFUN([MP_SED_EXTENDED_REGEXP],[
-	AC_PATH_PROG(SED, [sed])
-
-	if test "x$SED" = "x"; then
-		AC_MSG_ERROR([cannot find sed. Is sed installed?])
-	fi
-
-	AC_MSG_CHECKING([which sed flag to use for extended regexp])
-	[any_sed_flag=`echo foo | $SED    -e s/foo+/OK/ 2>&1 | grep OK`]
-	[bsd_sed_flag=`echo foo | $SED -E -e s/foo+/OK/ 2>&1 | grep OK`]
-	[gnu_sed_flag=`echo foo | $SED -r -e s/foo+/OK/ 2>&1 | grep OK`]
-	if test "x$any_sed_flag" = "xOK" ; then
-		AC_MSG_RESULT([none])
-		SED_EXT=
-	elif test "x$bsd_sed_flag" = "xOK" ; then
-		AC_MSG_RESULT([-E (BSD)])
-		SED_EXT=-E
-	elif test "x$gnu_sed_flag" = "xOK" ; then
-		AC_MSG_RESULT([-r (GNU)])
-		SED_EXT=-r
-	else
-		AC_MSG_RESULT([not available])
-		SED_EXT='N/A'
-	fi
-	AC_SUBST(SED_EXT)
-])
-
 dnl This macro tests for tar support of -q (BSD) or not (GNU)
 AC_DEFUN([MP_TAR_FAST_READ],[
 	AC_PATH_PROG(TAR, [tar])
@@ -1160,55 +1132,6 @@ AC_DEFUN([MP_PATCH_GNU_VERSION],[
 		AC_MSG_RESULT([$PATCH_CMD])
 		GNUPATCH="$PATCH_CMD"
 	fi
-])
-
-#------------------------------------------------------------------------
-# MP_CHECK_READLINK_IS_P1003_1A --
-#
-#	Check if readlink conforms to POSIX 1003.1a standard, define
-#	READLINK_IS_NOT_P1003_1A if it doesn't.
-#
-# Arguments:
-#       None.
-#
-# Requires:
-#       None.
-#
-# Depends:
-#		AC_LANG_PROGRAM
-#
-# Results:
-#       Result is cached.
-#
-#	If readlink doesn't conform to POSIX 1003.1a, defines the following variables:
-#		READLINK_IS_NOT_P1003_1A
-#
-#------------------------------------------------------------------------
-AC_DEFUN(MP_CHECK_READLINK_IS_P1003_1A, [
-	AC_MSG_CHECKING([if readlink conforms to POSIX 1003.1a])
-
-	AC_CACHE_VAL(mp_cv_readlink_is_posix_1003_1a, [
-		AC_COMPILE_IFELSE([
-			AC_LANG_PROGRAM([
-					#include <unistd.h>
-					ssize_t readlink(const char *, char *, size_t);
-				], [
-			])
-			], [
-				mp_cv_readlink_is_posix_1003_1a="yes"
-			], [
-				mp_cv_readlink_is_posix_1003_1a="no"
-			]
-		)
-	])
-
-	AC_MSG_RESULT(${mp_cv_readlink_is_posix_1003_1a})
-
-	if test x"${mp_cv_readlink_is_posix_1003_1a}" = "xno"; then
-		AC_DEFINE([READLINK_IS_NOT_P1003_1A], [], [Define to 1 if readlink does not conform with POSIX 1003.1a (where third argument is a size_t and return value is a ssize_t)])
-	fi
-
-	AC_SUBST(READLINK_IS_NOT_P1003_1A)
 ])
 
 #------------------------------------------------------------------------

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-autoconf --warnings=all --force
-autoheader --warnings=all --force
+autoreconf --force -Wall -Werror

--- a/configure
+++ b/configure
@@ -667,7 +667,6 @@ OS_MAJOR
 OS_PLATFORM
 READLINE_LIBS
 MD5_LIBS
-READLINK_IS_NOT_P1003_1A
 ac_cv_func_strlcat
 EGREP
 GREP
@@ -692,7 +691,6 @@ CFLAGS_PEDANTIC
 CFLAGS_QUICHEEATERS
 TAR_CMD
 TAR_Q
-SED_EXT
 ZIP
 XZ
 XCRUN
@@ -5836,76 +5834,6 @@ if test "x$MTREE" = "x"; then
 fi
 
 
-	# Extract the first word of "sed", so it can be a program name with args.
-set dummy sed; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_SED+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $SED in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_SED="$SED" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_SED="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-SED=$ac_cv_path_SED
-if test -n "$SED"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SED" >&5
-$as_echo "$SED" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-
-	if test "x$SED" = "x"; then
-		as_fn_error $? "cannot find sed. Is sed installed?" "$LINENO" 5
-	fi
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking which sed flag to use for extended regexp" >&5
-$as_echo_n "checking which sed flag to use for extended regexp... " >&6; }
-	any_sed_flag=`echo foo | $SED    -e s/foo+/OK/ 2>&1 | grep OK`
-	bsd_sed_flag=`echo foo | $SED -E -e s/foo+/OK/ 2>&1 | grep OK`
-	gnu_sed_flag=`echo foo | $SED -r -e s/foo+/OK/ 2>&1 | grep OK`
-	if test "x$any_sed_flag" = "xOK" ; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: none" >&5
-$as_echo "none" >&6; }
-		SED_EXT=
-	elif test "x$bsd_sed_flag" = "xOK" ; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: -E (BSD)" >&5
-$as_echo "-E (BSD)" >&6; }
-		SED_EXT=-E
-	elif test "x$gnu_sed_flag" = "xOK" ; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: -r (GNU)" >&5
-$as_echo "-r (GNU)" >&6; }
-		SED_EXT=-r
-	else
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: not available" >&5
-$as_echo "not available" >&6; }
-		SED_EXT='N/A'
-	fi
-
-
-
 	# Extract the first word of "tar", so it can be a program name with args.
 set dummy tar; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -7244,58 +7172,6 @@ fi
 cat >>confdefs.h <<_ACEOF
 #define HAVE_DECL_ATOMIC_COMPARE_EXCHANGE_STRONG_EXPLICIT $ac_have_decl
 _ACEOF
-
-
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if readlink conforms to POSIX 1003.1a" >&5
-$as_echo_n "checking if readlink conforms to POSIX 1003.1a... " >&6; }
-
-	if ${mp_cv_readlink_is_posix_1003_1a+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-
-		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-					#include <unistd.h>
-					ssize_t readlink(const char *, char *, size_t);
-
-int
-main ()
-{
-
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-				mp_cv_readlink_is_posix_1003_1a="yes"
-
-else
-
-				mp_cv_readlink_is_posix_1003_1a="no"
-
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-fi
-
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: ${mp_cv_readlink_is_posix_1003_1a}" >&5
-$as_echo "${mp_cv_readlink_is_posix_1003_1a}" >&6; }
-
-	if test x"${mp_cv_readlink_is_posix_1003_1a}" = "xno"; then
-
-$as_echo "#define READLINK_IS_NOT_P1003_1A /**/" >>confdefs.h
-
-	fi
-
-
 
 
 # Check for md5 implementation

--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,6 @@ if test "x$MTREE" = "x"; then
     AC_MSG_ERROR([mtree not found])
 fi
 
-MP_SED_EXTENDED_REGEXP
 MP_TAR_FAST_READ
 MP_TAR_NO_SAME_OWNER
 MP_PATCH_GNU_VERSION
@@ -246,8 +245,6 @@ AC_CHECK_FUNCS([OSAtomicCompareAndSwap32 OSAtomicCompareAndSwap64 \
 AC_SUBST([ac_cv_func_strlcat])
 
 AC_CHECK_DECLS([atomic_compare_exchange_strong_explicit], [], [], [[#include <stdatomic.h>]])
-
-MP_CHECK_READLINK_IS_P1003_1A
 
 # Check for md5 implementation
 AC_CHECK_HEADER([CommonCrypto/CommonDigest.h], [AC_DEFINE([HAVE_COMMONCRYPTO_COMMONDIGEST_H], [1], [Define if CommonCrypto is available.])], [MP_LIB_MD5])

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -249,10 +249,6 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if readlink does not conform with POSIX 1003.1a (where third
-   argument is a size_t and return value is a ssize_t) */
-#undef READLINK_IS_NOT_P1003_1A
-
 /* Define to 1 if static build is requested */
 #undef STATIC_BUILD
 

--- a/src/darwintracelib1.0/readlink.c
+++ b/src/darwintracelib1.0/readlink.c
@@ -42,11 +42,7 @@
 /**
  * Deny \c readlink(2) if the file is not within the sandbox bounds.
  */
-#ifdef READLINK_IS_NOT_P1003_1A
-static int _dt_readlink(const char *path, char *buf, int bufsiz) {
-#else
 static ssize_t _dt_readlink(const char *path, char *buf, size_t bufsiz) {
-#endif
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/port1.0/port_autoconf.tcl.in
+++ b/src/port1.0/port_autoconf.tcl.in
@@ -67,7 +67,6 @@ namespace eval portutil::autoconf {
 	variable xcrun_path "@XCRUN@"
 	variable sandbox_exec_path "@SANDBOX_EXEC@"
 	variable sed_command "@SED@"
-	variable sed_ext_flag "@SED_EXT@"
 	variable tar_command "@TAR_CMD@"
 	variable tar_path "@TAR@"
 	variable tar_q "@TAR_Q@"

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -983,11 +983,7 @@ proc reinplace {args}  {
         set cmdline {}
         lappend cmdline $portutil::autoconf::sed_command
         if {$extended} {
-            if {$portutil::autoconf::sed_ext_flag eq "N/A"} {
-                ui_debug "sed extended regexp not available"
-                return -code error "reinplace sed(1) too old"
-            }
-            lappend cmdline $portutil::autoconf::sed_ext_flag
+            lappend cmdline -E
         }
         if {$suppress} {
             lappend cmdline -n


### PR DESCRIPTION
- GNU sed has supported -E for a long time. In addition, `-E` has been
  POSIX since 2012.  http://austingroupbugs.net/view.php?id=528#c1112

- readlink has been in POSIX even longer. Removal of this check breaks
  macOS 10.3 and lower.

  This is already broken in configure
  ```
  31   10.0*|10.1|10.1.*|10.2*|10.3*)
  32     AC_MSG_ERROR([This version of Mac OS X is not supported
  ```

- While here, change autogen.sh to use autoreconf