### PR TITLE
Add dependency from tclPkgConfig.c to Makefile

### DIFF
--- a/vendor/tcl8.5.19/unix/Makefile.in
+++ b/vendor/tcl8.5.19/unix/Makefile.in
@@ -1150,7 +1150,7 @@ tclPkg.o: $(GENERIC_DIR)/tclPkg.c
 # every path can be configured separately we do not remember one general
 # prefix/exec_prefix but all the different paths individually.
 
-tclPkgConfig.o: $(GENERIC_DIR)/tclPkgConfig.c
+tclPkgConfig.o: Makefile $(GENERIC_DIR)/tclPkgConfig.c
 	$(CC) -c $(CC_SWITCHES)					\
 		-DCFG_INSTALL_LIBDIR="\"$(LIB_INSTALL_DIR)\"" \
 		-DCFG_INSTALL_BINDIR="\"$(BIN_INSTALL_DIR)\"" \


### PR DESCRIPTION
tclPkgConfig.c is not recompiled if the configuration changes (e.g.: the prefix is changed), resulting in libtcl containing an incorrect configuration.