### PR TITLE
macOS name cleanup

### DIFF
--- a/configure
+++ b/configure
@@ -2758,11 +2758,23 @@ case "$MACOSX_VERSION" in
     as_fn_error $? "This version of Mac OS X is not supported
                   Please upgrade at http://store.apple.com/" "$LINENO" 5
     ;;
-  10.4.[0-9]|10.4.10|10.5.[0-7]|10.6.[0-7]|10.7.[0-4]|10.8.[0-4]|10.9.[0-4]|10.10.[0-4]|10.11.[0-5]|10.12.[0-5])
+  10.4.[0-9]|10.4.10|10.5.[0-7]|10.6.[0-7]|10.7.[0-4])
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of Mac OS X is out of date" >&5
 $as_echo "$as_me: WARNING: This version of Mac OS X is out of date" >&2;}
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please run Software Update to update it" >&5
 $as_echo "$as_me: WARNING: Please run Software Update to update it" >&2;}
+    ;;
+  10.8.[0-4]|10.9.[0-4]|10.10.[0-4]|10.11.[0-5])
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of OS X is out of date" >&5
+$as_echo "$as_me: WARNING: This version of OS X is out of date" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please use the Mac App Store to update it" >&5
+$as_echo "$as_me: WARNING: Please use the Mac App Store to update it" >&2;}
+    ;;
+  10.12.[0-5])
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of macOS is out of date" >&5
+$as_echo "$as_me: WARNING: This version of macOS is out of date" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please use the Mac App Store to update it" >&5
+$as_echo "$as_me: WARNING: Please use the Mac App Store to update it" >&2;}
     ;;
   10.4*|10.5*|10.6*|10.7*|10.8*|10.9*|10.10*|10.11*|10.12*|10.13*)
         ;;

--- a/configure
+++ b/configure
@@ -2746,8 +2746,8 @@ fi
 
 
 if test "x$SW_VERS" != "x"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking Mac OS X version" >&5
-$as_echo_n "checking Mac OS X version... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking macOS version" >&5
+$as_echo_n "checking macOS version... " >&6; }
   MACOSX_VERSION=`$SW_VERS -productVersion`
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MACOSX_VERSION" >&5
 $as_echo "$MACOSX_VERSION" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_PATH_PROG(DEFAULTS, defaults)
 AC_PATH_PROG(XCODE_SELECT, xcode-select)
 
 if test "x$SW_VERS" != "x"; then
-  AC_MSG_CHECKING(Mac OS X version)
+  AC_MSG_CHECKING(macOS version)
   MACOSX_VERSION=`$SW_VERS -productVersion`
   AC_MSG_RESULT([$MACOSX_VERSION])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -32,9 +32,17 @@ case "$MACOSX_VERSION" in
     AC_MSG_ERROR([This version of Mac OS X is not supported
                   Please upgrade at http://store.apple.com/])
     ;;
-  10.4.[[0-9]]|10.4.10|10.5.[[0-7]]|10.6.[[0-7]]|10.7.[[0-4]]|10.8.[[0-4]]|10.9.[[0-4]]|10.10.[[0-4]]|10.11.[[0-5]]|10.12.[[0-5]])
+  10.4.[[0-9]]|10.4.10|10.5.[[0-7]]|10.6.[[0-7]]|10.7.[[0-4]])
     AC_MSG_WARN([This version of Mac OS X is out of date])
     AC_MSG_WARN([Please run Software Update to update it])
+    ;;
+  10.8.[[0-4]]|10.9.[[0-4]]|10.10.[[0-4]]|10.11.[[0-5]])
+    AC_MSG_WARN([This version of OS X is out of date])
+    AC_MSG_WARN([Please use the Mac App Store to update it])
+    ;;
+  10.12.[[0-5]])
+    AC_MSG_WARN([This version of macOS is out of date])
+    AC_MSG_WARN([Please use the Mac App Store to update it])
     ;;
   10.4*|10.5*|10.6*|10.7*|10.8*|10.9*|10.10*|10.11*|10.12*|10.13*)
     dnl Supported version

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -127,7 +127,7 @@ universal_archs     	@UNIVERSAL_ARCHS@
 
 # Type of generated StartupItems.
 # - launchd: Create StartupItems for use with launchd.
-# - default: Create StartupItems for launchd on OS X and none on
+# - default: Create StartupItems for launchd on macOS and none on
 #   other platforms.
 # - none: Disable creation of StartupItems.
 # This setting only applies when building ports from source.

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -58,13 +58,13 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 
 # CPU architecture to target. Supported values are "ppc", "ppc64",
 # "i386", and "x86_64". Defaults to:
-# - OS X 10.5 and earlier: "ppc" on PowerPC, otherwise "i386".
-# - OS X 10.6 and later: "x86_64" on Intel 64, otherwise "i386".
+# - Mac OS X 10.5 and earlier: "ppc" on PowerPC, otherwise "i386".
+# - Mac OS X 10.6 and later: "x86_64" on 64-bit Intel, otherwise "i386".
 #build_arch          	i386
 
 # Space-delimited list of CPU architectures to target when building
-# universal. Defaults to "i386 ppc" on OS X 10.5 and earlier and
-# "x86_64 i386" on OS X 10.6 and later.
+# universal. Defaults to "i386 ppc" on Mac OS X 10.5 and earlier and
+# "x86_64 i386" on Mac OS X 10.6 and later.
 universal_archs     	@UNIVERSAL_ARCHS@
 
 # Use ccache, a compiler cache for C, C++, Objective-C, and
@@ -158,7 +158,7 @@ universal_archs     	@UNIVERSAL_ARCHS@
 # - COLUMNS, LINES
 # Variables listed in extra_env are added to this list. This has no
 # default value; setting it is intended for advanced users and is
-# unsupported. (Note that sudo(8) sanitizes its environment on OS X 10.5
+# unsupported. (Note that sudo(8) sanitizes its environment on Mac OS X 10.5
 # and later, so it may have to be configured to pass the desired
 # variables to MacPorts.)
 #extra_env           	KEEP_THIS THIS_TOO
@@ -169,7 +169,7 @@ universal_archs     	@UNIVERSAL_ARCHS@
 # "yes", MacPorts uses proxy_*, then Network Preferences, then the
 # environment. (Note that Network Preferences does not have a setting
 # for rsync proxies. Also note that sudo(8) sanitizes its environment on
-# OS X 10.5 and later, so it may have to be configured to pass desired
+# Mac OS X 10.5 and later, so it may have to be configured to pass desired
 # variables to MacPorts.)
 #proxy_override_env  	no
 

--- a/doc/port-dmg.1
+++ b/doc/port-dmg.1
@@ -48,7 +48,7 @@ These commands create OS X\-native binary archives of a given port\&. Depending 
 .sp
 \fBport pkg\fR creates an OS X installer package that installs all files that belong to a given port\&. \fBport dmg\fR wraps this installer package in a disk image\&. In most cases you probably want to package a port and all its library and runtime dependencies in a single package suitable for binary distribution\&. \fBport pkg\fR and \fBport dmg\fR don\(cqt do that, so those are only useful if you are going to take care of the dependencies separately\&. \fBport mpkg\fR creates an \&.mpkg installer image that contains installer packages for each of the dependencies and is suitable for standalone redistribution\&. \fBport mdmg\fR wraps this \&.mpkg package in a disk image\&.
 .sp
-On OS X 10\&.6 and later, the generated installer packages are in \(lqflat\(rq format, such that wrapping them in a disk image is no longer necessary for online redistribution\&. Prior to OS X 10\&.6, generated installer packages could not be used for online distribution without a wrapping disk image\&.
+On Mac OS X 10\&.6 and later, the generated installer packages are in \(lqflat\(rq format, such that wrapping them in a disk image is no longer necessary for online redistribution\&. Prior to Mac OS X 10\&.6, generated installer packages could not be used for online distribution without a wrapping disk image\&.
 .sp
 All packages are placed in a port\(cqs work directory, which can be located using \fBport-work\fR(1)\&.
 .if n \{\

--- a/doc/port-dmg.1
+++ b/doc/port-dmg.1
@@ -44,9 +44,9 @@ port-dmg, port-mdmg, port-pkg, port-mpkg \- Create binary archives of a port, an
 .fi
 .SH "DESCRIPTION"
 .sp
-These commands create OS X\-native binary archives of a given port\&. Depending on the command, one of a \&.dmg disk image file, a \&.pkg, or \&.mpkg installer package is created\&.
+These commands create macOS\-native binary archives of a given port\&. Depending on the command, one of a \&.dmg disk image file, a \&.pkg, or \&.mpkg installer package is created\&.
 .sp
-\fBport pkg\fR creates an OS X installer package that installs all files that belong to a given port\&. \fBport dmg\fR wraps this installer package in a disk image\&. In most cases you probably want to package a port and all its library and runtime dependencies in a single package suitable for binary distribution\&. \fBport pkg\fR and \fBport dmg\fR don\(cqt do that, so those are only useful if you are going to take care of the dependencies separately\&. \fBport mpkg\fR creates an \&.mpkg installer image that contains installer packages for each of the dependencies and is suitable for standalone redistribution\&. \fBport mdmg\fR wraps this \&.mpkg package in a disk image\&.
+\fBport pkg\fR creates a macOS installer package that installs all files that belong to a given port\&. \fBport dmg\fR wraps this installer package in a disk image\&. In most cases you probably want to package a port and all its library and runtime dependencies in a single package suitable for binary distribution\&. \fBport pkg\fR and \fBport dmg\fR don\(cqt do that, so those are only useful if you are going to take care of the dependencies separately\&. \fBport mpkg\fR creates an \&.mpkg installer image that contains installer packages for each of the dependencies and is suitable for standalone redistribution\&. \fBport mdmg\fR wraps this \&.mpkg package in a disk image\&.
 .sp
 On Mac OS X 10\&.6 and later, the generated installer packages are in \(lqflat\(rq format, such that wrapping them in a disk image is no longer necessary for online redistribution\&. Prior to Mac OS X 10\&.6, generated installer packages could not be used for online distribution without a wrapping disk image\&.
 .sp

--- a/doc/port-dmg.1.txt
+++ b/doc/port-dmg.1.txt
@@ -41,10 +41,10 @@ image that contains installer packages for each of the dependencies and is
 suitable for standalone redistribution. *port mdmg* wraps this .mpkg package in
 a disk image.
 
-On OS X 10.6 and later, the generated installer packages are in ``flat'' format,
-such that wrapping them in a disk image is no longer necessary for online
-redistribution. Prior to OS X 10.6, generated installer packages could not be
-used for online distribution without a wrapping disk image.
+On Mac OS X 10.6 and later, the generated installer packages are in ``flat''
+format, such that wrapping them in a disk image is no longer necessary for
+online redistribution. Prior to Mac OS X 10.6, generated installer packages
+could not be used for online distribution without a wrapping disk image.
 
 All packages are placed in a port's work directory, which can be located using
 man:port-work[1].

--- a/doc/port-dmg.1.txt
+++ b/doc/port-dmg.1.txt
@@ -27,11 +27,11 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-These commands create OS X-native binary archives of a given port. Depending on
+These commands create macOS-native binary archives of a given port. Depending on
 the command, one of a .dmg disk image file, a .pkg, or .mpkg installer package
 is created.
 
-*port pkg* creates an OS X installer package that installs all files that belong
+*port pkg* creates a macOS installer package that installs all files that belong
 to a given port. *port dmg* wraps this installer package in a disk image. In
 most cases you probably want to package a port and all its library and runtime
 dependencies in a single package suitable for binary distribution. *port pkg*

--- a/doc/port-info.1
+++ b/doc/port-info.1
@@ -129,7 +129,7 @@ is specified\&.
 \fB\-\-platform\fR, \fB\-\-platforms\fR
 .RS 4
 List the platforms supported by a port\&. This field exists for historical reasons only\&. In modern MacPorts, this is always
-\fIdarwin\fR, i\&.e\&., OS X\&.
+\fIdarwin\fR, i\&.e\&., macOS\&.
 .RE
 .PP
 \fB\-\-portdir\fR

--- a/doc/port-info.1.txt
+++ b/doc/port-info.1.txt
@@ -88,7 +88,7 @@ The rest of the options affect which fields will be given in the output:
 
 *--platform*, *--platforms*::
     List the platforms supported by a port. This field exists for historical
-    reasons only. In modern MacPorts, this is always 'darwin', i.e., OS X.
+    reasons only. In modern MacPorts, this is always 'darwin', i.e., macOS.
 
 *--portdir*::
     Print the path to a port's directory relative to the port tree root.

--- a/doc/port-installed.1
+++ b/doc/port-installed.1
@@ -38,7 +38,7 @@ Please see the section \fBGLOBAL OPTIONS\fR in the \fBport\fR(1) man page for a 
 .PP
 \fB\-v\fR
 .RS 4
-Print the platform at install time (i\&.e\&., your OS X version) and the architecture(s) of the installed port\&.
+Print the platform at install time (i\&.e\&., your macOS version) and the architecture(s) of the installed port\&.
 .RE
 .PP
 \fB\-q\fR

--- a/doc/port-installed.1.txt
+++ b/doc/port-installed.1.txt
@@ -26,7 +26,7 @@ section for an explanation of the active/inactive state.
 include::global-flags.txt[]
 
 *-v*::
-    Print the platform at install time (i.e., your OS X version) and the
+    Print the platform at install time (i.e., your macOS version) and the
     architecture(s) of the installed port.
 
 *-q*::

--- a/doc/port-outdated.1
+++ b/doc/port-outdated.1
@@ -71,7 +71,7 @@ due to an epoch increase (used in situations where the version number decreased,
 .sp -1
 .IP \(bu 2.3
 .\}
-due to an OS upgrade\&. MacPorts will consider ports built on a previous version of OS X outdated\&.
+due to an OS upgrade\&. MacPorts will consider ports built on a previous version of macOS outdated\&.
 .RE
 .sp
 The ports listed in \fBport outdated\fR are the ports that will be upgraded when you run

--- a/doc/port-outdated.1.txt
+++ b/doc/port-outdated.1.txt
@@ -23,7 +23,7 @@ could be
  - due to an epoch increase (used in situations where the version number
    decreased, but the port still is newer than the previous one), or
  - due to an OS upgrade. MacPorts will consider ports built on a previous
-   version of OS X outdated.
+   version of macOS outdated.
     
 The ports listed in *port outdated* are the ports that will be upgraded when you
 run

--- a/doc/port-platform.1
+++ b/doc/port-platform.1
@@ -30,7 +30,7 @@ port-platform \- Print the OS version for which MacPorts was built
 .sp
 This command prints the version of your operating system used to configure and build MacPorts\&. This value is used to detect OS updates and refer users to the \m[blue]\fBMigration\fR\m[]\&\s-2\u[1]\d\s+2 instructions\&.
 .sp
-Since MacPorts picks up a number of paths at configure\-time and uses them later on, changes in the operating system can break a MacPorts installation\&. For example, this happened when Apple removed \(lq/usr/bin/gnutar\(rq from OS X with the release of Mavericks\&. Since MacPorts keeps the path to its tar command in a file, this change required rebuilding MacPorts\&.
+Since MacPorts picks up a number of paths at configure\-time and uses them later on, changes in the operating system can break a MacPorts installation\&. For example, this happened when Apple removed \(lq/usr/bin/gnutar\(rq with the release of OS X Mavericks\&. Since MacPorts keeps the path to its tar command in a file, this change required rebuilding MacPorts\&.
 .SH "GLOBAL OPTIONS"
 .sp
 Please see the section \fBGLOBAL OPTIONS\fR in the \fBport\fR(1) man page for a description of global port options\&.

--- a/doc/port-platform.1.txt
+++ b/doc/port-platform.1.txt
@@ -19,9 +19,9 @@ wiki:Migration[] instructions.
 
 Since MacPorts picks up a number of paths at configure-time and uses them later
 on, changes in the operating system can break a MacPorts installation. For
-example, this happened when Apple removed ``/usr/bin/gnutar'' from OS X with the
-release of Mavericks. Since MacPorts keeps the path to its tar command in
-a file, this change required rebuilding MacPorts.
+example, this happened when Apple removed ``/usr/bin/gnutar'' with the release
+of OS X Mavericks. Since MacPorts keeps the path to its tar command in a file,
+this change required rebuilding MacPorts.
 
 
 include::global-flags.txt[]

--- a/doc/port-variants.1
+++ b/doc/port-variants.1
@@ -30,7 +30,7 @@ port-variants \- Print a list of variants with descriptions provided by a port
 .fi
 .SH "DESCRIPTION"
 .sp
-\fBport variants\fR prints a list of variants provided by the port(s) given on the command line\&. Variants allow users to select certain features when installing a certain port\&. For example, the gtk3 port provides two conflicting variants \fI+quartz\fR and \fI+x11\fR that select whether Gtk uses the X11 backend (which requires an X server) or the OS X\-native Quartz backend (which attempts to provide a more native OS X look and feel)\&. In addition, many ports feature an \fI+universal\fR variant that enables building of universal (i\&.e\&. multi\-arch) binaries\&.
+\fBport variants\fR prints a list of variants provided by the port(s) given on the command line\&. Variants allow users to select certain features when installing a certain port\&. For example, the gtk3 port provides two conflicting variants \fI+quartz\fR and \fI+x11\fR that select whether Gtk uses the X11 backend (which requires an X server) or the macOS\-native Quartz backend (which attempts to provide a more native macOS look and feel)\&. In addition, many ports feature an \fI+universal\fR variant that enables building of universal (i\&.e\&. multi\-arch) binaries\&.
 .sp
 \fBport variants\fR lists all variants by name and (if available) description\&. If variants depend on or conflict with other variants, this information is printed as a bulleted list for each variant\&.
 .sp
@@ -60,7 +60,7 @@ The output of \fBport variants\fR provides all available information on a port\(
 .nf
 $> port variants gtk3 \-universal
 gtk3 has the variants:
-(+)quartz: Support for native Mac OS X graphics
+(+)quartz: Enable native macOS graphics support
      * conflicts with x11
   \-universal: Build for multiple architectures
 [+]x11: Enable X11 support

--- a/doc/port-variants.1.txt
+++ b/doc/port-variants.1.txt
@@ -19,8 +19,8 @@ DESCRIPTION
 command line. Variants allow users to select certain features when installing
 a certain port. For example, the +gtk3+ port provides two conflicting variants
 '+quartz' and '+x11' that select whether Gtk uses the X11 backend (which
-requires an X server) or the OS X-native Quartz backend (which attempts to
-provide a more native OS X look and feel). In addition, many ports feature an
+requires an X server) or the macOS-native Quartz backend (which attempts to
+provide a more native macOS look and feel). In addition, many ports feature an
 '+universal' variant that enables building of universal (i.e. multi-arch)
 binaries.
 
@@ -53,7 +53,7 @@ variants. The +gtk3+ port can serve as a good example:
 ----
 $> port variants gtk3 -universal
 gtk3 has the variants:
-(+)quartz: Support for native Mac OS X graphics
+(+)quartz: Enable native macOS graphics support
      * conflicts with x11
   -universal: Build for multiple architectures
 [+]x11: Enable X11 support

--- a/doc/port.1
+++ b/doc/port.1
@@ -526,7 +526,7 @@ Honor state files even if the Portfile was modified\&. This flag is called \-o b
 .PP
 \-t
 .RS 4
-Enable trace mode debug facilities on platforms that support it, currently only Mac OS X\&.
+Enable trace mode debug facilities on platforms that support it, currently only macOS\&.
 
 This feature is two\-folded\&. It consists in automatically detecting and reporting undeclared dependencies based on what files the port reads or what programs the port executes\&. In verbose mode, it will also report unused dependencies for each stage of the port installation\&. It also consists in forbidding and reporting file creation and file writes outside allowed directories (temporary directories and ${workpath})\&.
 .RE
@@ -1258,26 +1258,26 @@ There are also actions for producing installable packages of ports:
 .PP
 pkg
 .RS 4
-Creates an OS X installer package of
+Creates a macOS installer package of
 \fIportname\fR\&.
 .RE
 .PP
 mpkg
 .RS 4
-Creates an OS X installer metapackage of
+Creates a macOS installer metapackage of
 \fIportname\fR
 and its dependencies\&.
 .RE
 .PP
 dmg
 .RS 4
-Creates an internet\-enabled disk image containing an OS X package of
+Creates an Internet\-enabled disk image containing a macOS package of
 \fIportname\fR\&.
 .RE
 .PP
 mdmg
 .RS 4
-Creates an internet\-enabled disk image containing an OS X metapackage of
+Creates an Internet\-enabled disk image containing a macOS metapackage of
 \fIportname\fR
 and its dependencies\&.
 .RE

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -178,7 +178,7 @@ The port command recognizes several global flags and options.
 
 -t::
     Enable trace mode debug facilities on platforms that support it, currently
-    only Mac OS X.
+    only macOS.
     +
     This feature is two-folded. It consists in automatically detecting and
     reporting undeclared dependencies based on what files the port reads or what
@@ -650,17 +650,17 @@ PACKAGING ACTIONS
 There are also actions for producing installable packages of ports:
 
 pkg::
-    Creates an OS X installer package of 'portname'.
+    Creates a macOS installer package of 'portname'.
 
 mpkg::
-    Creates an OS X installer metapackage of 'portname' and its dependencies.
+    Creates a macOS installer metapackage of 'portname' and its dependencies.
 
 dmg::
-    Creates an internet-enabled disk image containing an OS X package of
+    Creates an Internet-enabled disk image containing a macOS package of
     'portname'.
 
 mdmg::
-    Creates an internet-enabled disk image containing an OS X metapackage of
+    Creates an Internet-enabled disk image containing a macOS metapackage of
     'portname' and its dependencies.
 
 

--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -208,7 +208,7 @@ Declares which platforms are supported by the port.
 .Dl platforms darwin
 .It Ic supported_archs
 The CPU architectures for which this port can be built. Archs currently
-supported by Mac OS X are: i386, ppc, ppc64, x86_64. If this option is not set,
+supported by macOS are: i386, ppc, ppc64, x86_64. If this option is not set,
 it is assumed that the port can build for all archs. If a port does not install
 any architecture-specific files, use the special value noarch.
 .br
@@ -632,7 +632,7 @@ Group for MacPorts installation (e.g.
 .Sy Type:
 .Em read-only
 .It Ic applications_dir
-Absolute path to the final location to install Mac OS X application
+Absolute path to the final location to install macOS application
 bundles (.app directories).
 .br
 .Sy Type:
@@ -641,7 +641,7 @@ bundles (.app directories).
 .Sy Default:
 .Em /Applications/MacPorts
 .It Ic frameworks_dir
-Absolute path to the final location to install Mac OS X framework
+Absolute path to the final location to install macOS framework
 bundles (.framework directories).
 .br
 .Sy Type:
@@ -1276,7 +1276,7 @@ use the vanilla compiler suites installed via MacPorts.
 .Sy Example:
 .Dl configure.compiler llvm-gcc-4.2
 .It Ic configure.sdk_version
-Mac OS X SDK version to build against.
+macOS SDK version to build against.
 .br 
 .Sy Type:
 .Em optional
@@ -1492,7 +1492,7 @@ Test target to pass to
 .El
 .Sh STARTUPITEM OPTIONS
 If a port needs to run on system startup, it can use MacPorts
-startupitem keywords to install native OS X startup scripts.
+startupitem keywords to install native macOS startup scripts.
 Startup scripts require user interaction after port installation
 to activate them and instructions are given during port installs.
 .Bl -tag -width lc
@@ -1827,7 +1827,7 @@ value lists which variants are enabled by default.
 .Sy Example:
 .Dl default_variants +ssl +tcpd
 .It Ic universal_variant
-When using MacPorts on Mac OS X, a universal variant is defined and
+When using MacPorts on macOS, a universal variant is defined and
 the default behavior is to configure ports with universal flags
 (see the
 .Ic UNIVERSAL TARGET HOOKS

--- a/doc/portgroup.7
+++ b/doc/portgroup.7
@@ -39,7 +39,7 @@ MacPorts defines the notion of PortGroup classes with the PortGroup command\&. T
 .sp
 \fBPortGroup xcode\fR is here to easily port Xcode\-based opensource software\&. It handles configuration, build and destroot phases\&. It also defines some values for Xcode\-based software\&. A minimum Portfile using the \fBxcode PortGroup\fR class only defines the fetch and the checksum phases\&.
 .sp
-Using \fBPortGroup xcode\fR is a way to make your port more robust to Xcode version updates as the PortGroup is tested against all supported Mac OS X and Xcode versions\&.
+Using \fBPortGroup xcode\fR is a way to make your port more robust to Xcode version updates as the PortGroup is tested against all supported macOS and Xcode versions\&.
 .SS "XCODE PORTGROUP SUGAR"
 .sp
 Portfiles using \fBxcode PortGroup\fR do not need to define the following variables:

--- a/doc/portgroup.7.txt
+++ b/doc/portgroup.7.txt
@@ -33,7 +33,7 @@ for Xcode-based software. A minimum Portfile using the *xcode PortGroup* class
 only defines the fetch and the checksum phases.
 
 Using *PortGroup xcode* is a way to make your port more robust to Xcode version
-updates as the PortGroup is tested against all supported Mac OS X and Xcode
+updates as the PortGroup is tested against all supported macOS and Xcode
 versions.
 
 XCODE PORTGROUP SUGAR

--- a/doc/porthier.7
+++ b/doc/porthier.7
@@ -53,7 +53,7 @@ archive libraries
 .It Pa libexec/
 system daemons & system utilities (executed by other programs)
 .It Pa Library/Frameworks/
-Native Mac OS X Library Frameworks
+Native macOS Library Frameworks
 .It Pa sbin/
 system programs and administration utilities
 .It Pa share/
@@ -126,7 +126,7 @@ directory for cgi executables
 .El
 .El
 .It Pa /Applications/MacPorts/
-Native Mac OS X applications
+Native macOS applications
 .Pp
 .El
 .El

--- a/m4/tcl.m4
+++ b/m4/tcl.m4
@@ -733,7 +733,7 @@ AC_DEFUN(SC_CONFIG_MANPAGES, [
 #  TK_SHLIB_LD_EXTRAS   for the build of Tcl and Tk, but not recorded in the
 #                       tclConfig.sh, since they are only used for the build
 #                       of Tcl and Tk. 
-#                       Examples: MacOS X records the library version and
+#                       Examples: macOS records the library version and
 #                       compatibility version in the shared library.  But
 #                       of course the Tcl version of this is only used for Tcl.
 #       LIB_SUFFIX -    Specifies everything that comes after the "libfoo"

--- a/portmgr/ReleaseProcess.md
+++ b/portmgr/ReleaseProcess.md
@@ -154,7 +154,7 @@ done with the help of the infrastructure team.
 
 ### Create Release Packages and Disk Image(s) ###
 
-The dmg is a Mac OS X disk image that contains a standalone installer,
+The dmg is a macOS disk image that contains a standalone installer,
 configured in the usual way, named in a consistent fashion and incorporating
 the OS version for which it was built.
 
@@ -197,7 +197,7 @@ automated through a Makefile target or similar. A good way of validating the
 installer is to first create the destroot of the port and examine it for:
 
 *   Linking: libraries and binaries should not be linked against anything
-    that's not present by default on a vanilla Mac OS X installation +
+    that's not present by default on a vanilla macOS installation +
     developer tools, excluding even the MacPorts installation prefix; this can
     be accomplished through the use of `otool -L`. Currently the libraries and
     binaries in need of linking validation are:

--- a/portmgr/dmg/Distribution
+++ b/portmgr/dmg/Distribution
@@ -8,7 +8,7 @@
 function InstallationCheck () {
     if (system.compareVersions(system.version.ProductVersion, "__XVERS__") < 0
         || system.compareVersions(system.version.ProductVersion, "__NEXT_XVERS__") >= 0) {
-        my.result.message = "This package is meant to be installed on Mac OS X __XVERS__.";
+        my.result.message = "This package is meant to be installed on macOS __XVERS__.";
         my.result.type = 'Fatal';
         return false;
     }

--- a/portmgr/dmg/ReadMe.rtf
+++ b/portmgr/dmg/ReadMe.rtf
@@ -18,7 +18,7 @@ MacPorts provides an infrastructure for building, installing, and packaging open
 System Requirements:
 \f0\b0 \
 \
-This installer is built for Mac OS X __XVERS__.x and requires valid curl and OpenSSL installations to function - all present by default on Mac OS X. Also required is the installation of Apple's Xcode development suite, available from the Mac App Store or from {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/xcode/"}}{\fldrslt Apple's Developer site}}. It is also available as a separate installation on Mac OS X CDs and DVDs.\
+This installer is built for macOS __XVERS__.x and requires valid curl and OpenSSL installations to function - all present by default on macOS. Also required is the installation of Apple's Xcode development suite, available from the Mac App Store or from {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/xcode/"}}{\fldrslt Apple's Developer site}}. It is also available as a separate installation on Mac OS X CDs and DVDs.\
 \
 \
 

--- a/portmgr/dmg/ReadMe.rtf
+++ b/portmgr/dmg/ReadMe.rtf
@@ -18,7 +18,7 @@ MacPorts provides an infrastructure for building, installing, and packaging open
 System Requirements:
 \f0\b0 \
 \
-This disk image is built for Mac OS X __XVERS__.x and requires valid Tcl, curl and OpenSSL installations to function - all present by default on Mac OS X. Also required is the installation of Apple's Xcode programing suite, available as a separate installation from your OS X CDs or DVD, or preferably the latest version from {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/xcode/"}}{\fldrslt Apple's Developer site}}.\
+This installer is built for Mac OS X __XVERS__.x and requires valid curl and OpenSSL installations to function - all present by default on Mac OS X. Also required is the installation of Apple's Xcode development suite, available from the Mac App Store or from {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/xcode/"}}{\fldrslt Apple's Developer site}}. It is also available as a separate installation on Mac OS X CDs and DVDs.\
 \
 \
 

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -167,7 +167,7 @@ function create_run_user {
         done
         ${DSCL} -q . -create "/Users/${RUNUSR}" UniqueID $NEXTUID
 
-        # These are implicitly added on Mac OSX Lion.  AuthenticationAuthority
+        # These are implicitly added on Mac OS X Lion.  AuthenticationAuthority
         # causes the user to be visible in the Users & Groups Preference Pane,
         # and the others are just noise, so delete them.
         # https://trac.macports.org/ticket/30168

--- a/src/cregistry/Makefile.in
+++ b/src/cregistry/Makefile.in
@@ -11,7 +11,7 @@ SQLEXT_OBJS = sqlext.o vercomp.o
 
 include ../../Mk/macports.autoconf.mk
 
-# required for strdup(3) on Linux and OS X
+# required for strdup(3) on Linux and macOS
 CPPFLAGS+=-D_XOPEN_SOURCE=600
 
 all:: ${STLIB_NAME} ${SQLEXT_NAME}

--- a/src/cregistry/entry.c
+++ b/src/cregistry/entry.c
@@ -1,7 +1,7 @@
 /*
  * entry.c
  *
- * Copyright (c) 2010-2011, 2014, 2017 The MacPorts Project
+ * Copyright (c) 2010-2011, 2014, 2017-2018 The MacPorts Project
  * Copyright (c) 2007 Chris Pickel <sfiera@macports.org>
  * All rights reserved.
  *
@@ -30,7 +30,7 @@
 #include <config.h>
 #endif
 
-/* required for asprintf(3) on OS X */
+/* required for asprintf(3) on macOS */
 #define _DARWIN_C_SOURCE
 /* required for asprintf(3) on Linux */
 #define _GNU_SOURCE

--- a/src/darwintracelib1.0/darwintrace.c
+++ b/src/darwintracelib1.0/darwintrace.c
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2005 Apple Inc. All rights reserved.
  * Copyright (c) 2005-2006 Paul Guyot <pguyot@kallisys.net>,
+ * Copyright (c) 2006-2018 The MacPorts Project
  * All rights reserved.
- * Copyright (c) 2006-2015 The MacPorts Project
  *
  * @APPLE_BSD_LICENSE_HEADER_START@
  *
@@ -385,7 +385,7 @@ void __darwintrace_setup() {
 		}
 
 		/* Set the close-on-exec flag as early as possible after the socket
-		 * creation. On OS X, there is no way to do this race-condition free
+		 * creation. On macOS, there is no way to do this race-condition free
 		 * unless you synchronize around creation and fork(2) -- however,
 		 * blocking in this function is not acceptable for darwintrace, because
 		 * it could possibly run in a signal handler, leading to a deadlock.
@@ -523,7 +523,7 @@ static void frecv(void *restrict buf, size_t size) {
 	 * SA_RESTART isn't set) and fread(3) may return short without giving us
 	 * a way to know how many bytes have actually been read, i.e. without a way
 	 * to do the call again. Because of this great API design and
-	 * implementation on OS X, we'll just use read(2) here. */
+	 * implementation on macOS, we'll just use read(2) here. */
 	int fd = fileno(__darwintrace_sock());
 	size_t count = 0;
 	while (count < size) {
@@ -558,7 +558,7 @@ static void fsend(const void *restrict buf, size_t size) {
 	 * SA_RESTART isn't set) and fwrite(3) may return short without giving us
 	 * a way to know how many bytes have actually been written, i.e. without
 	 * a way to do the call again. Because of this great API design and
-	 * implementation on OS X, we'll just use write(2) here. */
+	 * implementation on macOS, we'll just use write(2) here. */
 	int fd = fileno(__darwintrace_sock());
 	size_t count = 0;
 	while (count < size) {

--- a/src/darwintracelib1.0/proc.c
+++ b/src/darwintracelib1.0/proc.c
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2005 Apple Inc. All rights reserved.
  * Copyright (c) 2005-2006 Paul Guyot <pguyot@kallisys.net>,
+ * Copyright (c) 2006-2018 The MacPorts Project
  * All rights reserved.
- * Copyright (c) 2006-2015 The MacPorts Project
  *
  * @APPLE_BSD_LICENSE_HEADER_START@
  *
@@ -210,7 +210,7 @@ static inline int check_interpreter(const char *restrict path) {
 	char buffer[MAXPATHLEN + 1 + 2];
 	ssize_t bytes_read;
 
-	/* Read the file for the interpreter. Fortunately, on OS X:
+	/* Read the file for the interpreter. Fortunately, on macOS:
 	 *   The system guarantees to read the number of bytes requested if
 	 *   the descriptor references a normal file that has that many
 	 *   bytes left before the end-of-file, but in no other case.

--- a/src/machista1.0/libmachista.c
+++ b/src/machista1.0/libmachista.c
@@ -2,7 +2,7 @@
  * -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=c:et:sw=4:ts=4:sts=4:tw=100
  * libmachista.c
  *
- * Copyright (c) 2011 The MacPorts Project
+ * Copyright (c) 2011-2012, 2014, 2016-2018 The MacPorts Project
  * Copyright (c) 2011 Landon Fuller <landonf@macports.org>
  * Copyright (c) 2011 Clemens Lang <cal@macports.org>
  * All rights reserved.
@@ -33,7 +33,7 @@
 #include <config.h>
 #endif
 
-/* required for asprintf(3) on OS X */
+/* required for asprintf(3) on macOS */
 #define _DARWIN_C_SOURCE
 /* required for asprintf(3) on Linux */
 #define _GNU_SOURCE

--- a/src/macports1.0/diagnose.tcl
+++ b/src/macports1.0/diagnose.tcl
@@ -1,11 +1,11 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 # diagnose.tcl
 #
-# Copyright (c) 2002 - 2003 Apple Inc.
-# Copyright (c) 2004 - 2005 Paul Guyot, <pguyot@kallisys.net>.
-# Copyright (c) 2004 - 2006 Ole Guldberg Jensen <olegb@opendarwin.org>.
-# Copyright (c) 2004 - 2005 Robert Shaw <rshaw@opendarwin.org>
-# Copyright (c) 2004 - 2014 The MacPorts Project
+# Copyright (c) 2002-2003 Apple Inc.
+# Copyright (c) 2004-2005 Paul Guyot, <pguyot@kallisys.net>.
+# Copyright (c) 2004-2006 Ole Guldberg Jensen <olegb@opendarwin.org>.
+# Copyright (c) 2004-2005 Robert Shaw <rshaw@opendarwin.org>
+# Copyright (c) 2004-2014, 2016-2018 The MacPorts Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -492,7 +492,7 @@ namespace eval diagnose {
         #           None
 
         if {${macports::macosx_version} eq "10.6"} {
-            output "X11.app on OS X 10.6 systems"
+            output "X11.app on Mac OS X 10.6 systems"
 
             if {[file exists /Applications/X11.app]} {
                 ui_error "it seems you have Mac OS X 10.6 installed, and are using X11 from \"X11.app\". This has been known to cause issues. \

--- a/src/package1.0/portpkg.tcl
+++ b/src/package1.0/portpkg.tcl
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 # portpkg.tcl
 #
-# Copyright (c) 2005, 2007 - 2013, 2016 The MacPorts Project
-# Copyright (c) 2002 - 2003 Apple Inc.
+# Copyright (c) 2005, 2007-2014, 2016-2018 The MacPorts Project
+# Copyright (c) 2002-2003 Apple Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -351,7 +351,7 @@ proc portpkg::write_welcome_html {filename portname portversion portrevision lon
     <title>Install ${portname}</title>
 </head>
 <body>
-<font face=\"Helvetica\"><b>Welcome to the ${portname} for Mac OS X Installer</b></font>
+<font face=\"Helvetica\"><b>Welcome to the ${portname} for macOS Installer</b></font>
 <p>
 <font face=\"Helvetica\">${long_description}</font>
 <p>"
@@ -360,7 +360,7 @@ proc portpkg::write_welcome_html {filename portname portversion portrevision lon
         puts $fd "<font face=\"Helvetica\"><a href=\"${homepage}\">${homepage}</a></font><p>"
     }
 
-    puts $fd "<font face=\"Helvetica\">This installer guides you through the steps necessary to install ${portname} ${portversion}${portrevision_str} for Mac OS X. To get started, click Continue.</font>
+    puts $fd "<font face=\"Helvetica\">This installer guides you through the steps necessary to install ${portname} ${portversion}${portrevision_str} for macOS. To get started, click Continue.</font>
 </body>
 </html>"
 

--- a/src/pextlib1.0/Pextlib.c
+++ b/src/pextlib1.0/Pextlib.c
@@ -1,10 +1,10 @@
 /*
  * Pextlib.c
  *
- * Copyright (c) 2002 - 2003 Apple Inc.
- * Copyright (c) 2004 - 2005 Paul Guyot <pguyot@kallisys.net>
+ * Copyright (c) 2002-2003 Apple Inc.
+ * Copyright (c) 2004-2005 Paul Guyot <pguyot@kallisys.net>
  * Copyright (c) 2004 Landon Fuller <landonf@macports.org>
- * Copyright (c) 2007 - 2017 The MacPorts Project
+ * Copyright (c) 2007-2018 The MacPorts Project
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,7 +44,7 @@
 /* required for vasprintf(3) on Linux */
 #define _GNU_SOURCE
 #endif
-/* required for clearenv(3)/setenv(3)/unsetenv(3) on OS X */
+/* required for clearenv(3)/setenv(3)/unsetenv(3) on macOS */
 #define _DARWIN_C_SOURCE
 
 #include <sys/resource.h>
@@ -268,7 +268,7 @@ int ExistsgroupCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, T
 }
 
 /* Find the first unused UID > 500
-   UIDs > 500 are visible on the login screen of OS X,
+   UIDs > 500 are visible on the macOS login screen,
    but UIDs < 500 are reserved by Apple */
 int NextuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED)
 {

--- a/src/pextlib1.0/adv-flock.c
+++ b/src/pextlib1.0/adv-flock.c
@@ -1,7 +1,7 @@
 /*
  * adv-flock.c
  *
- * Copyright (c) 2009 The MacPorts Project
+ * Copyright (c) 2009, 2014-2018 The MacPorts Project
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 #ifndef __APPLE__
 /* needed to get struct sigaction on some platforms, but
-  hides flock on OS X */
+  hides flock on macOS */
 #define _XOPEN_SOURCE 500L
 #endif
 

--- a/src/pextlib1.0/mktemp.c
+++ b/src/pextlib1.0/mktemp.c
@@ -1,7 +1,7 @@
 /*
  * mktemp.c
  *
- * Copyright (c) 2009 The MacPorts Project
+ * Copyright (c) 2009, 2014, 2016-2018 The MacPorts Project
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 #ifndef __APPLE__
 /* required for strdup(3)/mkdtemp(3) on Linux */
-/* hides mkdtemp(3) on OS X */
+/* hides mkdtemp(3) on macOS */
 #define _XOPEN_SOURCE 700L
 /* required for mktemp(3) if _XOPEN_SOURCE >= 600L on Linux */
 #define _BSD_SOURCE

--- a/src/pextlib1.0/readline.c
+++ b/src/pextlib1.0/readline.c
@@ -10,7 +10,7 @@
 #include <config.h>
 #endif
 
-/* required for strdup(3) on Linux and OS X */
+/* required for strdup(3) on Linux and macOS */
 #define _XOPEN_SOURCE 600L
 
 #include <stdio.h>

--- a/src/pextlib1.0/realpath.h
+++ b/src/pextlib1.0/realpath.h
@@ -1,7 +1,7 @@
 /*
  * realpath.h
  *
- * Copyright (c) 2009 The MacPorts Project.
+ * Copyright (c) 2009-2010, 2016, 2018 The MacPorts Project.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
  * realpath path
  *	Normalize path like file normalize does.
  *  Fixes a problem with Tcl installations affected by not defining HAVE_REALPATH (this is
- *	the case with the Tcl in OS X shipped prior to 10.6)
+ *  the case with the Tcl in Mac OS X prior to 10.6)
  */
 int RealpathCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
 

--- a/src/pextlib1.0/strsed.c
+++ b/src/pextlib1.0/strsed.c
@@ -130,7 +130,7 @@
 
 #include "strsed.h"
 
-/* required for strdup(3) on Linux and OS X */
+/* required for strdup(3) on Linux and macOS */
 #define _XOPEN_SOURCE 600L
 /* we're using this on raw strings, no escape sequences allowed */
 #define ESCAPED_STRING

--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -131,7 +131,7 @@ default os.endian {$os_endian}
 
 set macosx_version_text {}
 if {[option os.platform] eq "darwin"} {
-    set macosx_version_text "(Mac OS X ${macosx_version}) "
+    set macosx_version_text "(macOS ${macosx_version}) "
 }
 ui_debug "OS [option os.platform]/[option os.version] ${macosx_version_text}arch [option os.arch]"
 

--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -1,8 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 # portmain.tcl
 #
-# Copyright (c) 2004 - 2005, 2007 - 2012 The MacPorts Project
-# Copyright (c) 2002 - 2003 Apple Inc.
+# Copyright (c) 2004-2005, 2007-2018 The MacPorts Project
+# Copyright (c) 2002-2003 Apple Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -138,7 +138,7 @@ ui_debug "OS [option os.platform]/[option os.version] ${macosx_version_text}arch
 default universal_variant {${use_configure}}
 
 if {[option os.platform] eq "darwin" && [option os.subplatform] eq "macosx"} {
-    # we're on Mac OS X and can therefore build universal
+    # we're on macOS and can therefore build universal
     default os.universal_supported yes
 } else {
     default os.universal_supported no

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3257,10 +3257,10 @@ proc _check_xcode_version {} {
                 ui_warn "You downloaded Xcode from the Mac App Store but didn't install it. Run \"Install Xcode\" in the /Applications folder."
             }
         } elseif {[vercmp $xcodeversion $min] < 0} {
-            ui_error "The installed version of Xcode (${xcodeversion}) is too old to use on the installed OS version. Version $rec or later is recommended on Mac OS X ${macosx_version}."
+            ui_error "The installed version of Xcode (${xcodeversion}) is too old to use on the installed OS version. Version $rec or later is recommended on macOS ${macosx_version}."
             return 1
         } elseif {[vercmp $xcodeversion $ok] < 0} {
-            ui_warn "The installed version of Xcode (${xcodeversion}) is known to cause problems. Version $rec or later is recommended on Mac OS X ${macosx_version}."
+            ui_warn "The installed version of Xcode (${xcodeversion}) is known to cause problems. Version $rec or later is recommended on macOS ${macosx_version}."
         }
 
         # Xcode 4.3 and above requires the command-line utilities package to be installed. 

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -2306,7 +2306,7 @@ proc adduser {name args} {
         try {
             exec -ignorestderr $dscl . -create /Users/${name} UniqueID ${uid}
 
-            # These are implicitly added on Mac OSX Lion.  AuthenticationAuthority
+            # These are implicitly added on Mac OS X Lion.  AuthenticationAuthority
             # causes the user to be visible in the Users & Groups Preference Pane,
             # and the others are just noise, so delete them.
             # https://trac.macports.org/ticket/30168

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3,7 +3,7 @@
 # Copyright (c) 2002-2003 Apple Inc.
 # Copyright (c) 2004 Robert Shaw <rshaw@opendarwin.org>
 # Copyright (c) 2006-2007 Markus W. Weissmann <mww@macports.org>
-# Copyright (c) 2004-2017 The MacPorts Project
+# Copyright (c) 2004-2018 The MacPorts Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -2538,7 +2538,7 @@ proc PortGroup {group version} {
 proc get_portimage_name {} {
     global subport version revision portvariants os.platform os.major portarchivetype
     set ret "${subport}-${version}_${revision}${portvariants}.${os.platform}_${os.major}.[join [get_canonical_archs] -].${portarchivetype}"
-    # should really look up NAME_MAX here, but it's 255 for all OS X so far
+    # should really look up NAME_MAX here, but it's 255 for all macOS so far
     # (leave 10 chars for an extension like .rmd160 on the sig file)
     if {[string length $ret] > 245 && ${portvariants} ne ""} {
         # try hashing the variants

--- a/src/registry2.0/portimage.tcl
+++ b/src/registry2.0/portimage.tcl
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 # portimage.tcl
 #
-# Copyright (c) 2004-2005, 2007-2011, 2014 The MacPorts Project
+# Copyright (c) 2004-2005, 2007-2018 The MacPorts Project
 # Copyright (c) 2004 Will Barton <wbb4@opendarwin.org>
 # Copyright (c) 2002 Apple Inc.
 # All rights reserved.
@@ -700,7 +700,7 @@ proc _deactivate_contents {port imagefiles {force 0} {rollback 0}} {
             # match and activate will say that some file exists but doesn't
             # belong to any port.
             # The custom realpath proc is necessary because file normalize
-            # does not resolve symlinks on OS X < 10.6
+            # does not resolve symlinks on Mac OS X < 10.6
             set directory [realpath [::file dirname $file]]
             lappend files [::file join $directory [::file tail $file]]
 


### PR DESCRIPTION
Update the OS name to "macOS", except for references to historical versions where the earlier names "OS X" or "Mac OS X" are used.

In the configure script, also change the outdated OS warning to refer users to the Mac App Store on 10.8 and later instead of Software Update.

Also reword the requirements in the installer read me. Mention the Mac App Store as the first suggested source of Xcode, rather than an OS CD/DVD; change "disk image" to "installer" since we don't produce disk images for newer OS versions; and remove the reference to Tcl since we bundle it.