### PR TITLE
tracelib.c: Removed unnecessary condition in if

### DIFF
--- a/src/pextlib1.0/tracelib.c
+++ b/src/pextlib1.0/tracelib.c
@@ -771,7 +771,7 @@ static int TracelibRunCmd(Tcl_Interp *in) {
         /* kevent(2) on EV_RECEIPT: When passed as input, it forces EV_ERROR to
          * always be returned. When a filter is successfully added, the data field
          * will be zero. */
-        if ((kev.flags & EV_ERROR) == 0 || ((kev.flags & EV_ERROR) > 0 && kev.data != 0)) {
+        if ((kev.flags & EV_ERROR) == 0 || (kev.data != 0)) {
             error2tcl("kevent (listen socket receipt): ", kev.data, in);
             goto error_locked;
         }

--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -155,13 +155,13 @@ namespace eval porttrace {
         create_slave $workpath $fifo
 
         # Launch darwintrace.dylib.
-        set tracelib [file join ${portutil::autoconf::tcl_package_path} darwintrace1.0 darwintrace.dylib]
+        set darwintracepath [file join ${portutil::autoconf::tcl_package_path} darwintrace1.0 darwintrace.dylib]
 
         # Add darwintrace.dylib as last entry in DYLD_INSERT_LIBRARIES
         if {[info exists env(DYLD_INSERT_LIBRARIES)] && [string length $env(DYLD_INSERT_LIBRARIES)] > 0} {
-            set env(DYLD_INSERT_LIBRARIES) "${env(DYLD_INSERT_LIBRARIES)}:${tracelib}"
+            set env(DYLD_INSERT_LIBRARIES) "${env(DYLD_INSERT_LIBRARIES)}:${darwintracepath}"
         } else {
-            set env(DYLD_INSERT_LIBRARIES) ${tracelib}
+            set env(DYLD_INSERT_LIBRARIES) ${darwintracepath}
         }
         # Tell traced processes where to find their communication socket back
         # to this code.

--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -376,7 +376,7 @@ namespace eval porttrace {
         # Create the thread.
         set thread [macports_create_thread]
 
-        # The slave thred needs this file and macports 1.0
+        # The slave thread needs this file and macports 1.0
         thread::send $thread "package require porttrace 1.0"
         thread::send $thread "package require macports 1.0"
 


### PR DESCRIPTION
if ((kev.flags & EV_ERROR) == 0 || ((kev.flags & EV_ERROR) > 0 && kev.data != 0))
If compilers find first operand true while evaluating || , the second operand isn’t checked.
So the second operand is only checked if (kev.flags & EV_ERROR) != 0.
So (kev.flags & EV_ERROR) > 0  it doesn’t need to be checked in conjunction with kev.data != 0.
It doesn’t return negative.(tested)