### PR TITLE
portconfigure: Prioritize returning SDK with DEVELOPER_DIR set 

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -521,7 +521,7 @@ proc portconfigure::configure_get_developer_dir {} {
     # Assume that the existence of libxcselect indiciates the earliest version of
     # macOS that places CLT in /Library/Developer/CommandLineTools
     # If port is Xcode-dependent or CommandLineTools directory is invalid, set to developer_dir
-    if {[tbool use_xcode] || ![file exists /usr/lib/libxcselect.dylib] || ![file executable [file join $cltpath usr bin make]]} {
+    if {[tbool use_xcode]} {
         return ${developer_dir}
     } else {
         return ${cltpath}

--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -154,7 +154,8 @@ set egid [getegid]
 default worksymlink {[file normalize [file join $portpath work]]}
 default distpath {[file normalize [file join $portdbpath distfiles ${dist_subdir}]]}
 
-default use_xcode {[expr {[option build.type] eq "xcode"}]}
+set cltpath "/Library/Developer/CommandLineTools"
+default use_xcode {[expr {[option build.type] eq "xcode" || ![file exists /usr/lib/libxcselect.dylib] || ![file executable [file join $cltpath usr bin make]]}]}
 
 proc portmain::main {args} {
     return 0

--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -228,7 +228,7 @@ namespace eval porttrace {
         lappend xcode_paths [file join {*}$ddsplit]
 
         set cltpath "/Library/Developer/CommandLineTools"
-        if {[tbool use_xcode] || ![file exists /usr/lib/libxcselect.dylib] || ![file executable [file join $cltpath usr bin make]]} {
+        if {[tbool use_xcode]} {
             foreach xcode_path $xcode_paths {
                 allow trace_sandbox $xcode_path
             }


### PR DESCRIPTION
- move xcrun --sdk macosx to find macOS SDK to the top
- export DEVELOPER_DIR so xcrun can find CommandLineTools SDK

Relevant: https://trac.macports.org/ticket/57143

`xcrun --sdk macosx`, which was previously reenabled as the final fallback by @jmroot, is moved to the top of the `::configure_get_sdkroot` proc so the newest-available macOS SDK is returned first instead of the current OS version's SDKs. It was generally agreed on trac that the newest-available SDK should be used, so I assume this change is better and causes no problems.

[previously reenabled]: https://github.com/macports/macports-base/commit/8caac195a15c8a01d07cf337439fd68f4370d9ee

The DEVELOPER_DIR change is done so a CommandLineTools SDK is returned if the port isn't Xcode-dependent. This fixes gmp failing to install in tracemode with the latest changes to master.