### PR TITLE
portindex: support creating PortIndex for libc++ (portindex only)

### DIFF
--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -23,7 +23,7 @@ mportinit ui_options global_options global_variations
 # Standard procedures
 proc print_usage args {
     global argv0
-    puts "Usage: $argv0 \[-dfe\] \[-o output directory\] \[-p plat_ver_arch\] \[directory\]"
+    puts "Usage: $argv0 \[-dfe\] \[-o output directory\] \[-p plat_ver_\[cxxlib_\]arch\] \[directory\]"
     puts "-d:\tOutput debugging information"
     puts "-f:\tDo a full re-index instead of updating"
     puts "-e:\tExit code indicates if ports failed to parse"
@@ -199,7 +199,26 @@ for {set i 0} {$i < $argc} {incr i} {
                 set platlist [split [lindex $argv $i] _]
                 set os_platform [lindex $platlist 0]
                 set os_major [lindex $platlist 1]
-                set os_arch [lindex $platlist 2]
+                if {[llength $platlist] > 3} {
+                    set cxx_stdlib [lindex $platlist 2]
+                    switch -- $cxx_stdlib {
+                        libcxx {
+                            set cxx_stdlib libc++
+                        }
+                        libstdcxx {
+                            set cxx_stdlib libstdc++
+                        }
+                        default {
+                            puts stderr "Unknown C++ standard library: $cxx_stdlib (use libcxx or libstdcxx)"
+                            print_usage
+                            exit 1
+                        }
+                    }
+                    lappend port_options cxx_stdlib $cxx_stdlib
+                    set os_arch [lindex $platlist 3]
+                } else {
+                    set os_arch [lindex $platlist 2]
+                }
                 if {$os_platform eq "macosx"} {
                     lappend port_options os.subplatform $os_platform os.universal_supported yes
                     set os_platform darwin

--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -214,16 +214,22 @@ for {set i 0} {$i < $argc} {incr i} {
                             exit 1
                         }
                     }
-                    lappend port_options cxx_stdlib $cxx_stdlib
                     set os_arch [lindex $platlist 3]
                 } else {
+                    if {$os_platform eq "macosx"} {
+                        if {$os_major < 13} {
+                            set cxx_stdlib libstdc++
+                        } else {
+                            set cxx_stdlib libc++
+                        }
+                    }
                     set os_arch [lindex $platlist 2]
                 }
+                lappend port_options os.platform $os_platform os.major $os_major os.arch $os_arch
                 if {$os_platform eq "macosx"} {
-                    lappend port_options os.subplatform $os_platform os.universal_supported yes
+                    lappend port_options os.subplatform $os_platform os.universal_supported yes cxx_stdlib $cxx_stdlib
                     set os_platform darwin
                 }
-                lappend port_options os.platform $os_platform os.major $os_major os.arch $os_arch
             } elseif {$arg eq "-f"} { # Completely rebuild index
                 set full_reindex 1
             } elseif {$arg eq "-e"} { # Non-zero exit code on errors


### PR DESCRIPTION
I extracted the changes to `portindex` only from #63. These changes are safe to be merged in this form and do not require additional changes to our infrastructure generating the PortIndex (in mprsyncup).

This ensures we are using the default cxx_stdlib value when generating a PortIndex for older systems.

This is meant to be merged now so it can be released with MacPorts 2.5.0. The rest of the corresponding ticket, involving coordinated changes to mprsyncup and base, can be addressed afterwards.

See: https://trac.macports.org/ticket/55471