### PR TITLE
macports1.0: Only check Xcode if building from src

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3237,10 +3237,6 @@ proc check_supported_archs {} {
 proc _check_xcode_version {} {
     global os.subplatform macosx_version xcodeversion use_xcode subport
 
-    if {[_archive_available]} {
-        return 0
-    }
-
     if {${os.subplatform} eq "macosx"} {
         switch $macosx_version {
             10.4 {


### PR DESCRIPTION
We don't need to check the Xcode version (or presence) if we're not going to build a port from source. This was previously achieved with a shortcut in `_check_xcode_version` that would always return 0 if an archive was available.

This fixes a situation where `_check_xcode_version` would indicate Xcode isn't required because an archive is available even though a user specifically asked for a build from source (e.g. when running 'sudo port destroot' on a port that sets `use_xcode yes`).

The newly introduced `_target_needs_toolchain` now returns `yes` for all cases where a toolchain is required regardless of archive availability and returns `yes` iff an archive is available for those targets that only need a toolchain when no prebuilt archive is being used.

Tested by applying these wonderfully hackish patches and attempting to install gnuplot (which depends on aquaterm, which – depending on whether you force archive availability to `yes` or `no` will throw an error about requiring Xcode):

```patch
diff --git a/src/macports1.0/macports.tcl b/src/macports1.0/macports.tcl
index 80e75700..91327e29 100644
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -426,6 +426,7 @@ proc macports::setxcodeinfo {name1 name2 op} {
     trace remove variable macports::xcodebuildcmd read macports::setxcodeinfo

     try -pass_signal {
+        error "fail immediately"
         set xcodebuild [findBinary xcodebuild $macports::autoconf::xcodebuild_path]
         if {![info exists xcodeversion]} {
             # Determine xcode version
diff --git a/src/port1.0/portutil.tcl b/src/port1.0/portutil.tcl
index abe349be..3f373926 100644
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3359,6 +3359,10 @@ proc _archive_available {} {
         return $archive_available_result
     }

+    if {[option subport] eq "aquaterm"} {
+        return 0
+    }
+
     if {[tbool ports_source_only]} {
         set archive_available_result 0
         return 0
```

See: https://github.com/macports/macports-base/pull/140