### PR TITLE
Update year in AUTHORS for port man page

### DIFF
--- a/doc/port.1
+++ b/doc/port.1
@@ -1,5 +1,5 @@
 '\" t
-.TH "PORT" "1" "2018\-01\-09" "MacPorts 2\&.4\&.99" "MacPorts Manual"
+.TH "PORT" "1" "2017\-12\-14" "MacPorts 2\&.4\&.99" "MacPorts Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -1788,7 +1788,7 @@ The \fBport\fR utility exits 0 on success, and >0 if an error occurs\&.
 .\}
 .nf
 (C) 2002\-2003 Apple Inc\&.
-(C) 2004\-2012 The MacPorts Project
+(C) 2004\-2018 The MacPorts Project
 Landon Fuller <landonf@macports\&.org>
 James Berry <jberry@macports\&.org>
 Jordan K\&. Hubbard <jkh@macports\&.org>

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -44,7 +44,7 @@ available port tree(s). These may be used in the same way as a 'portname'.
     - 'inactive': set of installed but inactive ports
     - 'installed': set of all installed ports
     - 'uninstalled': ports in the ports tree(s) that are not installed
-    - 'outdated': installed ports that are out of date with respect to their 
+    - 'outdated': installed ports that are out of date with respect to their
       current version/revision in the ports tree(s)
     - 'obsolete': set of ports that are installed but no longer exist in any
       port tree
@@ -131,7 +131,7 @@ The port command recognizes several global flags and options.
     Quiet mode, suppress informational messages to a minimum, implies -N
 
 -N::
-    Non-interactive mode, interactive questions are not asked 
+    Non-interactive mode, interactive questions are not asked
 
 .Installation and upgrade
 -n::
@@ -179,7 +179,7 @@ The port command recognizes several global flags and options.
 -t::
     Enable trace mode debug facilities on platforms that support it, currently
     only Mac OS X.
-    + 
+    +
     This feature is two-folded. It consists in automatically detecting and
     reporting undeclared dependencies based on what files the port reads or what
     programs the port executes. In verbose mode, it will also report unused

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -698,7 +698,7 @@ man:portstyle[7], man:porthier[7]
 AUTHORS
 -------
  (C) 2002-2003 Apple Inc.
- (C) 2004-2012 The MacPorts Project
+ (C) 2004-2018 The MacPorts Project
  Landon Fuller <landonf@macports.org>
  James Berry <jberry@macports.org>
  Jordan K. Hubbard <jkh@macports.org>


### PR DESCRIPTION
Update year range from 2004-2012 to 2004-2017
under AUTHORS for port man page.

Change the from branch to separate branch instead of fork/master. 
Replaces PR #50 