### PR TITLE
Add depends_patch to handle the patch dependencies of ports

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -3560,8 +3560,8 @@ proc macports::_deptypes_for_target {target workername} {
     switch -- $target {
         fetch       -
         checksum    {return depends_fetch}
-        extract     -
-        patch       {return "depends_fetch depends_extract"}
+        extract     {return "depends_fetch depends_extract"}
+        patch       {return "depends_fetch depends_extract depends_patch"}
         configure   -
         build       {return "depends_fetch depends_extract depends_build depends_lib"}
         test        {return "depends_fetch depends_extract depends_build depends_lib depends_run depends_test"}

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -3563,9 +3563,9 @@ proc macports::_deptypes_for_target {target workername} {
         extract     {return "depends_fetch depends_extract"}
         patch       {return "depends_fetch depends_extract depends_patch"}
         configure   -
-        build       {return "depends_fetch depends_extract depends_build depends_lib"}
-        test        {return "depends_fetch depends_extract depends_build depends_lib depends_run depends_test"}
-        destroot    {return "depends_fetch depends_extract depends_build depends_lib depends_run"}
+        build       {return "depends_fetch depends_extract depends_patch depends_build depends_lib"}
+        test        {return "depends_fetch depends_extract depends_patch depends_build depends_lib depends_run depends_test"}
+        destroot    {return "depends_fetch depends_extract depends_patch depends_build depends_lib depends_run"}
         dmg         -
         pkg         -
         mdmg        -
@@ -3574,7 +3574,7 @@ proc macports::_deptypes_for_target {target workername} {
                 (![global_option_isset ports_source_only] && [$workername eval {_archive_available}])} {
                 return "depends_lib depends_run"
             } else {
-                return "depends_fetch depends_extract depends_build depends_lib depends_run"
+                return "depends_fetch depends_extract depends_patch depends_build depends_lib depends_run"
             }
         }
         install     -
@@ -3585,7 +3585,7 @@ proc macports::_deptypes_for_target {target workername} {
                 || (![global_option_isset ports_source_only] && [$workername eval {_archive_available}])} {
                 return "depends_lib depends_run"
             } else {
-                return "depends_fetch depends_extract depends_build depends_lib depends_run"
+                return "depends_fetch depends_extract depends_patch depends_build depends_lib depends_run"
             }
         }
     }

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -100,7 +100,7 @@ These pseudo-portnames expand to the set of ports named.
 
 Pseudo-portnames starting with variants:, variant:, description:, depends:,
 depends_lib:, depends_run:, depends_build:, depends_fetch:, depends_extract:,
-depends_test:,
+depends_patch:, depends_test:,
 portdir:, homepage:, epoch:, platforms:, platform:, name:, long_description:,
 maintainers:, maintainer:, categories:, category:, version:, revision:, and
 license: each select a set of ports based on a regex search of metadata
@@ -996,7 +996,7 @@ proc get_rdepends_ports {portname} {
     if {![info exists ::portDependenciesArray]} {
         # make an associative array of all the port names and their (reverse) dependencies
         # much faster to build this once than to call mportsearch thousands of times
-        set deptypes {depends_fetch depends_extract depends_build depends_lib depends_run depends_test}
+        set deptypes {depends_fetch depends_extract depends_patch depends_build depends_lib depends_run depends_test}
         foreach {pname pinfolist} [mportlistall] {
             array unset pinfo
             array set pinfo $pinfolist
@@ -1353,6 +1353,7 @@ proc element { resname } {
         ^(depends_run):(.*)      -
         ^(depends_extract):(.*)  -
         ^(depends_fetch):(.*)    -
+        ^(depends_patch):(.*)    -
         ^(depends_test):(.*)     -
         ^(replaced_by):(.*)      -
         ^(revision):(.*)         -
@@ -1381,6 +1382,7 @@ proc element { resname } {
             add_multiple_ports reslist [get_matching_ports $pat no regexp "depends_run"]
             add_multiple_ports reslist [get_matching_ports $pat no regexp "depends_extract"]
             add_multiple_ports reslist [get_matching_ports $pat no regexp "depends_fetch"]
+            add_multiple_ports reslist [get_matching_ports $pat no regexp "depends_patch"]
             add_multiple_ports reslist [get_matching_ports $pat no regexp "depends_test"]
 
             set el 1
@@ -2049,6 +2051,7 @@ proc action_info { action portlist opts } {
             categories      {", "  ", "  ","}
             depends_fetch   {", "  ", "  ","}
             depends_extract {", "  ", "  ","}
+            depends_patch   {", "  ", "  ","}
             depends_build   {", "  ", "  ","}
             depends_lib     {", "  ", "  ","}
             depends_run     {", "  ", "  ","}
@@ -2067,6 +2070,7 @@ proc action_info { action portlist opts } {
             variants    Variants
             depends_fetch "Fetch Dependencies"
             depends_extract "Extract Dependencies"
+            depends_patch "Patch Dependencies"
             depends_build "Build Dependencies"
             depends_run "Runtime Dependencies"
             depends_lib "Library Dependencies"
@@ -2091,6 +2095,7 @@ proc action_info { action portlist opts } {
             variants 22
             depends_fetch 22
             depends_extract 22
+            depends_patch 22
             depends_build 22
             depends_run 22
             depends_lib 22
@@ -2111,6 +2116,7 @@ proc action_info { action portlist opts } {
             array unset options ports_info_depends
             set options(ports_info_depends_fetch) yes
             set options(ports_info_depends_extract) yes
+            set options(ports_info_depends_patch) yes
             set options(ports_info_depends_build) yes
             set options(ports_info_depends_lib) yes
             set options(ports_info_depends_run) yes
@@ -2165,7 +2171,9 @@ proc action_info { action portlist opts } {
                 ports_info_skip_line
                 ports_info_long_description ports_info_homepage
                 ports_info_skip_line ports_info_depends_fetch
-                ports_info_depends_extract ports_info_depends_build
+                ports_info_depends_extract
+                ports_info_depends_patch
+                ports_info_depends_build
                 ports_info_depends_lib ports_info_depends_run
                 ports_info_depends_test
                 ports_info_conflicts
@@ -3088,7 +3096,7 @@ proc action_deps { action portlist opts } {
         set deplist {}
         set deps_output {}
         set ndeps 0
-        array set labeldict {depends_fetch Fetch depends_extract Extract depends_build Build depends_lib Library depends_run Runtime depends_test Test}
+        array set labeldict {depends_fetch Fetch depends_extract Extract depends_patch Patch depends_build Build depends_lib Library depends_run Runtime depends_test Test}
         # get list of direct deps
         foreach type $deptypes {
             if {[info exists portinfo($type)]} {
@@ -3729,6 +3737,7 @@ proc action_search { action portlist opts } {
         array unset options ports_search_depends
         set options(ports_search_depends_fetch) yes
         set options(ports_search_depends_extract) yes
+        set options(ports_search_depends_patch) yes
         set options(ports_search_depends_build) yes
         set options(ports_search_depends_lib) yes
         set options(ports_search_depends_run) yes
@@ -4435,6 +4444,7 @@ proc action_needs_portlist { action } {
 array set cmd_opts_array {
     edit        {{editor 1}}
     info        {category categories conflicts depends_fetch depends_extract
+                 depends_patch
                  depends_build depends_lib depends_run depends_test
                  depends description epoch fullname heading homepage index license
                  line long_description
@@ -4445,7 +4455,8 @@ array set cmd_opts_array {
     rdeps       {index no-build full}
     rdependents {full}
     search      {case-sensitive category categories depends_fetch
-                 depends_extract depends_build depends_lib depends_run depends_test
+                 depends_extract depends_patch
+                 depends_build depends_lib depends_run depends_test
                  depends description epoch exact glob homepage line
                  long_description maintainer maintainers name platform
                  platforms portdir regex revision variant variants version}

--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -266,7 +266,8 @@ if {[file isfile $outpath] && [file isfile ${outpath}.quick]} {
 set tempportindex [mktemp "/tmp/mports.portindex.XXXXXXXX"]
 set fd [open $tempportindex w]
 set save_prefix ${macports::prefix}
-foreach key {categories depends_fetch depends_extract depends_build \
+foreach key {categories depends_fetch depends_extract depends_patch \
+             depends_build \
              depends_lib depends_run depends_test description epoch homepage \
              long_description maintainers name platforms revision variants \
              version portdir replaced_by license installs_libs conflicts} {

--- a/src/port1.0/portdepends.tcl
+++ b/src/port1.0/portdepends.tcl
@@ -37,12 +37,13 @@ namespace eval portdepends {
 }
 
 # define options
-options depends_fetch depends_extract depends_build depends_run depends_lib depends_test depends
+options depends_fetch depends_extract depends_patch depends_build depends_run depends_lib depends_test depends
 # Export options via PortInfo
-options_export depends_fetch depends_extract depends_build depends_lib depends_run depends_test
+options_export depends_fetch depends_extract depends_patch depends_build depends_lib depends_run depends_test
 
 option_proc depends_fetch portdepends::validate_depends_options
 option_proc depends_extract portdepends::validate_depends_options
+option_proc depends_patch portdepends::validate_depends_options
 option_proc depends_build portdepends::validate_depends_options
 option_proc depends_run portdepends::validate_depends_options
 option_proc depends_lib portdepends::validate_depends_options

--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -343,7 +343,8 @@ proc portlint::lint_main {args} {
     global os.platform os.arch os.version version revision epoch \
            description long_description platforms categories all_variants \
            maintainers license homepage master_sites checksums patchfiles \
-           depends_fetch depends_extract depends_lib depends_build depends_run \
+           depends_fetch depends_extract depends_patch \
+           depends_lib depends_build depends_run \
            depends_test distfiles fetch.type lint_portsystem lint_platforms \
            lint_required lint_optional replaced_by conflicts
     set portarch [get_canonical_archs]
@@ -493,6 +494,9 @@ proc portlint::lint_main {args} {
     if {[info exists depends_extract]} {
         lappend all_depends {*}$depends_extract
     }
+    if {[info exists depends_patch]} {
+        lappend all_depends {*}$depends_patch
+    }
     if {[info exists depends_lib]} {
         lappend all_depends {*}$depends_lib
     }
@@ -520,7 +524,7 @@ proc portlint::lint_main {args} {
     }
 
     # Check for multiple dependencies
-    foreach deptype {depends_extract depends_lib depends_build depends_run depends_test} {
+    foreach deptype {depends_extract depends_patch depends_lib depends_build depends_run depends_test} {
         if {[info exists $deptype]} {
             array set depwarned {}
             foreach depspec [set $deptype] {

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1405,8 +1405,8 @@ proc target_run {ditem} {
                     switch $target {
                         fetch       -
                         checksum    { set deptypes "depends_fetch" }
-                        extract     -
-                        patch       { set deptypes "depends_fetch depends_extract" }
+                        extract     { set deptypes "depends_fetch depends_extract" }
+                        patch       { set deptypes "depends_fetch depends_extract depends_patch" }
                         configure   -
                         build       { set deptypes "depends_fetch depends_extract depends_lib depends_build" }
                         test        { set deptypes "depends_fetch depends_extract depends_lib depends_build depends_run depends_test" }

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1408,15 +1408,15 @@ proc target_run {ditem} {
                         extract     { set deptypes "depends_fetch depends_extract" }
                         patch       { set deptypes "depends_fetch depends_extract depends_patch" }
                         configure   -
-                        build       { set deptypes "depends_fetch depends_extract depends_lib depends_build" }
-                        test        { set deptypes "depends_fetch depends_extract depends_lib depends_build depends_run depends_test" }
+                        build       { set deptypes "depends_fetch depends_extract depends_patch depends_lib depends_build" }
+                        test        { set deptypes "depends_fetch depends_extract depends_patch depends_lib depends_build depends_run depends_test" }
                         destroot    -
                         dmg         -
                         pkg         -
                         portpkg     -
                         mpkg        -
                         mdmg        -
-                        ""          { set deptypes "depends_fetch depends_extract depends_lib depends_build depends_run" }
+                        ""          { set deptypes "depends_fetch depends_extract depends_patch depends_lib depends_build depends_run" }
 
                         # install may be run given an archive, which means
                         # depends_fetch, _extract, _build dependencies have


### PR DESCRIPTION
This can be used to handle xz patches in the below trac ticket (which
requires another patch to base).

See https://trac.macports.org/ticket/52445