### PR TITLE
use ##__VA_ARGS__ instead of __VA_ARGS__

### DIFF
--- a/src/darwintracelib1.0/darwintrace.h
+++ b/src/darwintracelib1.0/darwintrace.h
@@ -72,7 +72,7 @@ __attribute__((section ("__DATA,__interpose"))) = { \
 #if DARWINTRACE_DEBUG
 #	define debug_printf(format, ...) \
 		if (__darwintrace_stderr != NULL) { \
-			fprintf(__darwintrace_stderr, "darwintrace[%d:%p]: " format, getpid(), (void *) pthread_self(), __VA_ARGS__); \
+			fprintf(__darwintrace_stderr, "darwintrace[%d:%p]: " format, getpid(), (void *) pthread_self(), ##__VA_ARGS__); \
 			fflush(__darwintrace_stderr); \
 		}
 #else


### PR DESCRIPTION
On calling `debug_printf(format, …)`  if no variable args are passed, the current definition of the macro would cause errors.

Using ##__VA_ARGS__ would handle such a scenario by removing the trailing comma.