### PR TITLE
portutil: Export DEVELOPER_DIR for target {} blocks

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1471,6 +1471,8 @@ proc target_run {ditem} {
                     if {[llength $deptypes] > 0} {tracelib setdeps $deplist}
                 }
 
+                # For {} blocks in the Portfile, export DEVELOPER_DIR to prevent Xcode binaries if shouldn't be used
+                set ::env(DEVELOPER_DIR) [option configure.developer_dir]
                 if {$result == 0} {
                     foreach pre [ditem_key $ditem pre] {
                         ui_debug "Executing $pre"
@@ -1500,6 +1502,8 @@ proc target_run {ditem} {
                         if {$result != 0} { break }
                     }
                 }
+                # Keep the environment clean by unsetting DEVELOPER_DIR
+                unset -nocomplain ::env(DEVELOPER_DIR)
 
                 # Check dependencies & file creations outside workpath.
                 if {[tbool ports_trace]


### PR DESCRIPTION
Doesn't work yet. We want to fix `system -W` resolving to Xcode binaries which we now hide in tracemode if the port isn't Xcode-dependent. Ports like libnetpbm, tig, and emacs now fail to install in tracemode because of this.

I've said in the mail that it was around 60 ports that use system -W, but there's actually 357 matches for system -W in macports-ports, which would be a headache to patch since we don't know which ones might resolve to an Xcode tool.

Is this the wrong way to do it? It works with exec, I'm naively assuming it'd be the same for system.
```tcl
% set ::env(DEVELOPER_DIR) /Library/Developer/CommandLineTools/
/Library/Developer/CommandLineTools/
% exec clang -v
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```