### PR TITLE
Universally export DEVELOPER_DIR

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -425,6 +425,7 @@ proc command_exec {command args} {
     if {[option compiler.library_path] ne ""} {
         set ${varprefix}.env_array(LIBRARY_PATH) [join [option compiler.library_path] :]
     }
+    set ${varprefix}.env_array(DEVELOPER_DIR) [option configure.developer_dir]
 
     # Debug that.
     ui_debug "Environment: [environment_array_to_string ${varprefix}.env_array]"


### PR DESCRIPTION
* refactor autoreconf, automake etc to one loop
* export DEVELOPER_DIR for destroot, build, and autotools

Since we're hiding Xcode on trace mode if ports aren't Xcode-dependent, ports that do e.g `post-build { system -W "someotherdir" "make" }` fail because `/usr/bin/make` resolves to Xcode's make. It should resolve to CommandLineTools's make instead like `build.cmd make` already does.

This PR solves that problem by also setting DEVELOPER_DIR for build, destroot and all the autotools.