### PR TITLE
portconfigure.tcl add -Wc,-isysroot to LDFLAGS

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -892,6 +892,7 @@ proc portconfigure::configure_main {args} {
             foreach env_var {CPPFLAGS CFLAGS CXXFLAGS OBJCFLAGS OBJCXXFLAGS} {
                 append_to_environment_value configure $env_var -isysroot${configure.sdkroot}
             }
+            append_to_environment_value configure "LDFLAGS" -Wc,-isysroot,${configure.sdkroot}
             append_to_environment_value configure "LDFLAGS" -Wl,-syslibroot,${configure.sdkroot}
         }
 


### PR DESCRIPTION
clang does not prepend -syslibroot path to link search path
it appends it to the search path set in -isysroot

unless an -isysroot is sent to clang during the link, it uses
the default -isysroot instead

sending the -isysroot to clang during link uses the requested
SDK for link instead of the default

closes: https://trac.macports.org/ticket/57612