### PR TITLE
Update configure check for supported macOS versions

### DIFF
--- a/configure
+++ b/configure
@@ -2754,29 +2754,29 @@ $as_echo "$MACOSX_VERSION" >&6; }
 fi
 
 case "$MACOSX_VERSION" in
-  10.0*|10.1|10.1.*|10.2*|10.3*)
+  10.0|10.0.*|10.1|10.1.*|10.2|10.2.*|10.3|10.3.*)
     as_fn_error $? "This version of Mac OS X is not supported
                   Please upgrade at http://store.apple.com/" "$LINENO" 5
     ;;
-  10.4.[0-9]|10.4.10|10.5.[0-7]|10.6.[0-7]|10.7.[0-4])
+  10.4|10.4.[1-9]|10.4.10|10.5|10.5.[1-7]|10.6|10.6.[1-7]|10.7|10.7.[1-4])
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of Mac OS X is out of date" >&5
 $as_echo "$as_me: WARNING: This version of Mac OS X is out of date" >&2;}
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please run Software Update to update it" >&5
 $as_echo "$as_me: WARNING: Please run Software Update to update it" >&2;}
     ;;
-  10.8.[0-4]|10.9.[0-4]|10.10.[0-4]|10.11.[0-5])
+  10.8|10.8.[1-4]|10.9|10.9.[1-4]|10.10|10.10.[1-4]|10.11|10.11.[1-5])
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of OS X is out of date" >&5
 $as_echo "$as_me: WARNING: This version of OS X is out of date" >&2;}
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please use the Mac App Store to update it" >&5
 $as_echo "$as_me: WARNING: Please use the Mac App Store to update it" >&2;}
     ;;
-  10.12.[0-5]|10.13.[0-4])
+  10.12|10.12.[1-5]|10.13|10.13.[1-4])
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of macOS is out of date" >&5
 $as_echo "$as_me: WARNING: This version of macOS is out of date" >&2;}
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please use the Mac App Store to update it" >&5
 $as_echo "$as_me: WARNING: Please use the Mac App Store to update it" >&2;}
     ;;
-  10.4*|10.5*|10.6*|10.7*|10.8*|10.9*|10.10*|10.11*|10.12*|10.13*)
+  10.4.*|10.5.*|10.6.*|10.7.*|10.8.*|10.9.*|10.10.*|10.11.*|10.12.*|10.13.*)
         ;;
   *)
     ;;

--- a/configure
+++ b/configure
@@ -2776,7 +2776,13 @@ $as_echo "$as_me: WARNING: This version of macOS is out of date" >&2;}
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please use the Mac App Store to update it" >&5
 $as_echo "$as_me: WARNING: Please use the Mac App Store to update it" >&2;}
     ;;
-  10.4.*|10.5.*|10.6.*|10.7.*|10.8.*|10.9.*|10.10.*|10.11.*|10.12.*|10.13.*)
+  10.14|10.14.[1-4])
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: This version of macOS is out of date" >&5
+$as_echo "$as_me: WARNING: This version of macOS is out of date" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Please run Software Update to update it" >&5
+$as_echo "$as_me: WARNING: Please run Software Update to update it" >&2;}
+    ;;
+  10.4.*|10.5.*|10.6.*|10.7.*|10.8.*|10.9.*|10.10.*|10.11.*|10.12.*|10.13.*|10.14.*)
         ;;
   *)
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -28,23 +28,23 @@ if test "x$SW_VERS" != "x"; then
 fi
 
 case "$MACOSX_VERSION" in
-  10.0*|10.1|10.1.*|10.2*|10.3*)
+  10.0|10.0.*|10.1|10.1.*|10.2|10.2.*|10.3|10.3.*)
     AC_MSG_ERROR([This version of Mac OS X is not supported
                   Please upgrade at http://store.apple.com/])
     ;;
-  10.4.[[0-9]]|10.4.10|10.5.[[0-7]]|10.6.[[0-7]]|10.7.[[0-4]])
+  10.4|10.4.[[1-9]]|10.4.10|10.5|10.5.[[1-7]]|10.6|10.6.[[1-7]]|10.7|10.7.[[1-4]])
     AC_MSG_WARN([This version of Mac OS X is out of date])
     AC_MSG_WARN([Please run Software Update to update it])
     ;;
-  10.8.[[0-4]]|10.9.[[0-4]]|10.10.[[0-4]]|10.11.[[0-5]])
+  10.8|10.8.[[1-4]]|10.9|10.9.[[1-4]]|10.10|10.10.[[1-4]]|10.11|10.11.[[1-5]])
     AC_MSG_WARN([This version of OS X is out of date])
     AC_MSG_WARN([Please use the Mac App Store to update it])
     ;;
-  10.12.[[0-5]]|10.13.[[0-4]])
+  10.12|10.12.[[1-5]]|10.13|10.13.[[1-4]])
     AC_MSG_WARN([This version of macOS is out of date])
     AC_MSG_WARN([Please use the Mac App Store to update it])
     ;;
-  10.4*|10.5*|10.6*|10.7*|10.8*|10.9*|10.10*|10.11*|10.12*|10.13*)
+  10.4.*|10.5.*|10.6.*|10.7.*|10.8.*|10.9.*|10.10.*|10.11.*|10.12.*|10.13.*)
     dnl Supported version
     ;;
   *)

--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,11 @@ case "$MACOSX_VERSION" in
     AC_MSG_WARN([This version of macOS is out of date])
     AC_MSG_WARN([Please use the Mac App Store to update it])
     ;;
-  10.4.*|10.5.*|10.6.*|10.7.*|10.8.*|10.9.*|10.10.*|10.11.*|10.12.*|10.13.*)
+  10.14|10.14.[[1-4]])
+    AC_MSG_WARN([This version of macOS is out of date])
+    AC_MSG_WARN([Please run Software Update to update it])
+    ;;
+  10.4.*|10.5.*|10.6.*|10.7.*|10.8.*|10.9.*|10.10.*|10.11.*|10.12.*|10.13.*|10.14.*)
     dnl Supported version
     ;;
   *)


### PR DESCRIPTION
This PR updates the configure check for supported macOS versions with two fixes:

* The initial version of each major macOS version (e.g. "10.7" or "10.13") is now recognized. Previously we were checking for e.g. "10.7.0" or "10.13.0" but Apple does not use a trailing ".0" for initial macOS versions and the output of `sw_vers -productVersion` reflects that.
* macOS Mojave 10.14-10.14.4 are recognized as outdated while later versions are recognized as supported.