### PR TITLE
macports.tcl: repeat xcode check for dependencies

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2102,6 +2102,7 @@ proc _mportexec {target mport} {
     set workername [ditem_key $mport workername]
     $workername eval {validate_macportsuser}
     if {![catch {$workername eval "check_variants $target"} result] && $result == 0 &&
+        ![catch {$workername eval {_check_xcode_version}} result] && $result == 0 &&
         ![catch {$workername eval {check_supported_archs}} result] && $result == 0 &&
         ![catch {$workername eval "eval_targets $target"} result] && $result == 0} {
         # If auto-clean mode, clean-up after dependency install

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3239,7 +3239,11 @@ proc check_supported_archs {} {
 
 # check if the installed xcode version is new enough
 proc _check_xcode_version {} {
-    global os.subplatform macosx_version xcodeversion use_xcode
+    global os.subplatform macosx_version xcodeversion use_xcode subport
+
+    if {[_archive_available]} {
+        return 0
+    }
 
     if {${os.subplatform} eq "macosx"} {
         switch $macosx_version {
@@ -3309,7 +3313,9 @@ proc _check_xcode_version {} {
                 ui_warn "You downloaded Xcode from the Mac App Store but didn't install it. Run \"Install Xcode\" in the /Applications folder."
             }
             if {[tbool use_xcode]} {
-                return -code error "This port requires the full Xcode installation, which was not found on your system. You can install Xcode from the Mac App Store or https://developer.apple.com/xcode/"
+                ui_error "Port ${subport} requires a full Xcode installation, which was not found on your system."
+                ui_error "You can install Xcode from the Mac App Store or https://developer.apple.com/xcode/"
+                return 1
             }
         } elseif {[vercmp $xcodeversion $min] < 0} {
             ui_error "The installed version of Xcode (${xcodeversion}) is too old to use on the installed OS version. Version $rec or later is recommended on macOS ${macosx_version}."


### PR DESCRIPTION
* repeat _check_xcode_version in _mportexec
* add portname in _check_xcode_version error message

Error out earlier if dependency needs Xcode.

Current behavior:
```
$ sudo port install gnuplot
--->  Computing dependencies for gnuplot
The following dependencies will be installed: 
 aquaterm
 libcaca
 libcerf
 lua
 wxWidgets-3.0
 wxWidgets-common
 wxWidgets_select
Continue? [Y/n]: Y
--->  Fetching distfiles for aquaterm
--->  Verifying checksums for aquaterm
--->  Extracting aquaterm
--->  Applying patches to aquaterm
--->  Configuring aquaterm
--->  Building aquaterm
Error: Failed to build aquaterm: command execution failed
Error: See /opt/local/var/macports/logs/_aqua_aquaterm/aquaterm/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port gnuplot failed
```

PR behavior:
```
$ sudo port install gnuplot
--->  Computing dependencies for gnuplot
The following dependencies will be installed: 
 aquaterm
 libcaca
 libcerf
 lua
 wxWidgets-3.0
 wxWidgets-common
 wxWidgets_select
Continue? [Y/n]: Y
Error: Port aquaterm requires the full Xcode installation, which was not found on your system. You can install Xcode from the Mac App Store or https://developer.apple.com/xcode/
Error: See /opt/local/var/macports/logs/_aqua_aquaterm/aquaterm/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets to report a bug.
Error: Processing of port gnuplot failed
```