### PR TITLE
reclaim: Respect -N and -y flags

### DIFF
--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -80,28 +80,30 @@ namespace eval reclaim {
         uninstall_inactive
         remove_distfiles
 
-        set last_run_contents [read_last_run_file]
-        if {$last_run_contents eq ""} {
-            set msg "This appears to be the first time you have run 'port reclaim'."
+        if {![macports::global_option_isset ports_dryrun]} {
+            set last_run_contents [read_last_run_file]
+            if {$last_run_contents eq ""} {
+                set msg "This appears to be the first time you have run 'port reclaim'."
 
-            if {[info exists macports::ui_options(questions_yesno)]} {
-                set retval [$macports::ui_options(questions_yesno) $msg "ReclaimPrompt" "" {y} 0 "Would you like to be reminded to run it every two weeks?"]
-                if {$retval != 0} {
-                    # User said no, store disabled flag
-                    set last_run_contents disabled
-                    write_last_run_file $last_run_contents
-                    ui_msg "Reminders disabled. Run 'port reclaim --enable-reminders' to enable."
+                if {[info exists macports::ui_options(questions_yesno)]} {
+                    set retval [$macports::ui_options(questions_yesno) $msg "ReclaimPrompt" "" {y} 0 "Would you like to be reminded to run it every two weeks?"]
+                    if {$retval != 0} {
+                        # User said no, store disabled flag
+                        set last_run_contents disabled
+                        write_last_run_file $last_run_contents
+                        ui_msg "Reminders disabled. Run 'port reclaim --enable-reminders' to enable."
+                    } else {
+                        # the last run file will be updated below
+                        ui_msg "Reminders enabled. Run 'port reclaim --disable-reminders' to disable."
+                    }
                 } else {
-                    # the last run file will be updated below
-                    ui_msg "Reminders enabled. Run 'port reclaim --disable-reminders' to disable."
+                    # couldn't ask the question, leave disabled for now
+                    set last_run_contents disabled
                 }
-            } else {
-                # couldn't ask the question, leave disabled for now
-                set last_run_contents disabled
             }
-        }
-        if {$last_run_contents ne "disabled"} {
-            update_last_run
+            if {$last_run_contents ne "disabled"} {
+                update_last_run
+            }
         }
     }
 
@@ -235,59 +237,72 @@ namespace eval reclaim {
             incr size_superfluous_files [file size $f]
         }
         if {[llength $superfluous_files] > 0} {
-            if {[info exists macports::ui_options(questions_alternative)]} {
-                array set alternatives {d delete k keep l list}
-                while 1 {
+            array set alternatives {d delete k keep l list}
+            while 1 {
+                set retstring "d"
+                if {[info exists macports::ui_options(questions_alternative)]} {
                     set retstring [$macports::ui_options(questions_alternative) [msgcat::mc \
                         "Found %d files (total %s) that are no longer needed and can be deleted." \
                         $num_superfluous_files [bytesize $size_superfluous_files]] "deleteFilesQ" "alternatives" {k}]
-                
-                    switch $retstring {
-                        d {
-                            ui_msg "Deleting..."
-                            foreach f $superfluous_files {
-                                set root_length [string length "${root_dist}/"]
-                                set home_length [string length "${home_dist}/"]
+                }
 
-                                try -pass_signal {
+                switch $retstring {
+                    d {
+                        if {[macports::global_option_isset ports_dryrun]} {
+                            ui_msg "Deleting... (dry run)"
+                        } else {
+                            ui_msg "Deleting..."
+                        }
+                        foreach f $superfluous_files {
+                            set root_length [string length "${root_dist}/"]
+                            set home_length [string length "${home_dist}/"]
+
+                            try -pass_signal {
+                                if {[macports::global_option_isset ports_dryrun]} {
+                                    ui_info [msgcat::mc "Skipping deletion of unused file %s (dry run)" $f]
+                                } else {
                                     ui_info [msgcat::mc "Deleting unused file %s" $f]
                                     file delete -- $f
+                                }
 
-                                    set directory [file dirname $f]
-                                    while {1} {
-                                        set is_below_root [string equal -length $root_length $directory "${root_dist}/"]
-                                        set is_below_home [string equal -length $home_length $directory "${home_dist}/"]
+                                set directory [file dirname $f]
+                                while {1} {
+                                    set is_below_root [string equal -length $root_length $directory "${root_dist}/"]
+                                    set is_below_home [string equal -length $home_length $directory "${home_dist}/"]
 
-                                        if {!$is_below_root && !$is_below_home} {
-                                            break
-                                        }
+                                    if {!$is_below_root && !$is_below_home} {
+                                        break
+                                    }
 
-                                        if {[llength [readdir $directory]] > 0} {
-                                            break
-                                        }
+                                    if {[llength [readdir $directory]] > 0} {
+                                        break
+                                    }
 
+                                    if {[macports::global_option_isset ports_dryrun]} {
+                                        ui_info [msgcat::mc "Skipping deletion of empty directory %s (dry run)" $directory]
+                                    } else {
                                         ui_info [msgcat::mc "Deleting empty directory %s" $directory]
                                         try -pass_signal {
                                             file delete -- $directory
                                         } catch {{*} eCode eMessage} {
                                             ui_warn [msgcat::mc "Could not delete empty directory %s: %s" $directory $eMesage]
                                         }
-                                        set directory [file dirname $directory]
                                     }
-                                } catch {{*} eCode eMessage} {
-                                    ui_warn [msgcat::mc "Could not delete %s: %s" $f $eMessage]
+                                    set directory [file dirname $directory]
                                 }
+                            } catch {{*} eCode eMessage} {
+                                ui_warn [msgcat::mc "Could not delete %s: %s" $f $eMessage]
                             }
-                            break
                         }
-                        k {
-                            ui_msg "OK, keeping the files."
-                            break
-                        }
-                        l {
-                            foreach f $superfluous_files {
-                                ui_msg "  $f"
-                            }
+                        break
+                    }
+                    k {
+                        ui_msg "OK, keeping the files."
+                        break
+                    }
+                    l {
+                        foreach f $superfluous_files {
+                            ui_msg "  $f"
                         }
                     }
                 }
@@ -456,20 +471,24 @@ namespace eval reclaim {
             ui_msg "Found no inactive ports."
 
         } else {
+            set retval 0
             if {[info exists macports::ui_options(questions_yesno)]} {
                 set retval [$macports::ui_options(questions_yesno) "Inactive ports found:" "" $inactive_names "y" 0 "Would you like to uninstall them?"]
-                if {${retval} == 0} {
-                    foreach port $inactive_ports {
-                        # Note: 'uninstall' takes a name, version, revision, variants and an options list.
-                        try -pass_signal {
-                            registry_uninstall::uninstall [$port name] [$port version] [$port revision] [$port variants] {ports_force true}
-                        } catch {{*} eCode eMessage} {
-                            ui_error "Error uninstalling $name: $eMessage"
-                        }
+            }
+
+            if {${retval} == 0 && [macports::global_option_isset ports_dryrun]} {
+                ui_msg "Skipping uninstall of inactive ports (dry run)"
+            } elseif {${retval} == 0} {
+                foreach port $inactive_ports {
+                    # Note: 'uninstall' takes a name, version, revision, variants and an options list.
+                    try -pass_signal {
+                        registry_uninstall::uninstall [$port name] [$port version] [$port revision] [$port variants] {ports_force true}
+                    } catch {{*} eCode eMessage} {
+                        ui_error "Error uninstalling $name: $eMessage"
                     }
-                } else {
-                    ui_msg "Not uninstalling ports."
                 }
+            } else {
+                ui_msg "Not uninstalling ports."
             }
         }
         return 0
@@ -519,21 +538,24 @@ namespace eval reclaim {
             ui_msg "Found no unrequested ports without requested dependents."
 
         } else {
+            set retval 0
             if {[info exists macports::ui_options(questions_yesno)]} {
                 set retval [$macports::ui_options(questions_yesno) "Unrequested ports without requested dependents found:" "" $unnecessary_names "y" 0 "Would you like to uninstall them?"]
+            }
 
-                if {${retval} == 0} {
-                    foreach port $unnecessary_ports {
-                        # Note: 'uninstall' takes a name, version, revision, variants and an options list.
-                        try -pass_signal {
-                            registry_uninstall::uninstall [$port name] [$port version] [$port revision] [$port variants] {ports_force true}
-                        } catch {{*} eCode eMessage} {
-                            ui_error "Error uninstalling $name: $eMessage"
-                        }
+            if {${retval} == 0 && [macports::global_option_isset ports_dryrun]} {
+                ui_msg "Skipping uninstall of unrequested ports (dry run)"
+            } elseif {${retval} == 0} {
+                foreach port $unnecessary_ports {
+                    # Note: 'uninstall' takes a name, version, revision, variants and an options list.
+                    try -pass_signal {
+                        registry_uninstall::uninstall [$port name] [$port version] [$port revision] [$port variants] {ports_force true}
+                    } catch {{*} eCode eMessage} {
+                        ui_error "Error uninstalling $name: $eMessage"
                     }
-                } else {
-                    ui_msg "Not uninstalling ports; use 'port setrequested' mark a port as explicitly requested."
                 }
+            } else {
+                ui_msg "Not uninstalling ports; use 'port setrequested' mark a port as explicitly requested."
             }
         }
         return 0


### PR DESCRIPTION
Do not ask questions in non-interactive mode (-N), but still run all the
checks and remove ports and files by default. Do not delete any files in
dry-run mode (-y), even if the user confirmed the removal.

Closes: https://trac.macports.org/ticket/53857

---

@g5pw Sorry for hijacking the ticket assigned to you, but my system was in the need of a cleanup, so I went ahead and implemented this.