### PR TITLE
port1.0: Allow /var/db/mds/system in trace mode

### DIFF
--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -207,8 +207,9 @@ namespace eval porttrace {
             }
         }
 
-        # Allow timezone info
-        allow trace_sandbox "/var/db/timezone/zoneinfo/"
+        # Allow timezone info & access to system certificates
+        allow trace_sandbox "/var/db/timezone/zoneinfo"
+        allow trace_sandbox "/var/db/mds/system"
 
         # Allow access to SDK if it's not inside the Developer folder.
         if {${configure.sdkroot} ne ""} {


### PR DESCRIPTION
`/var/db/mds/system` is used when loading the system certificate store, so allow it in trace mode. This fixes trace mode builds using the haskell stack build system, which downloads things during the build phase.

Additionally, remove a trailing slash from the entry for `/var/db/timezone/zoneinfo`, which seems to have prevented it from working correctly.