### PR TITLE
port1.0: Include non-default SDK in trace sandbox.

### DIFF
--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -131,7 +131,7 @@ namespace eval porttrace {
     # @param workpath The $workpath of the current installation
     proc trace_start {workpath} {
         global \
-            developer_dir distpath env macportsuser os.platform \
+            developer_dir distpath env macportsuser os.platform configure.sdkroot \
             portpath prefix
 
         variable fifo
@@ -206,6 +206,9 @@ namespace eval porttrace {
                 allow trace_sandbox $tmpdir
             }
         }
+
+        # Allow access to SDK if it's not inside the Developer folder.
+        allow trace_sandbox "${configure.sdkroot}"
 
         # Allow access to some Xcode specifics
         allow trace_sandbox "/var/db/xcode_select_link"


### PR DESCRIPTION
Apple has a nasty habit of nuking folders when something is updated, which means it isn't really safe to store older SDKs in the Developer folder.

So, what does this do?

Considering macports supports pointing to a non-default SDK via ```configure.sdkroot``` (which is very necessary if one is building binaries meant to be bundled and shared), I made sure running in trace-mode includes that folder, for the cases when it is not under the Developer folder.