### PR TITLE
Fix plugin install names

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -106,7 +106,7 @@ MANXML=		${MANTXT:.txt=.xml}
 MANHTML=	${MANTXT:.txt=.html} ${MANSOELIM:.soelim=.html}
 
 CONF=		archive_sites.conf macports.conf pubkeys.conf sources.conf variants.conf
-INSTALLDIR=	${DESTDIR}${prefix}
+INSTALLDIR=	${prefix}
 TOPSRCDIR=	..
 
 ifneq ($(MAKECMDGOALS),distclean)
@@ -183,16 +183,16 @@ man: ${MAN} ${MAN:%=%.gz}
 endif
 
 install: all
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}"
 	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${mpconfigdir}"
 
-	< prefix.mtree $(MTREE) -U -e -p "${INSTALLDIR}" > /dev/null
-	< base.mtree $(MTREE) -U -e -p "${INSTALLDIR}" > /dev/null
+	< prefix.mtree $(MTREE) -U -e -p "${DESTDIR}${INSTALLDIR}" > /dev/null
+	< base.mtree $(MTREE) -U -e -p "${DESTDIR}${INSTALLDIR}" > /dev/null
 ifneq (,$(findstring darwin,@build_os@))
 ifneq (8,@OS_MAJOR@)
 # Tiger's chmod doesn't accept -h
 # mtree with umask 0077 doesn't get the permissions of the symlink right
-	chmod -h 755 "${INSTALLDIR}/man"
+	chmod -h 755 "${DESTDIR}${INSTALLDIR}/man"
 endif
 endif
 
@@ -205,15 +205,15 @@ endif
 	done
 
 	# delete old uncompressed man pages if they exist
-	for m in ${MAN1}; do rm -f "${INSTALLDIR}/share/man/man1/$$m" ; done
-	for m in ${MAN5}; do rm -f "${INSTALLDIR}/share/man/man5/$$m" ; done
-	for m in ${MAN7}; do rm -f "${INSTALLDIR}/share/man/man7/$$m" ; done
+	for m in ${MAN1}; do rm -f "${DESTDIR}${INSTALLDIR}/share/man/man1/$$m" ; done
+	for m in ${MAN5}; do rm -f "${DESTDIR}${INSTALLDIR}/share/man/man5/$$m" ; done
+	for m in ${MAN7}; do rm -f "${DESTDIR}${INSTALLDIR}/share/man/man7/$$m" ; done
 
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}/share/macports/install"
-	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 644 base.mtree "${INSTALLDIR}/share/macports/install/"
-	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 644 prefix.mtree "${INSTALLDIR}/share/macports/install/"
-	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 644 macosx.mtree "${INSTALLDIR}/share/macports/install/"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}/share/macports/install"
+	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 644 base.mtree "${DESTDIR}${INSTALLDIR}/share/macports/install/"
+	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 644 prefix.mtree "${DESTDIR}${INSTALLDIR}/share/macports/install/"
+	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 644 macosx.mtree "${DESTDIR}${INSTALLDIR}/share/macports/install/"
 
 	for page in ${MAN1} ${MAN5} ${MAN7}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$${page}.gz" "${INSTALLDIR}/share/man/man$$(echo $$page | sed -e 's/.*\.//')"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$${page}.gz" "${DESTDIR}${INSTALLDIR}/share/man/man$$(echo $$page | sed -e 's/.*\.//')"; \
 	done

--- a/src/darwintracelib1.0/Makefile.in
+++ b/src/darwintracelib1.0/Makefile.in
@@ -34,7 +34,7 @@ CPPFLAGS+= -I$(srcdir)/../compat
 LIBS+= $(COMPAT_OBJS)
 
 SHLIB_NAME = darwintrace$(SHLIB_SUFFIX)
-INSTALLDIR = $(DESTDIR)$(TCL_PACKAGE_PATH)/darwintrace1.0
+INSTALLDIR = $(TCL_PACKAGE_PATH)/darwintrace1.0
 
 # Yes, we know having $ signs in identifiers is not a very good idea; in the
 # case of darwintrace we still need them, though.
@@ -70,8 +70,8 @@ distclean:: clean
 	rm -f Makefile
 
 install:: all
-	$(INSTALL) -d -o "$(DSTUSR)" -g "$(DSTGRP)" -m "$(DSTMODE)" "$(INSTALLDIR)"
-	$(INSTALL)    -o "$(DSTUSR)" -g "$(DSTGRP)" -m 444 "$(SHLIB_NAME)" "$(INSTALLDIR)"
+	$(INSTALL) -d -o "$(DSTUSR)" -g "$(DSTGRP)" -m "$(DSTMODE)" "$(DESTDIR)$(INSTALLDIR)"
+	$(INSTALL)    -o "$(DSTUSR)" -g "$(DSTGRP)" -m 444 "$(SHLIB_NAME)" "$(DESTDIR)$(INSTALLDIR)"
 
 test::
 

--- a/src/darwintracelib1.0/Makefile.in
+++ b/src/darwintracelib1.0/Makefile.in
@@ -41,6 +41,9 @@ INSTALLDIR = $(TCL_PACKAGE_PATH)/darwintrace1.0
 CFLAGS_PEDANTIC =
 CFLAGS += -fPIC $(UNIVERSAL_ARCHFLAGS)
 SHLIB_LDFLAGS += $(UNIVERSAL_ARCHFLAGS)
+ifeq ($(shell uname),Darwin)
+SHLIB_LDFLAGS += -install_name $(INSTALLDIR)/$(SHLIB_NAME)
+endif
 
 # Generate dependency information
 %.d : %.c

--- a/src/machista1.0/Makefile.in
+++ b/src/machista1.0/Makefile.in
@@ -5,7 +5,7 @@ include ../../Mk/macports.autoconf.mk
 
 OBJS= 		libmachista.o hashmap.o machista_wrap.o
 SHLIB_NAME= machista${SHLIB_SUFFIX}
-INSTALLDIR=	${DESTDIR}${TCL_PACKAGE_PATH}/machista1.0
+INSTALLDIR=	${TCL_PACKAGE_PATH}/machista1.0
 
 SWIG         = @SWIG@
 SWIG_FLAGS   = -tcl8 -pkgversion 1.0 -namespace

--- a/src/machista1.0/Makefile.in
+++ b/src/machista1.0/Makefile.in
@@ -20,6 +20,9 @@ TESTS = ./tests/libmachista-test
 include $(srcdir)/../../Mk/macports.tea.mk
 
 CFLAGS+= -fPIC
+ifeq ($(shell uname),Darwin)
+SHLIB_LDFLAGS+= -install_name ${INSTALLDIR}/${SHLIB_NAME}
+endif
 
 ${SWIG_SRCS}:: ${SWIG_IFACE}
 ifdef SWIG

--- a/src/macports1.0/Makefile.in
+++ b/src/macports1.0/Makefile.in
@@ -8,7 +8,7 @@ SRCS=		macports.tcl macports_dlist.tcl macports_util.tcl \
 OBJS=		macports.o get_systemconfiguration_proxies.o sysctl.o
 SHLIB_NAME=	MacPorts${SHLIB_SUFFIX}
 
-INSTALLDIR=	${DESTDIR}${TCL_PACKAGE_PATH}/macports1.0
+INSTALLDIR=	${TCL_PACKAGE_PATH}/macports1.0
 OLDINSTALLDIR= ${datadir}/macports/Tcl
 
 ifeq (@HAVE_FRAMEWORK_COREFOUNDATION@,yes)
@@ -32,15 +32,15 @@ install:: all
 
 	@# Remove the previously installed link if it still exists. Without this,
 	@# creating the directory will fail.
-	if test -L "${INSTALLDIR}"; then rm -rf "${INSTALLDIR}"; fi
+	if test -L "${DESTDIR}${INSTALLDIR}"; then rm -rf "${DESTDIR}${INSTALLDIR}"; fi
 
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}"
 
 	$(SILENT) set -x; for file in ${SRCS}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$$file" "${INSTALLDIR}/$$file"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$$file" "${DESTDIR}${INSTALLDIR}/$$file"; \
 	done
 
-	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${DESTDIR}${INSTALLDIR}"
 
 
 include $(srcdir)/../../Mk/macports.tea.mk

--- a/src/macports1.0/Makefile.in
+++ b/src/macports1.0/Makefile.in
@@ -19,6 +19,10 @@ endif
 
 pkgIndex.tcl: $(SRCS)
 
+ifeq ($(shell uname),Darwin)
+SHLIB_LDFLAGS+= -install_name ${INSTALLDIR}/${SHLIB_NAME}
+endif
+
 test::
 	$(TCLSH) $(srcdir)/../tests/test.tcl -nocolor
 

--- a/src/mpcommon1.0/Makefile.in
+++ b/src/mpcommon1.0/Makefile.in
@@ -5,7 +5,7 @@ include ../../Mk/macports.autoconf.mk
 
 SRCS = mpcommon.tcl signalcatch.tcl
 
-INSTALLDIR= ${DESTDIR}${TCL_PACKAGE_PATH}/mpcommon1.0
+INSTALLDIR= ${TCL_PACKAGE_PATH}/mpcommon1.0
 
 all:: pkgIndex.tcl
 
@@ -19,10 +19,10 @@ distclean:: clean
 	rm -f Makefile
 
 install:: all
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}"
 	$(SILENT) set -x; for file in ${SRCS}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${INSTALLDIR}/$$file"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${DESTDIR}${INSTALLDIR}/$$file"; \
 	done
-	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${DESTDIR}${INSTALLDIR}"
 
 test:: ;

--- a/src/package1.0/Makefile.in
+++ b/src/package1.0/Makefile.in
@@ -3,7 +3,7 @@ VPATH  = @srcdir@
 
 include ../../Mk/macports.autoconf.mk
 
-INSTALLDIR=	${DESTDIR}${TCL_PACKAGE_PATH}/package1.0
+INSTALLDIR=	${TCL_PACKAGE_PATH}/package1.0
 
 SRCS=	package.tcl portdmg.tcl portmdmg.tcl portmpkg.tcl portpkg.tcl \
 	portunarchive.tcl \
@@ -25,8 +25,8 @@ test::
 	$(TCLSH) $(srcdir)/../tests/test.tcl -nocolor
 
 install:: all
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}"
 	$(SILENT)set -x; for file in ${SRCS}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${INSTALLDIR}"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${DESTDIR}${INSTALLDIR}"; \
 	done
-	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${DESTDIR}${INSTALLDIR}"

--- a/src/pextlib1.0/Makefile.in
+++ b/src/pextlib1.0/Makefile.in
@@ -53,7 +53,7 @@ tracelib.o: ../darwintracelib1.0/sandbox_actions.h
 
 CFLAGS+= ${CURL_CFLAGS} ${MD5_CFLAGS} ${READLINE_CFLAGS}
 LIBS+= ${CURL_LIBS} ${MD5_LIBS} ${READLINE_LIBS}
-ifeq ($(shell uname), Darwin)
+ifeq ($(shell uname),Darwin)
 LIBS+= ../registry2.0/registry${SHLIB_SUFFIX}
 SHLIB_LDFLAGS+= -install_name ${TCL_PACKAGE_PATH}/pextlib1.0/${SHLIB_NAME}
 ${SHLIB_NAME}: ../registry2.0/registry${SHLIB_SUFFIX}

--- a/src/pextlib1.0/Makefile.in
+++ b/src/pextlib1.0/Makefile.in
@@ -55,7 +55,7 @@ CFLAGS+= ${CURL_CFLAGS} ${MD5_CFLAGS} ${READLINE_CFLAGS}
 LIBS+= ${CURL_LIBS} ${MD5_LIBS} ${READLINE_LIBS}
 ifeq ($(shell uname),Darwin)
 LIBS+= ../registry2.0/registry${SHLIB_SUFFIX}
-SHLIB_LDFLAGS+= -install_name ${TCL_PACKAGE_PATH}/pextlib1.0/${SHLIB_NAME}
+SHLIB_LDFLAGS+= -install_name ${INSTALLDIR}/${SHLIB_NAME}
 ${SHLIB_NAME}: ../registry2.0/registry${SHLIB_SUFFIX}
 endif
 

--- a/src/pextlib1.0/Makefile.in
+++ b/src/pextlib1.0/Makefile.in
@@ -44,7 +44,7 @@ CPPFLAGS+= -I$(srcdir)/../compat
 LIBS+= $(COMPAT_OBJS)
 
 SHLIB_NAME= Pextlib${SHLIB_SUFFIX}
-INSTALLDIR= ${DESTDIR}${TCL_PACKAGE_PATH}/pextlib1.0
+INSTALLDIR= ${TCL_PACKAGE_PATH}/pextlib1.0
 
 include $(srcdir)/../../Mk/macports.tea.mk
 

--- a/src/port/Makefile.in
+++ b/src/port/Makefile.in
@@ -3,7 +3,7 @@ VPATH  = @srcdir@
 
 include ../../Mk/macports.autoconf.mk
 
-INSTALLDIR=	${DESTDIR}${prefix}
+INSTALLDIR=	${prefix}
 TOPSRCDIR=	../..
 SCRIPTS=	portmirror portindex port
 
@@ -23,8 +23,8 @@ port: port.tcl ../../Mk/macports.autoconf.mk
 	${edit} $(srcdir)/port.tcl > $@
 
 mkdirs:
-	< ../../doc/prefix.mtree $(MTREE) -U -d -e -p ${INSTALLDIR} > /dev/null
-	< ../../doc/base.mtree $(MTREE) -U -d -e -p ${INSTALLDIR} > /dev/null
+	< ../../doc/prefix.mtree $(MTREE) -U -d -e -p "${DESTDIR}${INSTALLDIR}" > /dev/null
+	< ../../doc/base.mtree $(MTREE) -U -d -e -p "${DESTDIR}${INSTALLDIR}" > /dev/null
 
 clean:
 	rm -f ${SCRIPTS}
@@ -35,13 +35,13 @@ distclean: clean
 	rm -f Makefile
 
 install: all mkdirs
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}/bin"
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}/var/macports"
-	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 555 port portindex portmirror "${INSTALLDIR}/bin/"
-	cd "${INSTALLDIR}/bin" && $(LN_S) -f port portf
-	cd "${INSTALLDIR}/bin" && $(LN_S) -f "${TCLSH}" port-tclsh
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}/bin"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}/var/macports"
+	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 555 port portindex portmirror "${DESTDIR}${INSTALLDIR}/bin/"
+	cd "${DESTDIR}${INSTALLDIR}/bin" && $(LN_S) -f port portf
+	cd "${DESTDIR}${INSTALLDIR}/bin" && $(LN_S) -f "${TCLSH}" port-tclsh
 ifneq (,$(findstring darwin,@build_os@))
 ifneq (8,@OS_MAJOR@)
-	chmod -h 555 "${INSTALLDIR}/bin/portf" "${INSTALLDIR}/bin/port-tclsh"
+	chmod -h 555 "${DESTDIR}${INSTALLDIR}/bin/portf" "${DESTDIR}${INSTALLDIR}/bin/port-tclsh"
 endif
 endif

--- a/src/port1.0/Makefile.in
+++ b/src/port1.0/Makefile.in
@@ -3,7 +3,7 @@ VPATH  = @srcdir@
 
 include ../../Mk/macports.autoconf.mk
 
-INSTALLDIR=	${DESTDIR}${TCL_PACKAGE_PATH}/port1.0
+INSTALLDIR=	${TCL_PACKAGE_PATH}/port1.0
 
 SRCS_AUTOCONF= port_autoconf.tcl
 SRCS=	port.tcl portchecksum.tcl portconfigure.tcl portextract.tcl	    \
@@ -31,14 +31,14 @@ distclean:: clean
 	rm -f Makefile
 
 install:: all
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}"
 	$(SILENT)set -x; for file in ${SRCS}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${INSTALLDIR}"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${DESTDIR}${INSTALLDIR}"; \
 	done
 	$(SILENT)set -x; for file in ${SRCS_AUTOCONF}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$$file" "${INSTALLDIR}"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$$file" "${DESTDIR}${INSTALLDIR}"; \
 	done
-	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${DESTDIR}${INSTALLDIR}"
 
 test::
 	$(TCLSH) $(srcdir)/../tests/test.tcl -nocolor

--- a/src/registry2.0/Makefile.in
+++ b/src/registry2.0/Makefile.in
@@ -12,7 +12,7 @@ OBJS = registry.o util.o \
 	portgroup.o portgroupobj.o
 
 SHLIB_NAME= registry${SHLIB_SUFFIX}
-INSTALLDIR= ${DESTDIR}${TCL_PACKAGE_PATH}/registry2.0
+INSTALLDIR= ${TCL_PACKAGE_PATH}/registry2.0
 
 include $(srcdir)/../../Mk/macports.tea.mk
 
@@ -39,12 +39,12 @@ distclean:: clean
 	rm -f Makefile
 
 install:: all $(SHLIB_NAME)
-	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${INSTALLDIR}"
-	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "${SHLIB_NAME}" "${INSTALLDIR}"
+	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}"
+	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "${SHLIB_NAME}" "${DESTDIR}${INSTALLDIR}"
 	$(SILENT) set -x; for file in ${SRCS}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${INSTALLDIR}/$$file"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$(srcdir)/$$file" "${DESTDIR}${INSTALLDIR}/$$file"; \
 	done
 	$(SILENT) set -x; for file in ${SRCS_AUTOCONF}; do \
-		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$$file" "${INSTALLDIR}/$$file"; \
+		$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 "$$file" "${DESTDIR}${INSTALLDIR}/$$file"; \
 	done
-	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${INSTALLDIR}"
+	$(INSTALL) -o "${DSTUSR}" -g "${DSTGRP}" -m 444 pkgIndex.tcl "${DESTDIR}${INSTALLDIR}"

--- a/src/registry2.0/Makefile.in
+++ b/src/registry2.0/Makefile.in
@@ -22,7 +22,7 @@ pkgIndex.tcl: $(SRCS) $(SRCS_AUTOCONF)
 
 CFLAGS+=	${SQLITE3_CFLAGS}
 LIBS+=	${SQLITE3_LIBS} ../cregistry/cregistry.a
-ifeq ($(shell uname), Darwin)
+ifeq ($(shell uname),Darwin)
 SHLIB_LDFLAGS+= -install_name @loader_path/../registry2.0/${SHLIB_NAME}
 endif
 


### PR DESCRIPTION
This fixes the `install_name` of the darwintrace1.0, machista1.0 and macports1.0 plugins. There was already code in the pextlib1.0 Makefile to set the `install_name` which I copied to the other Makefiles.

The registry2.0 plugin uses an `install_name` containing `@loader_path` and this PR doesn't change that. This is needed to prevent a build failure when MacPorts is not already installed, because the pextlib1.0 plugin links with the registry2.0 plugin as a library. See 5f7e3d27bcd8643c820cacd9c6883980ff2298eb.

The `install_name` of the other plugins doesn't technically matter, but it is tidier to set it correctly, especially on Tiger where otherwise a randomly-generated temporary filename is used as the `install_name` (see https://trac.macports.org/ticket/37867).

I removed the space after the comma in the `ifeq` for consistency with our other `ifeq`s.

There was already a variable `INSTALLDIR` in each Makefile containing the path where the library will be installed, except that it was preceded by `DESTDIR` which we don't want in the `install_name`. I added a new variable `INSTALLDIR_WITHOUT_DESTDIR` which is now used to set the `install_name` and to construct `INSTALLDIR`. I'm open to suggestions for a shorter name for the `INSTALLDIR_WITHOUT_DESTDIR` variable.

It looks like all `INSTALLDIR` variables, in all Makefiles, begin with `DESTDIR`. So maybe an even better idea is to factor that out of the variable's definition, and just write `${DESTDIR}${INSTALLDIR}` everywhere that we currently write `${INSTALLDIR}`. That's what we recommend to other projects, so why don't we do it in our own code?