### PR TITLE
Remove Xcode uninstalled warning message

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3300,7 +3300,6 @@ proc _check_xcode_version {} {
             }
         }
         if {$xcodeversion eq "none"} {
-            ui_warn "Xcode does not appear to be installed; most ports will likely fail to build."
             if {[file exists "/Applications/Install Xcode.app"]} {
                 ui_warn "You downloaded Xcode from the Mac App Store but didn't install it. Run \"Install Xcode\" in the /Applications folder."
             }


### PR DESCRIPTION
* ~~Changes message from “most ports” to “some ports”. This has been requested.~~
* ~~Warn only once every two weeks. This solves the complaint that the warning spams the terminal (e.g when doing `sudo port upgrade`).~~
* Remove warning since we already error out on Xcode-dependent ports.

References https://trac.macports.org/ticket/35045
References https://trac.macports.org/ticket/58016