### PR TITLE
mportinit: Disable running unknown cmds in $SHELL

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -587,6 +587,10 @@ proc macports::_is_valid_developer_dir {dir} {
 
 
 proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
+    # Disable unknown(n)'s behavior of running unknown commands in the system
+    # shell
+    set ::auto_noexec yes
+
     if {$up_ui_options eq {}} {
         array set macports::ui_options {}
     } else {


### PR DESCRIPTION
Tcl defaults to running unknown commands in a shell automatically. This can inadvertently lead to running things in the shell instead of using a Tcl builtin, e.g. due to a typo.

It does not seem like we are currently using this functionality, and we really shouldn't, so disable it on startup to ensure it is not used.