### PR TITLE
Do not return an error if there's no ports to upgrade

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -310,7 +310,7 @@ proc require_portlist { nameportlist {is_upgrade "no"} } {
             # "upgrade", let's print a message that's a little easier to
             # understand and less alarming.
             ui_msg "Nothing to upgrade."
-            return 1
+            return 0
         }
         ui_error "No ports matched the given expression"
         return 1


### PR DESCRIPTION
e05bba0f867a9ef88d80a97678a34c6a1bf0a3ce added a "Nothing to upgrade"
message when doing a 'port upgrade outdated' and returned an error.
This changes the return value to a non error.

closes https://trac.macports.org/ticket/58309