### PR TITLE
don't use Apple clang if libc++ on 10.6.8

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -739,9 +739,8 @@ proc portconfigure::get_min_command_line {compiler} {
     switch ${compiler} {
         clang {
             if {[option configure.cxx_stdlib] eq "libc++"} {
-                set cxx [file tail [portconfigure::configure_get_compiler cxx ${compiler}]]
-                if {${cxx} ne "clang++"} {
-                    # 3.2 <= Xcode < 4.0 does not provide clang++
+                if {${os.major} < 11} {
+                    # no Xcode clang can build against libc++ on < 10.7
                     return none
                 }
             }


### PR DESCRIPTION
No Apple clang can build on 10.6.8 against libc++
only macports-clang-* compilers will so so

This fixes my corner case where I used Xcode 4.2 with MacPorts 2.6 on 10.6.8, and portconfigure.tcl was returning "clang" for the compiler (which failed).
