### PR TITLE
If with-no-root-privileges, set without-startupitems=yes

### DIFF
--- a/configure
+++ b/configure
@@ -6167,6 +6167,8 @@ $as_echo "$mpconfigdir" >&6; }
 # Check whether --with-no-root-privileges was given.
 if test "${with_no_root_privileges+set}" = set; then :
   withval=$with_no_root_privileges; ROOTPRIVS=$withval
+  # with-no-root-privileges implies without-startupitems
+  with_startupitems=no
 fi
 
 


### PR DESCRIPTION
configure --with-no-root-privileges implies --without-startupitems=yes
Otherwise, startupitems will attempt to be installed under /Library

closes: https://trac.macports.org/ticket/56743