### PR TITLE
postflight: Support zsh

### DIFF
--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -221,7 +221,6 @@ USHELL=${USHELL#*shell: }
 case "${USHELL}" in
     */tcsh)
         echo "Detected the tcsh shell."
-        LOGIN_FLAG=""
         ENV_COMMAND="setenv"
         ASSIGN=" "
         if [[ -f "${HOME}/.tcshrc" ]]; then
@@ -234,7 +233,6 @@ case "${USHELL}" in
         ;;
     */bash)
         echo "Detected the bash shell."
-        LOGIN_FLAG="-l"
         ENV_COMMAND="export"
         ASSIGN="="
         if [[ -f "${HOME}/.bash_profile" ]]; then

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -243,6 +243,12 @@ case "${USHELL}" in
             CONF_FILE=profile
         fi
         ;;
+    */zsh)
+        echo "Detected the zsh shell."
+        ENV_COMMAND="export"
+        ASSIGN="="
+        CONF_FILE="zprofile"
+        ;;
     *)
         echo "Unknown shell ($USHELL)! Please set your MacPorts compatible environment manually."
         update_macports


### PR DESCRIPTION
Apple switched the default Shell on macOS Catalina to zsh, so our installer now no longer correctly configures $PATH in the default configuration.

Add support for zsh to fix this. Write the PATH configuration to `~/.zshenv`, which seems to be the default location for this kind of configuration data on zsh.