### PR TITLE
set $SDKROOT if configure.sdkroot is set

### DIFF
--- a/src/port1.0/portbuild.tcl
+++ b/src/port1.0/portbuild.tcl
@@ -195,6 +195,12 @@ proc portbuild::build_start {args} {
 proc portbuild::build_main {args} {
     global build.cmd
 
+    global configure.sdkroot
+    if { ${configure.sdkroot} ne "" } {
+        ui_debug "setting build SDKROOT to ${configure.sdkroot}"
+        build.env-append "SDKROOT=${configure.sdkroot}"
+    }
+
     set jobs_suffix [build_getjobsarg]
 
     set realcmd ${build.cmd}

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -1477,6 +1477,8 @@ proc portconfigure::configure_main {args} {
                 append_to_environment_value configure $env_var -isysroot${configure.sdkroot}
             }
             append_to_environment_value configure "LDFLAGS" -Wl,-syslibroot,${configure.sdkroot}
+            ui_debug "setting configure SDKROOT to ${configure.sdkroot}"
+            append_to_environment_value configure "SDKROOT" ${configure.sdkroot}
         }
 
         # add extra flags that are conditional on whether we're building universal

--- a/src/port1.0/portdestroot.tcl
+++ b/src/port1.0/portdestroot.tcl
@@ -121,6 +121,13 @@ proc portdestroot::destroot_start {args} {
 }
 
 proc portdestroot::destroot_main {args} {
+
+    global configure.sdkroot
+    if { ${configure.sdkroot} ne "" } {
+        ui_debug "setting destroot SDKROOT to ${configure.sdkroot}"
+        destroot.env-append "SDKROOT=${configure.sdkroot}"
+    }
+
     command_exec destroot
     return 0
 }


### PR DESCRIPTION
current and recent versions of xcrun look to $SDKROOT
to decide which macOS SDK to choose. If none is set, then
xcrun defaults to the current macOS SDK.

if the user has selected a specific SDK to use by setting
configure.sdkroot, honour that setting by setting $SDKROOT

this has to be done in all port phases where xcrun might be called,
ie configure, build, and destroot