### PR TITLE
configure: Pass the selected $CC to vendor sources

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -270,6 +270,9 @@ AC_DEFUN([MP_CONFIG_SUBDIR], [
 			mp_arg="--srcdir=$ac_srcdir"
 			_MP_LIST_APPEND_QUOTED([mp_sub_configure_args], [mp_arg])
 
+			mp_arg="CC=$CC"
+			_MP_LIST_APPEND_QUOTED([mp_sub_configure_args], [mp_arg])
+
 			AC_MSG_NOTICE([running $SHELL $ac_srcdir/configure $mp_sub_configure_args in $ac_dir])
 			eval "\$SHELL \$ac_srcdir/configure $mp_sub_configure_args" || AC_MSG_ERROR([configure failed for $ac_dir])
 		else

--- a/configure
+++ b/configure
@@ -7936,6 +7936,16 @@ $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 	as_fn_append mp_sub_configure_args " $mp_arg"
 
 
+			mp_arg="CC=$CC"
+					case $mp_arg in
+		*\'*)
+			mp_arg=$($as_echo "$mp_arg" | sed "s/'/'\\\\\\\\''/g")
+		;;
+	esac
+	mp_arg="'$mp_arg'"
+	as_fn_append mp_sub_configure_args " $mp_arg"
+
+
 			{ $as_echo "$as_me:${as_lineno-$LINENO}: running $SHELL $ac_srcdir/configure $mp_sub_configure_args in $ac_dir" >&5
 $as_echo "$as_me: running $SHELL $ac_srcdir/configure $mp_sub_configure_args in $ac_dir" >&6;}
 			eval "\$SHELL \$ac_srcdir/configure $mp_sub_configure_args" || as_fn_error $? "configure failed for $ac_dir" "$LINENO" 5
@@ -8235,6 +8245,16 @@ $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 
 
 			mp_arg="--srcdir=$ac_srcdir"
+					case $mp_arg in
+		*\'*)
+			mp_arg=$($as_echo "$mp_arg" | sed "s/'/'\\\\\\\\''/g")
+		;;
+	esac
+	mp_arg="'$mp_arg'"
+	as_fn_append mp_sub_configure_args " $mp_arg"
+
+
+			mp_arg="CC=$CC"
 					case $mp_arg in
 		*\'*)
 			mp_arg=$($as_echo "$mp_arg" | sed "s/'/'\\\\\\\\''/g")
@@ -8547,6 +8567,16 @@ $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 	as_fn_append mp_sub_configure_args " $mp_arg"
 
 
+			mp_arg="CC=$CC"
+					case $mp_arg in
+		*\'*)
+			mp_arg=$($as_echo "$mp_arg" | sed "s/'/'\\\\\\\\''/g")
+		;;
+	esac
+	mp_arg="'$mp_arg'"
+	as_fn_append mp_sub_configure_args " $mp_arg"
+
+
 			{ $as_echo "$as_me:${as_lineno-$LINENO}: running $SHELL $ac_srcdir/configure $mp_sub_configure_args in $ac_dir" >&5
 $as_echo "$as_me: running $SHELL $ac_srcdir/configure $mp_sub_configure_args in $ac_dir" >&6;}
 			eval "\$SHELL \$ac_srcdir/configure $mp_sub_configure_args" || as_fn_error $? "configure failed for $ac_dir" "$LINENO" 5
@@ -8843,6 +8873,16 @@ $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 
 
 			mp_arg="--srcdir=$ac_srcdir"
+					case $mp_arg in
+		*\'*)
+			mp_arg=$($as_echo "$mp_arg" | sed "s/'/'\\\\\\\\''/g")
+		;;
+	esac
+	mp_arg="'$mp_arg'"
+	as_fn_append mp_sub_configure_args " $mp_arg"
+
+
+			mp_arg="CC=$CC"
 					case $mp_arg in
 		*\'*)
 			mp_arg=$($as_echo "$mp_arg" | sed "s/'/'\\\\\\\\''/g")


### PR DESCRIPTION
This came up in discussion on [pull request #86](https://github.com/macports/macports-base/pull/86#discussion_r186274970).

Should we also do the same for the other variables listed in `./configure --help`?

```
Some influential environment variables:
  CC          C compiler command
  CFLAGS      C compiler flags
  LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
              nonstandard directory <lib dir>
  LIBS        libraries to pass to the linker, e.g. -l<library>
  CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
              you have headers in a nonstandard directory <include dir>
  CPP         C preprocessor
```