### PR TITLE
portindex: support creating PortIndex for libc++

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2514,6 +2514,14 @@ proc mportsync {{optionslist {}}} {
     set obsoletesvn 0
 
     ui_msg "$macports::ui_prefix Updating the ports tree"
+    if {${macports::os_platform} eq "darwin" &&
+        ((${macports::os_major} >= 13 && ${macports::cxx_stdlib} ne "libc++") ||
+        (${macports::os_major} < 13 && ${macports::cxx_stdlib} ne "libstdc++"))} {
+        set platindex_cxxlib "_[string map {+ x} ${macports::cxx_stdlib}]"
+    } else {
+        set platindex_cxxlib {}
+    }
+    set platindex "PortIndex_${macports::os_platform}_${macports::os_major}${platindex_cxxlib}_${macports::os_arch}/PortIndex"
     foreach source $sources {
         set flags [lrange $source 1 end]
         set source [lindex $source 0]
@@ -2641,7 +2649,7 @@ proc mportsync {{optionslist {}}} {
                     } else {
                         set index_source $source
                     }
-                    set remote_indexfile "${index_source}PortIndex_${macports::os_platform}_${macports::os_major}_${macports::os_arch}/PortIndex"
+                    set remote_indexfile "$index_source$platindex"
                     set rsync_commandline "$macports::autoconf::rsync_path $rsync_options $remote_indexfile $destdir"
                     try -pass_signal {
                         system $rsync_commandline
@@ -2750,7 +2758,6 @@ proc mportsync {{optionslist {}}} {
                     ui_warn "Setting world read permissions on parts of the ports tree failed, need root?"
                 }
 
-                set platindex "PortIndex_${macports::os_platform}_${macports::os_major}_${macports::os_arch}/PortIndex"
                 if {[file isfile ${destdir}/$platindex] && [file isfile ${destdir}/${platindex}.quick]} {
                     file rename -force ${destdir}/$platindex ${destdir}/${platindex}.quick $destdir
                 }

--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -23,7 +23,7 @@ mportinit ui_options global_options global_variations
 # Standard procedures
 proc print_usage args {
     global argv0
-    puts "Usage: $argv0 \[-dfe\] \[-o output directory\] \[-p plat_ver_arch\] \[directory\]"
+    puts "Usage: $argv0 \[-dfe\] \[-o output directory\] \[-p plat_ver_\[cxxlib_\]arch\] \[directory\]"
     puts "-d:\tOutput debugging information"
     puts "-f:\tDo a full re-index instead of updating"
     puts "-e:\tExit code indicates if ports failed to parse"
@@ -199,7 +199,26 @@ for {set i 0} {$i < $argc} {incr i} {
                 set platlist [split [lindex $argv $i] _]
                 set os_platform [lindex $platlist 0]
                 set os_major [lindex $platlist 1]
-                set os_arch [lindex $platlist 2]
+                if {[llength $platlist] > 3} {
+                    set cxx_stdlib [lindex $platlist 2]
+                    switch -- $cxx_stdlib {
+                        libcxx {
+                            set cxx_stdlib libc++
+                        }
+                        libstdcxx {
+                            set cxx_stdlib libstdc++
+                        }
+                        default {
+                            puts stderr "Unknown C++ standard library: $cxx_stdlib (use libcxx or libstdcxx)"
+                            print_usage
+                            exit 1
+                        }
+                    }
+                    lappend port_options cxx_stdlib $cxx_stdlib
+                    set os_arch [lindex $platlist 3]
+                } else {
+                    set os_arch [lindex $platlist 2]
+                }
                 if {$os_platform eq "macosx"} {
                     lappend port_options os.subplatform $os_platform os.universal_supported yes
                     set os_platform darwin

--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -214,16 +214,22 @@ for {set i 0} {$i < $argc} {incr i} {
                             exit 1
                         }
                     }
-                    lappend port_options cxx_stdlib $cxx_stdlib
                     set os_arch [lindex $platlist 3]
                 } else {
+                    if {$os_platform eq "macosx"} {
+                        if {$os_major < 13} {
+                            set cxx_stdlib libstdc++
+                        } else {
+                            set cxx_stdlib libc++
+                        }
+                    }
                     set os_arch [lindex $platlist 2]
                 }
+                lappend port_options os.platform $os_platform os.major $os_major os.arch $os_arch
                 if {$os_platform eq "macosx"} {
-                    lappend port_options os.subplatform $os_platform os.universal_supported yes
+                    lappend port_options os.subplatform $os_platform os.universal_supported yes cxx_stdlib $cxx_stdlib
                     set os_platform darwin
                 }
-                lappend port_options os.platform $os_platform os.major $os_major os.arch $os_arch
             } elseif {$arg eq "-f"} { # Completely rebuild index
                 set full_reindex 1
             } elseif {$arg eq "-e"} { # Non-zero exit code on errors


### PR DESCRIPTION
I'm submitting @ryandesign's patch from https://trac.macports.org/ticket/55471 for easier review and testing. 

It would be great to see it deployed soon. For that to happen another minor patch is needed, see the ticket.