### PR TITLE
Change puts to ui_msg in reclaim.tcl

### DIFF
--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -72,7 +72,7 @@ namespace eval reclaim {
             write_last_run_file disabled
             return
         }
-
+        ui_msg "$macports::ui_prefix Initializing Reclaim"
         uninstall_unrequested
         uninstall_inactive
         remove_distfiles
@@ -339,7 +339,7 @@ namespace eval reclaim {
         set fd -1
         try -pass_signal {
             set fd [open $path w]
-            puts $fd $contents
+            ui_msg " $fd $contents"
         } catch {*} {
             # Ignore error silently
         } finally {

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -72,7 +72,7 @@ namespace eval reclaim {
             write_last_run_file disabled
             return
         }
-        ui_msg "$macports::ui_prefix Initializing Reclaim"
+        
         uninstall_unrequested
         uninstall_inactive
         remove_distfiles


### PR DESCRIPTION
```reclaim.tcl``` states change from ```puts``` to ```ui_msg``` as a finished task in line 45. 
But I noticed that one single puts instance wasn't changed, and as far as I understand there isn't any need for it to be ```puts```.

