### PR TITLE
Fix a crash due to an out-of-bounds array access

### DIFF
--- a/src/cregistry/entry.c
+++ b/src/cregistry/entry.c
@@ -397,8 +397,8 @@ static int reg_all_entries(reg_registry* reg, char* query, int query_len,
  * @param [out] errPtr   on error, a description of the error that occurred
  * @return               the number of entries if success; false if failure
  */
-int reg_entry_search(reg_registry* reg, char** keys, char** vals, int key_count,
-        int *strategies, reg_entry*** entries, reg_error* errPtr) {
+int reg_entry_search(reg_registry* reg, const char** keys, const char** vals,
+        int key_count, int *strategies, reg_entry*** entries, reg_error* errPtr) {
     int i;
     char* kwd = " WHERE ";
     char* query;

--- a/src/cregistry/entry.h
+++ b/src/cregistry/entry.h
@@ -52,8 +52,8 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr);
 
 void reg_entry_free(reg_entry* entry);
 
-int reg_entry_search(reg_registry* reg, char** keys, char** vals, int key_count,
-        int* strategies, reg_entry*** entries, reg_error* errPtr);
+int reg_entry_search(reg_registry* reg, const char** keys, const char** vals,
+        int key_count, int* strategies, reg_entry*** entries, reg_error* errPtr);
 
 int reg_entry_imaged(reg_registry* reg, const char* name, const char* version,
         const char* revision, const char* variants, reg_entry*** entries,

--- a/src/registry2.0/tests/entry.tcl
+++ b/src/registry2.0/tests/entry.tcl
@@ -74,6 +74,9 @@ proc main {pextlibname} {
         test_set {[registry::entry search name -glob vi*]} {$vim1 $vim2 $vim3}
         test_set {[registry::entry search name -regexp {zlib|pcre}]} \
             {$zlib $pcre}
+
+        # test that passing in confusing arguments doesn't crash
+        test {[catch {registry::entry search name vim1 --}] == 1}
     }
 
     # try mapping files and checking their owners


### PR DESCRIPTION
entry_search had a "type confusion" bug where it would perform array accesses that bypassed bounds checks if given arguments that looked like strategies. I've rewritten most of the argument parsing loop in a way that should eliminate this issue, while being shorter and more straightforward (with less duplicated code), only requiring one pass through the arguments. The downside is that we allocate a bit more memory and have a couple of gotos to handle errors.

You can reproduce this crash with `port install [some port name] --`, if you'd like to test it. If there's something stylistically wrong with my pull request, please feel free to let me know–I'm not completely sure how you'd like it formatted.