### PR TITLE
port-info: output fields in the order given on the command line

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -1913,6 +1913,8 @@ proc action_log { action portlist opts } {
 
 proc action_info { action portlist opts } {
     global global_variations
+    global ui_options
+
     set status 0
     if {[require_portlist portlist]} {
         return 1
@@ -2094,7 +2096,7 @@ proc action_info { action portlist opts } {
 
         # Spin through action options, emitting information for any found
         set fields {}
-        set opts_todo [array names options ports_info_*]
+        set opts_todo $ui_options(options_info_order)
         set fields_tried {}
         if {![llength $opts_todo]} {
             set opts_todo {ports_info_heading
@@ -4468,6 +4470,8 @@ proc parse_options { action ui_options_name global_options_name } {
     upvar $ui_options_name ui_options
     upvar $global_options_name global_options
 
+    set options_info_order {}
+
     while {[moreargs]} {
         set arg [lookahead]
 
@@ -4495,6 +4499,9 @@ proc parse_options { action ui_options_name global_options_name } {
                     set kargc [lindex $kopts 0 1]
                     if {$kargc == 0} {
                         set global_options(ports_${action}_${key}) yes
+                        if {${action} eq "info"} {
+                            lappend options_info_order ports_${action}_${key}
+                        }
                     } else {
                         set args {}
                         while {[moreargs] && $kargc > 0} {
@@ -4591,6 +4598,7 @@ proc parse_options { action ui_options_name global_options_name } {
 
         advance
     }
+    set ui_options(options_info_order) $options_info_order
 }
 
 # acquire exclusive registry lock for actions that need it


### PR DESCRIPTION
Currently due to the use of 'array names', the output of
'port info --multiple-fields' are displayed in a random order.
Now, the fields are kept in a list which preserves their order they
were given on the command line.
This has the effect of also allowing duplicate fields to be displayed.

Closes: https://trac.macports.org/ticket/57003