### PR TITLE
Remove reference to MP clang 3.9 and 4.0

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -601,12 +601,7 @@ proc portconfigure::get_compiler_fallback {} {
     }
     if {$our_stdlib eq "libc++"} {
         # clang-3.5+ require libc++
-        lappend compilers macports-clang-5.0 macports-clang-4.0
-
-        if {${os.major} < 17} {
-            # The High Sierra SDK requires a toolchain that can apply nullability to uuid_t
-            lappend compilers macports-clang-3.9
-        }
+        lappend compilers macports-clang-8.0 macports-clang-7.0 macports-clang-6.0 macports-clang-5.0 
 
         if {${os.major} < 16} {
             # The Sierra SDK requires a toolchain that supports class properties


### PR DESCRIPTION
backport changes in https://github.com/macports/macports-base/pull/137 to the 2.5.x branch.