### PR TITLE
Disable universal when there are fewer than 2 universal_archs

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1063,10 +1063,6 @@ match macports.conf.default."
         } else {
             set macports::universal_archs {i386 ppc}
         }
-    } elseif {[llength $macports::universal_archs] < 2} {
-        if {$os_major < 18} {
-            ui_warn "invalid universal_archs configured (should contain at least 2 archs)"
-        }
     }
 
     # Default arch to build for

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1056,7 +1056,9 @@ match macports.conf.default."
 
     # Default mp universal options
     if {![info exists macports::universal_archs]} {
-        if {$os_major >= 10} {
+        if {$os_major >= 18} {
+            set macports::universal_archs {x86_64}
+        } elseif {$os_major >= 10} {
             set macports::universal_archs {x86_64 i386}
         } else {
             set macports::universal_archs {i386 ppc}

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -664,6 +664,10 @@ proc variant {args} {
 proc variant_isset {name} {
     global variations
 
+    if {$name eq "universal" && [llength [option configure.universal_archs]] < 2} {
+        return 0
+    }
+
     if {[info exists variations($name)] && $variations($name) eq "+"} {
         return 1
     }

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -595,6 +595,11 @@ proc variant {args} {
         return -code error "Variant name $name contains invalid characters"
     }
 
+    if {[ditem_key $ditem name] eq "universal" && [llength [option configure.universal_archs]] < 2} {
+        ditem_delete $ditem
+        return
+    }
+
     # make a user procedure named variant-blah-blah
     # we will call this procedure during variant-run
     makeuserproc variant-[ditem_key $ditem name] $code


### PR DESCRIPTION
This PR makes the changes proposed in [ticket #57133](https://trac.macports.org/ticket/57133) to make having fewer than 2 `universal_archs` no longer be considered invalid, and to instead make it disable the universal variant.