### PR TITLE
portconfigure: fix compiler selection on PPC

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -473,7 +473,7 @@ proc portconfigure::configure_get_default_compiler {} {
 
 # internal function to choose compiler fallback list based on platform
 proc portconfigure::get_compiler_fallback {} {
-    global xcodeversion macosx_deployment_target default_compilers configure.sdkroot configure.cxx_stdlib os.major
+    global xcodeversion macosx_deployment_target default_compilers configure.sdkroot configure.cxx_stdlib os.major configure.build_arch
 
     # Check our override
     if {[info exists default_compilers]} {
@@ -492,9 +492,17 @@ proc portconfigure::get_compiler_fallback {} {
                 return {gcc-4.0}
             }
         } elseif {[vercmp $xcodeversion 3.0] >= 0} {
-            return {gcc-4.2 apple-gcc-4.2 gcc-4.0 macports-clang-3.4 macports-clang-3.3}
+            if {${configure.build_arch} eq "ppc" || ${configure.build_arch} eq "ppc64"} {
+                return {gcc-4.2 apple-gcc-4.2 gcc-4.0 macports-gcc-6 macports-gcc-7}
+            } else {
+                return {gcc-4.2 apple-gcc-4.2 gcc-4.0 macports-clang-3.4 macports-clang-3.3}
+            }
         } else {
-            return {apple-gcc-4.2 gcc-4.0 gcc-3.3 macports-clang-3.3}
+            if {${configure.build_arch} eq "ppc" || ${configure.build_arch} eq "ppc64"} {
+                return {apple-gcc-4.2 gcc-4.0 macports-gcc-6 macports-gcc-7}
+            } else {
+                return {apple-gcc-4.2 gcc-4.0 macports-clang-3.3}
+            }
         }
     }
 


### PR DESCRIPTION
PPC cannot use clang-3.3 or clang-3.4 successfully
fallback to gcc6 or gcc7 if default compilers are blacklisted
fixes innumerable tickets to be closed individually

Also - deleted gcc-3.3 from 10.4 Intel as a compiler fallback choice
for consistency with the PPC changes