### PR TITLE
If expected path of extract doesn't exist, symlink to actual path.

### DIFF
--- a/src/pextlib1.0/fs-traverse.c
+++ b/src/pextlib1.0/fs-traverse.c
@@ -170,7 +170,7 @@ do_traverse(Tcl_Interp *interp, int flags, char * CONST *targets, Tcl_Obj *varna
     FTS *root_fts;
     FTSENT *ent;
 
-    root_fts = fts_open(targets, FTS_PHYSICAL /*| FTS_COMFOLLOW */| FTS_NOCHDIR | FTS_XDEV, &do_compare);
+    root_fts = fts_open(targets, FTS_PHYSICAL | FTS_COMFOLLOW | FTS_NOCHDIR | FTS_XDEV, &do_compare);
 
     while ((ent = fts_read(root_fts)) != NULL) {
         switch (ent->fts_info) {

--- a/src/pextlib1.0/tests/fs-traverse.tcl
+++ b/src/pextlib1.0/tests/fs-traverse.tcl
@@ -255,6 +255,10 @@ proc setup_trees {root} {
 
     set trees(sub1) "
         $root/a/c/a     {link ../d}
+        $root/a/c/a/a   file
+        $root/a/c/a/b   {link ../../b/a}
+        $root/a/c/a/c   directory
+        $root/a/c/a/d   file
     "
 
     set trees(sub2) "

--- a/src/port1.0/portextract.tcl
+++ b/src/port1.0/portextract.tcl
@@ -124,7 +124,7 @@ proc portextract::extract_start {args} {
 }
 
 proc portextract::extract_main {args} {
-    global UI_PREFIX filespath worksrcpath extract.dir use_dmg
+    global UI_PREFIX filespath workpath worksrcdir worksrcpath extract.dir use_dmg
 
     if {![exists distfiles] && ![exists extract.only]} {
         # nothing to do
@@ -155,6 +155,17 @@ proc portextract::extract_main {args} {
         }
 
         chownAsRoot ${extract.dir}
+    }
+
+    # If expected path of extract doesn't exist && worksrcdir is
+    # not explicitly set to subdirectory, symlink to actual path.
+    if {![file isdirectory $worksrcpath] && [regexp {^[^/]+$} $worksrcdir]} {
+        set workdirs [glob -nocomplain -types d [file join $workpath *]]
+        if {[llength $workdirs] == 1} {
+            set dir [file tail [lindex $workdirs 0]]
+            ui_debug [format [msgcat::mc "Symlink: %s -> %s"] $worksrcpath $dir]
+            symlink $dir $worksrcpath
+        }
     }
     return 0
 }


### PR DESCRIPTION
This attempts to resolve an [issue raised by Mojca](https://github.com/macports/macports-ports/pull/1075#discussion_r154493451) where worksrcdir has to be set manually if a source archive extracts to an unexpected directory.  In this particular case, for instance, the archive is named v2.4.1.tar.gz and extracts to libwebsockets-2.4.1.

Similarly, using the github.setup defaults, the archive (tagged as v2.4.1) is libwebsockets-2.4.1.tar.gz and extracts to warmcat-libwebsockets-e4e774b.
