### PR TITLE
cregistry: add SQLITE3 flags

### DIFF
--- a/src/cregistry/Makefile.in
+++ b/src/cregistry/Makefile.in
@@ -14,6 +14,9 @@ include ../../Mk/macports.autoconf.mk
 # required for strdup(3) on Linux and OS X
 CPPFLAGS+=-D_XOPEN_SOURCE=600
 
+CFLAGS+= ${SQLITE3_CFLAGS}
+LIBS+= ${SQLITE3_LIBS}
+
 all:: ${STLIB_NAME} ${SQLEXT_NAME}
 
 .c.o:


### PR DESCRIPTION
allows cregistry Makefile.in  to respond to
--with-sqlite3prefix
similarly to registry2.0 Makefile.in