### PR TITLE
tracelib.c: Removed unnecessary condition in if

### DIFF
--- a/src/pextlib1.0/tracelib.c
+++ b/src/pextlib1.0/tracelib.c
@@ -771,7 +771,7 @@ static int TracelibRunCmd(Tcl_Interp *in) {
         /* kevent(2) on EV_RECEIPT: When passed as input, it forces EV_ERROR to
          * always be returned. When a filter is successfully added, the data field
          * will be zero. */
-        if ((kev.flags & EV_ERROR) == 0 || ((kev.flags & EV_ERROR) > 0 && kev.data != 0)) {
+        if ((kev.flags & EV_ERROR) == 0 || (kev.data != 0)) {
             error2tcl("kevent (listen socket receipt): ", kev.data, in);
             goto error_locked;
         }
@@ -801,7 +801,7 @@ static int TracelibRunCmd(Tcl_Interp *in) {
         /* kevent(2) on EV_RECEIPT: When passed as input, it forces EV_ERROR to
          * always be returned. When a filter is successfully added, the data field
          * will be zero. */
-        if ((kev.flags & EV_ERROR) == 0 || ((kev.flags & EV_ERROR) > 0 && kev.data != 0)) {
+        if ((kev.flags & EV_ERROR) == 0 || (kev.data != 0)) {
             error2tcl("kevent (selfpipe receipt): ", kev.data, in);
             goto error_locked;
         }
@@ -892,7 +892,7 @@ static int TracelibRunCmd(Tcl_Interp *in) {
                 /* kevent(2) on EV_RECEIPT: When passed as input, it forces EV_ERROR to
                  * always be returned. When a filter is successfully added, the data field
                  * will be zero. */
-                if ((kev.flags & EV_ERROR) == 0 || ((kev.flags & EV_ERROR) > 0 && kev.data != 0)) {
+                if ((kev.flags & EV_ERROR) == 0 || (kev.data != 0)) {
                     ui_warn(interp, "tracelib: error adding socket to kqueue (receipt)");
                     close(s);
                     continue;


### PR DESCRIPTION
if ((kev.flags & EV_ERROR) == 0 || ((kev.flags & EV_ERROR) > 0 && kev.data != 0))
If compilers find first operand true while evaluating || , the second operand isn’t checked.
So the second operand is only checked if (kev.flags & EV_ERROR) != 0.
So (kev.flags & EV_ERROR) > 0 it doesn’t need to be checked in conjunction with kev.data != 0.
It doesn’t return negative as its of type uint16_t.