### PR TITLE
Basic target progress bar support

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1409,9 +1409,13 @@ proc macports::worker_init {workername portpath porturl portbuildpath options va
     foreach priority $macports::ui_priorities {
         $workername alias ui_$priority ui_$priority
     }
-    # add the UI progress call-back
-    if {[info exists macports::ui_options(progress_download)]} {
-        $workername alias ui_progress_download $macports::ui_options(progress_download)
+    # add the UI progress call-backs (or a no-op alias, if unavailable)
+    foreach pname {progress_download progress_generic} {
+        if {[info exists macports::ui_options($pname)]} {
+            $workername alias ui_$pname $macports::ui_options($pname)
+        } else {
+            $workername alias ui_$pname return -level 0
+        }
     }
 
     # notifications callback

--- a/src/package1.0/portarchivefetch.tcl
+++ b/src/package1.0/portarchivefetch.tcl
@@ -196,7 +196,7 @@ proc portarchivefetch::fetchfiles {args} {
     if {$portverbose eq "yes"} {
         lappend fetch_options "--progress"
         lappend fetch_options "builtin"
-    } elseif {[llength [info commands ui_progress_download]] > 0} {
+    } else {
         lappend fetch_options "--progress"
         lappend fetch_options "ui_progress_download"
     }

--- a/src/pextlib1.0/system.c
+++ b/src/pextlib1.0/system.c
@@ -49,6 +49,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/resource.h>
+#include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
@@ -79,6 +80,40 @@ extern char **environ;
 #define _PATH_DEVNULL "/dev/null"
 #endif
 
+#define SYSEVENT_TYPE_KEY               "type"
+#define SYSEVENT_PID_KEY                "pid"
+
+#define SYSEVENT_TYPE_EXEC              "exec"
+#define SYSEVENT_TYPE_EXIT              "exit"
+#define SYSEVENT_TYPE_STDIN             "stdin"
+
+#define SYSEVENT_STDIN_LINE_KEY         "line"
+
+#define SYSEVENT_EXIT_STATUS_KEY        "exit_status"
+
+#define SYSEVENT_SIGNALED               "signaled"
+#define SYSEVENT_SIGNAL_ID_KEY          "signal_id"
+#define SYSEVENT_SIGNAL_MSG_KEY         "signal_msg"
+
+#define SYSEVENT_EXITED                 "exited"
+#define SYSEVENT_EXITED_CODE_KEY        "exit_code"
+
+#define SYSEVENT_IOERR                  "ioerr"
+#define SYSEVENT_EXIT_IOERR_ERRNO_KEY   "io_errno"
+#define SYSEVENT_EXIT_IOERR_MSG_KEY     "io_message"
+
+typedef struct SystemCmd_Callback {
+    Tcl_Interp  *interp;            /**< interpreter */
+    Tcl_Obj     *proc;              /**< callback proc */
+    Tcl_Obj     *pid;               /**< child process pid, or NULL if child has not yet been executed */
+
+    /* Commonly used event keys and values */
+    Tcl_Obj     *type_key;          /**< cached event type dictionary key */
+    Tcl_Obj     *pid_key;           /**< cached event pid dictionary key */
+    Tcl_Obj     *stdin_type;        /**< cached stdin event type */
+    Tcl_Obj     *stdin_line_key;    /**< cached stdin line dictionary key */
+} SystemCmd_Callback;
+
 static int check_sandboxing(Tcl_Interp *interp, char **sandbox_exec_path, char **profilestr)
 {
     Tcl_Obj *tcl_result;
@@ -104,12 +139,115 @@ static int check_sandboxing(Tcl_Interp *interp, char **sandbox_exec_path, char *
     return 1;
 }
 
+static int SystemCmd_Callback_Create(Tcl_Interp *interp, Tcl_Obj *callbackProc, SystemCmd_Callback **cb)
+{
+    SystemCmd_Callback *result;
+
+    if ((result = malloc(sizeof(*result))) == NULL) {
+            Tcl_SetResult(interp, strerror(errno), TCL_STATIC);
+            return TCL_ERROR;
+    }
+
+    *result = (struct SystemCmd_Callback) {
+        .interp = interp,
+        .proc = callbackProc,
+        .type_key = Tcl_NewStringObj(SYSEVENT_TYPE_KEY, -1),
+        .pid_key = Tcl_NewStringObj(SYSEVENT_PID_KEY, -1),
+        .pid = NULL,
+        .stdin_type = Tcl_NewStringObj(SYSEVENT_TYPE_STDIN, -1),
+        .stdin_line_key = Tcl_NewStringObj(SYSEVENT_STDIN_LINE_KEY, -1)
+    };
+
+    Tcl_IncrRefCount(result->proc);
+    Tcl_IncrRefCount(result->type_key);
+    Tcl_IncrRefCount(result->pid_key);
+    Tcl_IncrRefCount(result->stdin_type);
+    Tcl_IncrRefCount(result->stdin_line_key);
+
+    *cb = result;
+    return TCL_OK;
+}
+
+static void SystemCmd_Callback_Free(SystemCmd_Callback *cb)
+{
+    Tcl_DecrRefCount(cb->proc);
+    Tcl_DecrRefCount(cb->type_key);
+    Tcl_DecrRefCount(cb->pid_key);
+    Tcl_DecrRefCount(cb->stdin_type);
+    Tcl_DecrRefCount(cb->stdin_line_key);
+
+    if (cb->pid != NULL)
+        Tcl_DecrRefCount(cb->pid);
+
+    free(cb);
+}
+
+static void SystemCmd_Callback_SetPid(SystemCmd_Callback *cb, pid_t pid)
+{
+    if (cb->pid != NULL)
+        Tcl_DecrRefCount(cb->pid);
+
+    cb->pid = Tcl_NewWideIntObj(pid);
+    Tcl_IncrRefCount(cb->pid);
+}
+
+static int SystemCmd_Callback_Invoke(SystemCmd_Callback *cb, Tcl_Obj *event)
+{
+    Tcl_Obj *objv[] = { cb->proc, event };
+    return Tcl_EvalObjv(cb->interp, (sizeof(objv)/sizeof(objv[0])), objv, TCL_EVAL_GLOBAL);
+}
+
+static Tcl_Obj *SystemCmd_Event_Create(SystemCmd_Callback *cb, Tcl_Obj *type)
+{
+    Tcl_Obj *event = Tcl_NewDictObj();
+
+    assert(cb->pid != NULL);
+
+    Tcl_DictObjPut(cb->interp, event, cb->type_key, type);
+    Tcl_DictObjPut(cb->interp, event, cb->pid_key, cb->pid);
+
+    Tcl_IncrRefCount(event);
+    return event;
+}
+
+static void SystemCmd_Event_Release(Tcl_Obj *event)
+{
+    Tcl_DecrRefCount(event);
+}
+
+static void SystemCmd_Event_SetExitType(SystemCmd_Callback *cb, Tcl_Obj *event, const char *exit_type)
+{
+    Tcl_DictObjPut(cb->interp, event, Tcl_NewStringObj(SYSEVENT_EXIT_STATUS_KEY,-1),        Tcl_NewStringObj(exit_type, -1));
+}
+
+static void SystemCmd_Event_SetExitCode(SystemCmd_Callback *cb, Tcl_Obj *event, int exit_code)
+{
+    Tcl_DictObjPut(cb->interp, event, Tcl_NewStringObj(SYSEVENT_EXITED_CODE_KEY,-1),        Tcl_NewIntObj(exit_code));
+}
+
+static void SystemCmd_Event_SetLine(SystemCmd_Callback *cb, Tcl_Obj *event, Tcl_Obj *line)
+{
+    Tcl_DictObjPut(cb->interp, event, cb->stdin_line_key, line);
+}
+
+static void SystemCmd_Event_SetIOError(SystemCmd_Callback *cb, Tcl_Obj *event, int error)
+{
+    Tcl_DictObjPut(cb->interp, event, Tcl_NewStringObj(SYSEVENT_EXIT_IOERR_ERRNO_KEY, -1),  Tcl_NewIntObj(error));
+    Tcl_DictObjPut(cb->interp, event, Tcl_NewStringObj(SYSEVENT_EXIT_IOERR_MSG_KEY, -1),    Tcl_NewStringObj(strerror(error), -1));
+}
+
+static void SystemCmd_Event_SetSignaled(SystemCmd_Callback *cb, Tcl_Obj *event, int signal)
+{
+    Tcl_DictObjPut(cb->interp, event, Tcl_NewStringObj(SYSEVENT_SIGNAL_ID_KEY,-1),          Tcl_NewStringObj(Tcl_SignalId(signal), -1));
+    Tcl_DictObjPut(cb->interp, event, Tcl_NewStringObj(SYSEVENT_SIGNAL_MSG_KEY,-1),         Tcl_NewStringObj(Tcl_SignalMsg(signal), -1));
+}
+
 static volatile sig_atomic_t interrupted_by = 0;
 static void handle_sigint(int s) {
     interrupted_by = s;
 }
 
-/* usage: system ?-notty? ?-nodup? ?-nice value? ?-W path? command */
+/* usage: system ?-callback proc? ?-notty? ?-nodup? ?-nice value? ?-W path? command */
 int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
     char *args[7];
@@ -118,7 +256,8 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
     char *sandbox_exec_path = NULL;
     char *profilestr = NULL;
     FILE *pdes;
-    int fdset[2], nullfd;
+    int fdset[2] = { -1, -1 };
+    int nullfd;
     int ret;
     int osetsid = 0;
     int odup = 1; /* redirect stdin/stdout/stderr by default */
@@ -127,12 +266,13 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
     pid_t pid;
     uid_t euid;
     Tcl_Obj *tcl_result;
+    SystemCmd_Callback *callback = NULL;
     int read_failed = 0;
     int status;
     int i;
 
     if (objc < 2) {
-        Tcl_WrongNumArgs(interp, 1, objv, "?-notty? ?-nice value? ?-W path? command");
+        Tcl_WrongNumArgs(interp, 1, objv, "?-callback proc? ?-notty? ?-nice value? ?-W path? command");
         return TCL_ERROR;
     }
 
@@ -140,22 +280,40 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 
     for (i = 1; i < objc - 1; i++) {
         char *arg = Tcl_GetString(objv[i]);
-        if (strcmp(arg, "-notty") == 0) {
+        if (strcmp(arg, "-callback") == 0) {
+            if (++i >= objc) {
+                Tcl_WrongNumArgs(interp, 1, objv, "proc");
+                return TCL_ERROR;
+            }
+
+            if ((status = SystemCmd_Callback_Create(interp, objv[i], &callback)) != TCL_OK)
+                return status;
+        } else if (strcmp(arg, "-notty") == 0) {
             osetsid = 1;
         } else if (strcmp(arg, "-nodup") == 0) {
             odup = 0;
         } else if (strcmp(arg, "-nice") == 0) {
-            i++;
+            if (++i >= objc) {
+                Tcl_WrongNumArgs(interp, 1, objv, "value");
+                return TCL_ERROR;
+            }
+
             if (Tcl_GetIntFromObj(interp, objv[i], &oniceval) != TCL_OK) {
                 Tcl_SetResult(interp, "invalid value for -nice", TCL_STATIC);
                 return TCL_ERROR;
             }
         } else if (strcmp(arg, "-W") == 0) {
-            i++;
+            if (++i >= objc) {
+                Tcl_WrongNumArgs(interp, 1, objv, "path");
+                return TCL_ERROR;
+            }
+
             if ((path = Tcl_GetString(objv[i])) == NULL) {
                 Tcl_SetResult(interp, "invalid value for -W", TCL_STATIC);
                 return TCL_ERROR;
             }
+        } else if (strcmp(arg, "--") == 0) {
+            break;
         } else {
             tcl_result = Tcl_NewStringObj("bad option ", -1);
             Tcl_AppendObjToObj(tcl_result, Tcl_NewStringObj(arg, -1));
@@ -213,6 +371,7 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
     case 0: /* child */
         if (odup) {
             close(fdset[0]);
+            fdset[0] = -1;
 
             if ((nullfd = open(_PATH_DEVNULL, O_RDONLY)) == -1)
                 _exit(1);
@@ -278,11 +437,29 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
         exit(128);
         /*NOTREACHED*/
     default: /* parent */
+        if (callback != NULL) {
+            /* Must be done before creating any events from the callback context */
+            SystemCmd_Callback_SetPid(callback, pid);
+        }
+
         break;
+    }
+
+    /* Inform the callback of our exec event */
+    if (callback != NULL) {
+        Tcl_Obj *event;
+
+        event = SystemCmd_Event_Create(callback, Tcl_NewStringObj(SYSEVENT_TYPE_EXEC,-1));
+        status = SystemCmd_Callback_Invoke(callback, event);
+        SystemCmd_Event_Release(event);
+
+        if (status != TCL_OK)
+            goto cleanup;
     }
 
     if (odup) {
         close(fdset[1]);
+        fdset[1] = -1;
 
         /* read from simulated popen() pipe */
         read_failed = 0;
@@ -292,30 +469,133 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
             size_t linesz = 0;
             ssize_t linelen;
 
+            status = TCL_OK;
             while ((linelen = getline(&line, &linesz, pdes)) > 0) {
                 /* replace '\n' if it exists */
                 if (line[linelen - 1] == '\n') {
                     line[linelen - 1] = '\0';
                 }
 
+                /* Provide the line event to our callback */
+                if (callback != NULL) {
+                    Tcl_Obj *event = SystemCmd_Event_Create(callback, callback->stdin_type);
+
+                    SystemCmd_Event_SetLine(callback, event, Tcl_NewStringObj(line,linelen));
+                    status = SystemCmd_Callback_Invoke(callback, event);
+                    SystemCmd_Event_Release(event);
+
+                    if (status != TCL_OK) {
+                        free(line);
+                        fclose(pdes);
+                        goto cleanup;
+                    }
+                }
+
                 ui_info(interp, "%s", line);
             }
+
             free(line);
             fclose(pdes);
         } else {
+            int error = errno;
+
+            /* Provide the exit event to our callback */
+            if (callback != NULL) {
+                Tcl_Obj *event = SystemCmd_Event_Create(callback, Tcl_NewStringObj(SYSEVENT_EXITED,-1));
+
+                SystemCmd_Event_SetExitType(callback, event, SYSEVENT_IOERR);
+                SystemCmd_Event_SetIOError(callback, event, error);
+
+                status = SystemCmd_Callback_Invoke(callback, event);
+                SystemCmd_Event_Release(event);
+
+                if (status != TCL_OK)
+                    goto cleanup;
+            }
+
+            Tcl_SetResult(interp, strerror(error), TCL_STATIC);
             read_failed = 1;
-            Tcl_SetResult(interp, strerror(errno), TCL_STATIC);
+            status = TCL_ERROR;
         }
     }
 
     status = TCL_ERROR;
-
     if (wait(&ret) == pid && (WIFEXITED(ret) || WIFSIGNALED(ret)) && !read_failed) {
+        Tcl_Obj *event = NULL;
+
+        /* Populate common exit event fields */
+        if (callback != NULL) {
+            /* Determine the exit status type */
+            const char *exit_type = NULL;
+            if (WIFEXITED(ret)) {
+                exit_type = SYSEVENT_EXITED;
+            } else if (WIFSIGNALED(ret) || interrupted_by != 0) {
+                exit_type = SYSEVENT_SIGNALED;
+            } else {
+                Tcl_SetObjResult(interp, Tcl_ObjPrintf("unhandled exit status: %d", ret));
+                status = TCL_ERROR;
+                goto cleanup;
+            }
+
+            /* Populate a new exit event with exit_status and exit_code */
+            event = SystemCmd_Event_Create(callback, Tcl_NewStringObj(SYSEVENT_TYPE_EXIT,-1));
+            SystemCmd_Event_SetExitType(callback, event, exit_type);
+            SystemCmd_Event_SetExitCode(callback, event, WEXITSTATUS(ret));
+        }
+
         /* Normal exit, and reading from the pipe didn't fail. */
         if (WIFEXITED(ret) && WEXITSTATUS(ret) == 0) {
+            /* Report the exit to our callback */
+            if (callback != NULL) {
+                status = SystemCmd_Callback_Invoke(callback, event);
+                SystemCmd_Event_Release(event);
+                if (status != TCL_OK)
+                    goto cleanup;
+            }
+
             status = TCL_OK;
         } else {
-            Tcl_Obj* errorCode;
+            Tcl_Obj *errorCode = Tcl_NewListObj(0, NULL);
+            Tcl_IncrRefCount(errorCode);
+
+            if (interrupted_by != 0) {
+                /* Add signal keys to our exit event */
+                if (event != NULL)
+                    SystemCmd_Event_SetSignaled(callback, event, interrupted_by);
+
+                /* set errorCode [list POSIX SIG <SIGNAME> <signal descripton>] */
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("POSIX", -1));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("SIG", -1));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalId(interrupted_by), -1));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalMsg(interrupted_by), -1));
+                tcl_result = Tcl_NewStringObj("interrupted by signal", -1);
+            } else if (WIFEXITED(ret)) {
+                /* set errorCode [list CHILDSTATUS <pid> <code>] */
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("CHILDSTATUS", -1));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewWideIntObj(pid));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewIntObj(WEXITSTATUS(ret)));
+                Tcl_SetObjErrorCode(interp, errorCode);
+                tcl_result = Tcl_NewStringObj("command execution failed", -1);
+            } else if (WIFSIGNALED(ret)) {
+                /* Add signal keys to our exit event */
+                if (event != NULL)
+                    SystemCmd_Event_SetSignaled(callback, event, WTERMSIG(ret));
+
+                /* set errorCode [list CHILDKILLED <pid> <SIGNAME> <signal descripton>] */
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("CHILDKILLED", -1));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewWideIntObj(pid));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalId(WTERMSIG(ret)), -1));
+                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalMsg(WTERMSIG(ret)), -1));
+                tcl_result = Tcl_NewStringObj("command execution failed", -1);
+            }
+
+            /* Report the exit to our callback */
+            if (callback != NULL) {
+                status = SystemCmd_Callback_Invoke(callback, event);
+                SystemCmd_Event_Release(event);
+                if (status != TCL_OK)
+                    goto cleanup;
+            }
 
             /* print error */
             ui_info(interp, "Command failed: %s", cmdstring);
@@ -325,31 +605,11 @@ int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
                 ui_info(interp, "Killed by signal: %d", WTERMSIG(ret));
             }
 
-            errorCode = Tcl_NewListObj(0, NULL);
-            if (interrupted_by != 0) {
-                /* set errorCode [list POSIX SIG <SIGNAME> <signal descripton>] */
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("POSIX", -1));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("SIG", -1));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalId(interrupted_by), -1));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalMsg(interrupted_by), -1));
-                Tcl_SetObjErrorCode(interp, errorCode);
-                Tcl_SetObjResult(interp, Tcl_NewStringObj("interrupted by signal", -1));
-            } else if (WIFEXITED(ret)) {
-                /* set errorCode [list CHILDSTATUS <pid> <code>] */
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("CHILDSTATUS", -1));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewIntObj(pid));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewIntObj(WEXITSTATUS(ret)));
-                Tcl_SetObjErrorCode(interp, errorCode);
-                Tcl_SetObjResult(interp, Tcl_NewStringObj("command execution failed", -1));
-            } else if (WIFSIGNALED(ret)) {
-                /* set errorCode [list CHILDKILLED <pid> <SIGNAME> <signal descripton>] */
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj("CHILDKILLED", -1));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewIntObj(pid));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalId(WTERMSIG(ret)), -1));
-                Tcl_ListObjAppendElement(interp, errorCode, Tcl_NewStringObj(Tcl_SignalMsg(WTERMSIG(ret)), -1));
-                Tcl_SetObjErrorCode(interp, errorCode);
-                Tcl_SetObjResult(interp, Tcl_NewStringObj("command execution failed", -1));
-            }
+            /* Set the error result */
+            Tcl_SetObjErrorCode(interp, errorCode);
+            Tcl_SetObjResult(interp, tcl_result);
+            Tcl_DecrRefCount(errorCode);
+            status = TCL_ERROR;
         }
     }
 
@@ -358,10 +618,15 @@ cleanup:
     sigaction(SIGINT, &old_sa_int, NULL);
     sigaction(SIGQUIT, &old_sa_quit, NULL);
 
-    if (odup) {
-        /* Cleanup. */
+    /* Cleanup. */
+    if (fdset[0] >= 0)
         close(fdset[0]);
-    }
+
+    if (fdset[1] >= 0)
+        close(fdset[1]);
+
+    if (callback != NULL)
+        SystemCmd_Callback_Free(callback);
 
     return status;
 }

--- a/src/port1.0/Makefile.in
+++ b/src/port1.0/Makefile.in
@@ -7,7 +7,7 @@ INSTALLDIR=	${TCL_PACKAGE_PATH}/port1.0
 
 SRCS_AUTOCONF= port_autoconf.tcl
 SRCS=	port.tcl portchecksum.tcl portconfigure.tcl portextract.tcl	    \
-	portfetch.tcl portmain.tcl portbuild.tcl portpatch.tcl portutil.tcl \
+	portfetch.tcl portmain.tcl portbuild.tcl portpatch.tcl portprogress.tcl portutil.tcl \
 	portinstall.tcl portuninstall.tcl portdepends.tcl portdestroot.tcl \
 	portlint.tcl portclean.tcl porttest.tcl portactivate.tcl portbump.tcl \
 	portdeactivate.tcl portstartupitem.tcl porttrace.tcl portlivecheck.tcl \

--- a/src/port1.0/portbuild.tcl
+++ b/src/port1.0/portbuild.tcl
@@ -200,7 +200,7 @@ proc portbuild::build_main {args} {
 
     set realcmd ${build.cmd}
     set build.cmd "${build.cmd}$jobs_suffix"
-    command_exec -callback portprogress::system_progress_callback build
+    command_exec -callback portprogress::target_progress_callback build
     set build.cmd ${realcmd}
     return 0
 }

--- a/src/port1.0/portbuild.tcl
+++ b/src/port1.0/portbuild.tcl
@@ -32,6 +32,7 @@
 
 package provide portbuild 1.0
 package require portutil 1.0
+package require portprogress 1.0
 
 set org.macports.build [target_new org.macports.build portbuild::build_main]
 target_provides ${org.macports.build} build
@@ -199,7 +200,7 @@ proc portbuild::build_main {args} {
 
     set realcmd ${build.cmd}
     set build.cmd "${build.cmd}$jobs_suffix"
-    command_exec build
+    command_exec -callback portprogress::system_progress_callback build
     set build.cmd ${realcmd}
     return 0
 }

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -32,6 +32,7 @@
 
 package provide portconfigure 1.0
 package require portutil 1.0
+package require portprogress 1.0
 
 set org.macports.configure [target_new org.macports.configure portconfigure::configure_main]
 target_provides ${org.macports.configure} configure
@@ -1404,32 +1405,34 @@ proc portconfigure::configure_main {args} {
         global configure.${flags} configure.universal_${flags}
     }
 
+    set callback [list "-callback" portprogress::system_progress_callback]
+
     if {[tbool use_autoreconf]} {
-        if {[catch {command_exec autoreconf} result]} {
+        if {[catch {command_exec {*}${callback} autoreconf} result]} {
             return -code error "[format [msgcat::mc "%s failure: %s"] autoreconf $result]"
         }
     }
 
     if {[tbool use_automake]} {
-        if {[catch {command_exec automake} result]} {
+        if {[catch {command_exec {*}${callback} automake} result]} {
             return -code error "[format [msgcat::mc "%s failure: %s"] automake $result]"
         }
     }
 
     if {[tbool use_autoconf]} {
-        if {[catch {command_exec autoconf} result]} {
+        if {[catch {command_exec {*}${callback} autoconf} result]} {
             return -code error "[format [msgcat::mc "%s failure: %s"] autoconf $result]"
         }
     }
 
     if {[tbool use_xmkmf]} {
         parse_environment xmkmf
-        if {[catch {command_exec xmkmf} result]} {
+        if {[catch {command_exec {*}${callback} xmkmf} result]} {
             return -code error "[format [msgcat::mc "%s failure: %s"] xmkmf $result]"
         }
 
         parse_environment xmkmf
-        if {[catch {command_exec "cd ${worksrcpath} && make Makefiles" -varprefix xmkmf} result]} {
+        if {[catch {command_exec {*}${callback} "cd ${worksrcpath} && make Makefiles" -varprefix xmkmf} result]} {
             return -code error "[format [msgcat::mc "%s failure: %s"] "make Makefiles" $result]"
         }
     } elseif {[tbool use_configure]} {
@@ -1519,7 +1522,7 @@ proc portconfigure::configure_main {args} {
         }
 
         # Execute the command (with the new environment).
-        if {[catch {command_exec configure} result]} {
+        if {[catch {command_exec {*}${callback} configure} result]} {
             global configure.dir
             if {[file exists ${configure.dir}/config.log]} {
                 ui_error "[format [msgcat::mc "Failed to configure %s, consult %s/config.log"] [option subport] ${configure.dir}]"

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -1405,7 +1405,7 @@ proc portconfigure::configure_main {args} {
         global configure.${flags} configure.universal_${flags}
     }
 
-    set callback [list "-callback" portprogress::system_progress_callback]
+    set callback [list "-callback" portprogress::target_progress_callback]
 
     if {[tbool use_autoreconf]} {
         if {[catch {command_exec {*}${callback} autoreconf} result]} {

--- a/src/port1.0/portdestroot.tcl
+++ b/src/port1.0/portdestroot.tcl
@@ -121,7 +121,7 @@ proc portdestroot::destroot_start {args} {
 }
 
 proc portdestroot::destroot_main {args} {
-    command_exec destroot
+    command_exec -callback portprogress::system_progress_callback destroot
     return 0
 }
 

--- a/src/port1.0/portdestroot.tcl
+++ b/src/port1.0/portdestroot.tcl
@@ -121,7 +121,7 @@ proc portdestroot::destroot_start {args} {
 }
 
 proc portdestroot::destroot_main {args} {
-    command_exec -callback portprogress::system_progress_callback destroot
+    command_exec -callback portprogress::target_progress_callback destroot
     return 0
 }
 

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -536,7 +536,7 @@ proc portfetch::fetchfiles {args} {
     if {$portverbose eq "yes"} {
         lappend fetch_options "--progress"
         lappend fetch_options "builtin"
-    } elseif {[llength [info commands ui_progress_download]] > 0} {
+    } else {
         lappend fetch_options "--progress"
         lappend fetch_options "ui_progress_download"
     }

--- a/src/port1.0/portprogress.tcl
+++ b/src/port1.0/portprogress.tcl
@@ -45,9 +45,9 @@ namespace eval portprogress {
     variable indeterminate             yes
 }
 
-# A SystemCmd callback that parses common progress formats to display
+# A SystemCmd callback that parses common target progress formats to display
 # a progress bar
-proc portprogress::system_progress_callback {event} {
+proc portprogress::target_progress_callback {event} {
     global portverbose
     variable indeterminate
     variable indeterminate_timer

--- a/src/port1.0/portprogress.tcl
+++ b/src/port1.0/portprogress.tcl
@@ -1,0 +1,110 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+#
+# Copyright (c) 2002-2003 Apple Inc.
+# Copyright (c) 2004-2014, 2016-2019 The MacPorts Project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of Apple Inc. nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+package provide portprogress 1.0
+package require portutil 1.0
+package require Pextlib 1.0
+
+namespace eval portprogress {
+    # The time in milliseconds to wait before we switch our progress bar from
+    # determinate to indeterminate
+    variable indeterminate_threshold   3000
+
+    # The time (in milliseconds since epoch) since our progress callback last
+    # produced a determinate progress update.
+    variable indeterminate_timer       0
+
+    # If our progress callback should issue indeterminate progress updates
+    variable indeterminate             yes
+}
+
+# A SystemCmd callback that parses common progress formats to display
+# a progress bar
+proc portprogress::system_progress_callback {event} {
+    global portverbose
+    variable indeterminate
+    variable indeterminate_timer
+    variable indeterminate_threshold
+
+    if {${portverbose}} {
+        return
+    }
+
+    switch -- [dict get $event type] {
+        exec {
+            set indeterminate yes
+            set indeterminate_timer 0
+            ui_progress_generic start
+        }
+        stdin {
+            set line [dict get $event line]
+
+            # Try to parse the build line
+            set determinate_match no
+            set cur 1
+            set total 0
+
+            # ninja ([<completed tasks>/<pending tasks>])
+            if {[regexp {^\[([1-9][0-9]*)/([1-9][0-9]*)\].*} ${line} -> cur total]} {
+                set determinate_match yes
+
+            # cmake makefiles ([<percentage>%])
+            } elseif {[regexp {^\[\s*([1-9][0-9]*)%\].*} ${line} -> cur]} {
+                set total 100
+                set determinate_match yes
+
+            # No match
+            } else {
+                set cur 1
+                set total 0
+            }
+
+            if {${determinate_match}} {
+                set indeterminate no
+                set indeterminate_timer [clock milliseconds]
+            } elseif {!${indeterminate}} {
+                set time_last $indeterminate_timer
+                set time_now [clock milliseconds]
+                set time_diff [expr { $time_now - $time_last }]
+
+                if {${time_diff} >= ${indeterminate_threshold}} {
+                    set indeterminate yes
+                }
+            }
+
+            if {${determinate_match} || ${indeterminate}} {
+                ui_progress_generic update ${cur} ${total}
+            }
+        }
+        exit {
+            ui_progress_generic finish
+        }
+    }
+}

--- a/src/port1.0/portprogress.tcl
+++ b/src/port1.0/portprogress.tcl
@@ -1,7 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 #
-# Copyright (c) 2002-2003 Apple Inc.
-# Copyright (c) 2004-2014, 2016-2019 The MacPorts Project
+# Copyright (c) 2019-2020 The MacPorts Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,14 +34,14 @@ package require Pextlib 1.0
 namespace eval portprogress {
     # The time in milliseconds to wait before we switch our progress bar from
     # determinate to indeterminate
-    variable indeterminate_threshold   3000
+    variable indeterminate_threshold    10000
 
     # The time (in milliseconds since epoch) since our progress callback last
     # produced a determinate progress update.
-    variable indeterminate_timer       0
+    variable indeterminate_timer        0
 
     # If our progress callback should issue indeterminate progress updates
-    variable indeterminate             yes
+    variable indeterminate              yes
 
     # ninja ([<completed tasks>/<pending tasks>])
     variable ninja_line_re              {^\[([1-9][0-9]*)/([1-9][0-9]*)\].*}

--- a/src/port1.0/portprogress.tcl
+++ b/src/port1.0/portprogress.tcl
@@ -43,6 +43,12 @@ namespace eval portprogress {
 
     # If our progress callback should issue indeterminate progress updates
     variable indeterminate             yes
+
+    # ninja ([<completed tasks>/<pending tasks>])
+    variable ninja_line_re              {^\[([1-9][0-9]*)/([1-9][0-9]*)\].*}
+
+    # cmake makefiles ([<percentage>%])
+    variable cmake_line_re              {^\[\s*([1-9][0-9]*)%\].*}
 }
 
 # A SystemCmd callback that parses common target progress formats to display
@@ -52,6 +58,8 @@ proc portprogress::target_progress_callback {event} {
     variable indeterminate
     variable indeterminate_timer
     variable indeterminate_threshold
+    variable ninja_line_re
+    variable cmake_line_re
 
     if {${portverbose}} {
         return
@@ -72,11 +80,11 @@ proc portprogress::target_progress_callback {event} {
             set total 0
 
             # ninja ([<completed tasks>/<pending tasks>])
-            if {[regexp {^\[([1-9][0-9]*)/([1-9][0-9]*)\].*} ${line} -> cur total]} {
+            if {[regexp $ninja_line_re ${line} -> cur total]} {
                 set determinate_match yes
 
             # cmake makefiles ([<percentage>%])
-            } elseif {[regexp {^\[\s*([1-9][0-9]*)%\].*} ${line} -> cur]} {
+            } elseif {[regexp $cmake_line_re ${line} -> cur]} {
                 set total 100
                 set determinate_match yes
 

--- a/src/port1.0/porttest.tcl
+++ b/src/port1.0/porttest.tcl
@@ -3,6 +3,7 @@
 
 package provide porttest 1.0
 package require portutil 1.0
+package require portprogress 1.0
 
 set org.macports.test [target_new org.macports.test porttest::test_main]
 target_provides ${org.macports.test} test
@@ -32,7 +33,7 @@ proc porttest::test_start {args} {
 proc porttest::test_main {args} {
     global subport test.run
     if {[tbool test.run]} {
-        command_exec test
+        command_exec -callback portprogress::system_progress_callback test
     } else {
     return -code error [format [msgcat::mc "%s has no tests turned on. see 'test.run' in portfile(7)"] $subport]
     }

--- a/src/port1.0/porttest.tcl
+++ b/src/port1.0/porttest.tcl
@@ -33,7 +33,7 @@ proc porttest::test_start {args} {
 proc porttest::test_main {args} {
     global subport test.run
     if {[tbool test.run]} {
-        command_exec -callback portprogress::system_progress_callback test
+        command_exec -callback portprogress::target_progress_callback test
     } else {
     return -code error [format [msgcat::mc "%s has no tests turned on. see 'test.run' in portfile(7)"] $subport]
     }


### PR DESCRIPTION
- Parses ninja and cmake makefile output to display determinate progress bars.
- If there's nothing to be parsed (or its been too long since parsing succeeded), switches to an indeterminate progress bar.