### PR TITLE
Add use_tar option

### DIFF
--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1,6 +1,6 @@
 .\" portfile.7
 .\"
-.\" Copyright (c) 2004-2014 The MacPorts Project
+.\" Copyright (c) 2004-2015, 2017-2018 The MacPorts Project
 .\" Copyright (c) 2002-2003 Apple Inc.
 .\" All rights reserved.
 .\"
@@ -873,6 +873,20 @@ Sets extract.cmd to: lzma
 .br
 .Sy Example:
 .Dl use_lzma yes
+.It Ic use_tar
+Use an uncompressed tar archive.
+.br
+Sets extract.suffix to: .tar
+.br
+Sets extract.cmd to: tar
+.br
+Sets extract.pre_args to: -xf
+.br
+.Sy Type:
+.Em optional
+.br
+.Sy Example:
+.Dl use_tar yes
 .It Ic use_xz
 Use xz.
 .br

--- a/src/port1.0/portextract.tcl
+++ b/src/port1.0/portextract.tcl
@@ -1,7 +1,7 @@
 # et:ts=4
 # portextract.tcl
 #
-# Copyright (c) 2005, 2007-2011, 2013 The MacPorts Project
+# Copyright (c) 2005, 2007-2011, 2013-2014, 2016, 2018 The MacPorts Project
 # Copyright (c) 2002 - 2003 Apple Inc.
 # Copyright (c) 2007 Markus W. Weissmann <mww@macports.org>
 # All rights reserved.
@@ -74,7 +74,7 @@ proc portextract::disttagclean {list} {
 }
 
 proc portextract::extract_start {args} {
-    global UI_PREFIX extract.dir extract.mkdir use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg
+    global UI_PREFIX extract.dir extract.mkdir use_tar use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg
 
     ui_notice "$UI_PREFIX [format [msgcat::mc "Extracting %s"] [option subport]]"
 
@@ -88,7 +88,11 @@ proc portextract::extract_start {args} {
         file mkdir ${worksrcpath}
         set extract.dir ${worksrcpath}
     }
-    if {[tbool use_bzip2]} {
+    if {[tbool use_tar]} {
+        option extract.cmd [findBinary tar ${portutil::autoconf::tar_command}]
+        option extract.pre_args -xf
+        option extract.post_args ""
+    } elseif {[tbool use_bzip2]} {
         if {![catch {findBinary lbzip2} result]} {
             option extract.cmd $result
         } else {

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 #
-# Copyright (c) 2004 - 2014, 2016 The MacPorts Project
+# Copyright (c) 2004 - 2014, 2016-2018 The MacPorts Project
 # Copyright (c) 2002 - 2003 Apple Inc.
 # All rights reserved.
 #
@@ -46,7 +46,8 @@ namespace eval portfetch {
 }
 
 # define options: distname master_sites
-options master_sites patch_sites extract.suffix distfiles patchfiles use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg dist_subdir \
+options master_sites patch_sites extract.suffix distfiles patchfiles use_tar \
+    use_bzip2 use_lzma use_xz use_zip use_7z use_lzip use_dmg dist_subdir \
     fetch.type fetch.user fetch.password fetch.use_epsv fetch.ignore_sslcert \
     master_sites.mirror_subdir patch_sites.mirror_subdir \
     bzr.url bzr.revision \
@@ -120,6 +121,7 @@ default mirror_sites.listfile {"mirror_sites.tcl"}
 default mirror_sites.listpath {"port1.0/fetch"}
 
 # Option-executed procedures
+option_proc use_tar   portfetch::set_extract_type
 option_proc use_bzip2 portfetch::set_extract_type
 option_proc use_lzma  portfetch::set_extract_type
 option_proc use_xz    portfetch::set_extract_type
@@ -134,6 +136,9 @@ proc portfetch::set_extract_type {option action args} {
     global extract.suffix
     if {[string equal ${action} "set"] && [tbool args]} {
         switch $option {
+            use_tar {
+                set extract.suffix .tar
+            }
             use_bzip2 {
                 set extract.suffix .tar.bz2
                 if {![catch {findBinary lbzip2} result]} {


### PR DESCRIPTION
In the interest of trying to reduce the number of ports that need to override the options of the extract phase, this PR introduces a new `use_tar` option. A separate PR will be sent to macports-ports to update the ports that currently manually implement this functionality.