### PR TITLE
porttrace: allow /var/db/timezone/zoneinfo/

### DIFF
--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -207,6 +207,9 @@ namespace eval porttrace {
             }
         }
 
+        # Allow timezone info
+        allow trace_sandbox "/var/db/timezone/zoneinfo/"
+
         # Allow access to SDK if it's not inside the Developer folder.
         if {${configure.sdkroot} ne ""} {
             allow trace_sandbox "${configure.sdkroot}"


### PR DESCRIPTION
```
Warning: The following existing file were hidden from the build system by trace mode:
  /var/db/timezone/zoneinfo/Asia/Jakarta
```
When installing 261 ports with tracemode, this message popped up [232] and [233] times respectively on 10.13 w/o Xcode and 10.14 w/ Xcode.

`/var/root/.CFUserTextEncoding` also popped up, but I don't know if that's as harmless as timezone.

[232]: https://paste.macports.org/8d4a12615e02
[233]: https://paste.macports.org/ba4702689b08
