### PR TITLE
gcc_min_version: always allow macports-gcc on PowerPC

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -837,8 +837,12 @@ proc portconfigure::get_min_clang {} {
 proc portconfigure::get_min_gcc {} {
     global compiler.c_standard compiler.cxx_standard compiler.openmp_version compiler.thread_local_storage
 
+    # on Intel systems configured to libstdc++ or libc++, return "none"
+    # on PowerPC systems, gcc is the best option available, so allow it to be returned
     if {[option configure.cxx_stdlib] ne "" && [option configure.cxx_stdlib] ne "macports-libstdc++"} {
-        return none
+        if {[option configure.build_arch] eq "i386" || [option configure.build_arch] eq "x86_64"} {
+            return none
+        }
     }
 
     set min_value 1.0


### PR DESCRIPTION
on Intel systems, macports-gcc is allowed only if the stdlib selection allows it.

on PowerPC, we have to be more flexible and allow macports-gcc versions
even if there might be a stdlib issue, as there are often no other options.

Luckily no issues have been raised with this in the several years it has been allowed.

This selection can be revisited if & when a suitable clang compiler and libc++
implementation become available on PowerPC