### PR TITLE
Mk: Record header dependencies in *.d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/port/*
 !src/port/*.tcl
 src/programs/daemondo/build/
 src/**/*.o
+src/**/*.d
 src/**/*.a
 src/**/*.dylib
 src/**/*.dSYM

--- a/Mk/macports.tea.mk
+++ b/Mk/macports.tea.mk
@@ -1,4 +1,4 @@
-.c.o:
+%.o: %.c
 	${CC} -c -DUSE_TCL_STUBS -DTCL_NO_DEPRECATED ${CFLAGS} ${CPPFLAGS} ${SHLIB_CFLAGS} $< -o $@
 
 PKGINDEX ?= pkgIndex.tcl

--- a/Mk/macports.tea.mk
+++ b/Mk/macports.tea.mk
@@ -1,9 +1,13 @@
-%.o: %.c
-	${CC} -c -DUSE_TCL_STUBS -DTCL_NO_DEPRECATED ${CFLAGS} ${CPPFLAGS} ${SHLIB_CFLAGS} $< -o $@
-
 PKGINDEX ?= pkgIndex.tcl
 
 all:: ${SHLIB_NAME} ${PKGINDEX}
+
+# OBJS are *.o produced from *.c with header dependencies in *.d
+OBJSDEP = ${OBJS:.o=.d}
+-include ${OBJSDEP}
+
+%.o: %.c
+	${CC} -c -DUSE_TCL_STUBS -DTCL_NO_DEPRECATED ${CFLAGS} ${CPPFLAGS} ${SHLIB_CFLAGS} -MMD $< -o $@
 
 $(SHLIB_NAME): ${OBJS}
 	${SHLIB_LD} ${OBJS} -o ${SHLIB_NAME} ${TCL_STUB_LIB_SPEC} ${SHLIB_LDFLAGS} ${LIBS}
@@ -12,7 +16,7 @@ pkgIndex.tcl: $(SHLIB_NAME)
 	$(SILENT) ../pkg_mkindex.sh . || ( rm -rf $@ && exit 1 )
 
 clean::
-	rm -f ${OBJS} ${SHLIB_NAME} so_locations pkgIndex.tcl
+	rm -f ${OBJS} ${OBJSDEP} ${SHLIB_NAME} so_locations pkgIndex.tcl
 
 distclean:: clean
 

--- a/src/machista1.0/Makefile.in
+++ b/src/machista1.0/Makefile.in
@@ -33,7 +33,7 @@ else
 	@exit 1
 endif
 
-${SWIG_OBJS}:: ${SWIG_SRCS}
+${SWIG_OBJS}: ${SWIG_SRCS}
 
 ${PKG_INDEX}:: ${SWIG_SHLIB}
 	$(SILENT) ../pkg_mkindex.sh $< || ( rm -rf $@ && exit 1 )


### PR DESCRIPTION
Let's be more accurate about dependencies in our source files, which can cause problems when switching branches or when updating headers in the `vendor/` directory. Although this also does not force to re-make everything, at least it should help to catch more cases where an update of a target was necessary.