### PR TITLE
Extend argument --no-mirrors to port distfiles

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -4416,6 +4416,7 @@ array set cmd_opts_array {
     diagnose    {quiet}
     reclaim     {enable-reminders disable-reminders}
     fetch       {no-mirrors}
+    distfiles   {no-mirrors}
 }
 
 ##

--- a/src/port1.0/portdistfiles.tcl
+++ b/src/port1.0/portdistfiles.tcl
@@ -61,6 +61,8 @@ proc portdistfiles::distfiles_main {args} {
         return 0
     }
 
+    uplevel #0 upvar #0 ports_distfiles_no-mirrors ports_fetch_no-mirrors
+
     # from portfetch... process the sites, files and patches
     set fetch_urls {}
     portfetch::checkfiles fetch_urls


### PR DESCRIPTION
Extend 0cf1faf216c59419fb22edcd304ce02571d10504 to port-distfiles(1).

Maybe not the best way, but it works.