### PR TITLE
Logically reorder output of port selfupdate

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2438,6 +2438,9 @@ proc action_selfupdate { action portlist opts } {
     }
 
     if {$base_updated} {
+        ui_msg "Rerunning selfupdate with updated version of MacPorts\n"
+        execl $::argv0 $::argv
+        
         # exit immediately if in batch/shell mode
         return -999
     } else {


### PR DESCRIPTION
This splits up a conditional to make version-related output come before updating the ports tree. Notably, this means that output that used to look like this:

```console
# port selfupdate
---> Updating MacPorts base sources using rsync
MacPorts base version 2.5.4 installed,
MacPorts base version 2.5.4 downloaded.
---> Updating the ports tree
---> MacPorts base is already the latest version
```

now should look like this:

```console
# port selfupdate
---> Updating MacPorts base sources using rsync
MacPorts base version 2.5.4 installed,
MacPorts base version 2.5.4 downloaded.
---> MacPorts base is already the latest version
---> Updating the ports tree
```

Closes: https://trac.macports.org/ticket/57950