### PR TITLE
Add check that port can be used on current platform

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2019,7 +2019,8 @@ proc _mportexec {target mport} {
     # xxx: set the work path?
     set workername [ditem_key $mport workername]
     $workername eval {validate_macportsuser}
-    if {![catch {$workername eval "check_variants $target"} result] && $result == 0 &&
+    if {![catch {$workername eval {check_supported_platforms}} result] && $result == 0 &&
+        ![catch {$workername eval "check_variants $target"} result] && $result == 0 &&
         ![catch {$workername eval {check_supported_archs}} result] && $result == 0 &&
         ![catch {$workername eval "eval_targets $target"} result] && $result == 0} {
         # If auto-clean mode, clean-up after dependency install
@@ -2068,6 +2069,13 @@ proc mportexec {mport target} {
     # build and will therefore need to check Xcode version and
     # supported_archs.
     if {[macports::_target_needs_deps $target]} {
+        # error out if current platform is not supported by this port
+        if {[$workername eval {check_supported_platforms}] != 0} {
+            if {$log_needs_pop} {
+                macports::pop_log
+            }
+            return 1
+        }
         # possibly warn or error out depending on how old xcode is
         if {[$workername eval {_check_xcode_version}] != 0} {
             if {$log_needs_pop} {

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3157,6 +3157,17 @@ proc check_supported_archs {} {
     return 1
 }
 
+# check that this port is supported on current platform
+proc check_supported_platforms {} {
+    global os.platform platforms subport
+
+    if {[lsearch $platforms ${os.platform}] == -1} {
+        ui_error "$subport cannot be installed on this platform '${os.platform}' because it only supports '$platforms'."
+        return 1
+    }
+    return 0
+}
+
 # check if the installed xcode version is new enough
 proc _check_xcode_version {} {
     global os.subplatform macosx_version xcodeversion


### PR DESCRIPTION
Implement a check that the current platform is in the port's
platforms list.

This only handles the current platforms statement in the Portfile.

see https://trac.macports.org/ticket/15712