### PR TITLE
clang 3.9, 4.0 have been obsoleted, in favour of clang 8.0, so remove from fallback

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -946,21 +946,13 @@ proc portconfigure::get_clang_compilers {} {
         source ${compiler_file}
     } else {
         ui_debug "clang_compilers.tcl not found in ports tree, using built-in selections"
-        lappend compilers macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
-        if {${os.major} < 18} {
-            # see https://github.com/macports/macports-ports/commit/d387f4e4a47b298b1775ea8bf61772e2c2e6cd8b
-            lappend compilers macports-clang-4.0
-            if {${os.major} < 17} {
-                # The High Sierra SDK requires a toolchain that can apply nullability to uuid_t
-                lappend compilers macports-clang-3.9
-                if {${os.major} < 16} {
-                    # The Sierra SDK requires a toolchain that supports class properties
-                    lappend compilers macports-clang-3.7
-                    lappend compilers macports-clang-3.4
-                    if {${os.major} < 9} {
-                        lappend compilers macports-clang-3.3
-                    }
-                }
+        lappend compilers macports-clang-8.0 macports-clang-7.0 macports-clang-6.0 macports-clang-5.0
+        if {${os.major} < 16} {
+            # The Sierra SDK requires a toolchain that supports class properties
+            lappend compilers macports-clang-3.7
+            lappend compilers macports-clang-3.4
+            if {${os.major} < 9} {
+                lappend compilers macports-clang-3.3
             }
         }
     }


### PR DESCRIPTION
clang-3.9 and clang-4.0 have been obsoleted, in favour of clang-8.0.

```
> port info clang-3.9 clang-4.0
clang-3.9 @3.9.1_10 (lang)
Replaced by:          clang-8.0

Description:          This port has been replaced by clang-8.0.
Homepage:             https://www.macports.org

Platforms:            darwin
License:              NCSA
Maintainers:          Email: jeremyhu@macports.org, GitHub: jeremyhu
                      Email: larryv@macports.org, GitHub: larryv
--
clang-4.0 @4.0.1_7 (lang)
Replaced by:          clang-8.0

Description:          This port has been replaced by clang-8.0.
Homepage:             https://www.macports.org

Platforms:            darwin
License:              NCSA
Maintainers:          Email: jeremyhu@macports.org, GitHub: jeremyhu
                      Email: larryv@macports.org, GitHub: larryv
```

consequently base should remove them from the known compilers lists, otherwise they are still sometimes selected as a fallback, which fails. e.g.

https://paste.macports.org/a40c87f7f98d
