### PR TITLE
Fix a typo

### DIFF
--- a/src/compat/strlcpy.c
+++ b/src/compat/strlcpy.c
@@ -35,7 +35,7 @@
 
 #ifndef HAVE_STRLCPY
 
-#include "strlcopy.h"
+#include "strlcpy.h"
 
 /* Define strlcpy if it's not available. */
 size_t strlcpy(char * restrict dst, const char * restrict src, size_t size) {


### PR DESCRIPTION
The typo prevents building on Linux
```
cc -c -DUSE_TCL_STUBS -DTCL_NO_DEPRECATED -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -fno-plt -std=c99 -Wextra -Wall -pedantic  -D_FORTIFY_SOURCE=2 -DHAVE_CONFIG_H -I/build/macports-base-git/src/macports-base/src -I/build/macports-base-git/src/macports-base/src -I. -I/build/macports-base-git/src/macports-base/vendor/vendor-destroot//opt/local/libexec/macports/include -fPIC strlcpy.c -o strlcpy.o
strlcpy.c:38:10: fatal error: strlcopy.h: No such file or directory
 #include "strlcopy.h"
          ^~~~~~~~~~~~
compilation terminated.
```