### PR TITLE
Make port-tclsh a relative symlink, not absolute

### DIFF
--- a/src/port/Makefile.in
+++ b/src/port/Makefile.in
@@ -39,7 +39,7 @@ install: all mkdirs
 	$(INSTALL) -d -o "${DSTUSR}" -g "${DSTGRP}" -m "${DSTMODE}" "${DESTDIR}${INSTALLDIR}/var/macports"
 	$(INSTALL)    -o "${DSTUSR}" -g "${DSTGRP}" -m 555 port portindex portmirror "${DESTDIR}${INSTALLDIR}/bin/"
 	$(LN_S) -f port "${DESTDIR}${INSTALLDIR}/bin/portf"
-	$(LN_S) -f "${TCLSH}" "${DESTDIR}${INSTALLDIR}/bin/port-tclsh"
+	$(LN_S) -f $(shell perl -MFile::Spec -e 'print File::Spec->abs2rel(@ARGV)' "${TCLSH}" "${INSTALLDIR}/bin") "${DESTDIR}${INSTALLDIR}/bin/port-tclsh"
 ifneq (,$(findstring darwin,@build_os@))
 ifneq (8,@OS_MAJOR@)
 	chmod -h 555 "${DESTDIR}${INSTALLDIR}/bin/portf" "${DESTDIR}${INSTALLDIR}/bin/port-tclsh"


### PR DESCRIPTION
This is a step toward allowing the MacPorts installer package to install to any prefix.

Using Perl is the most straightforward and most compatible way I found to compute a relative path from two absolute paths.

I wrote the Perl command inline because this is the only place where it's needed right now. But it could be broken out into a custom Makefile function to make it reusable.

Is it ok to just use `perl`, since it is so widely available, or do we need to do autoconf stuff to find it and set a variable with its path? We already use `sed` in the same Makefile without checking for it.