### PR TITLE
port lint: warn if checksum section is missing file size field

### DIFF
--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -556,6 +556,13 @@ proc portlint::lint_main {args} {
         }
     }
 
+    if {[info exists checksums]} {
+        if {![regexp {size\s+(\d+)} $checksums]} {
+            ui_warn "Checksum(s) should include the 'size' field"
+            incr warnings
+        }
+    }
+
     if {[info exists conflicts]} {
         foreach cport $conflicts {
             if {[regexp {[^[:alnum:]_.-]} $cport]} {


### PR DESCRIPTION
As per discussion in macports/macports-guide#21