### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04 AS builder
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential autotools-dev debhelper \
+        gobjc gobjc++ gobjc-multilib gobjc++-multilib \
+        libgnustep-base-dev gnustep-core-devel sqlite \
+        libsqlite3-dev openssl libcurl4-openssl-dev curl \
+        tcl tcl-dev tcl-doc tclthread tclreadline \
+        freebsd-buildutils binutils libc6-dev perl \
+        doxygen swig cvs ed pax rlwrap rsync libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD . /tmp/
+
+RUN cd /tmp/ \
+    && ./configure --with-objc-runtime=GNU --with-objc-foundation=GNU --enable-maintainer-mode --enable-symbols --enable-readline \
+    && make \
+    && make install
+
+FROM ubuntu:18.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential autotools-dev debhelper \
+        gobjc gobjc++ gobjc-multilib gobjc++-multilib \
+        libgnustep-base-dev gnustep-core-devel sqlite \
+        libsqlite3-dev openssl libcurl4-openssl-dev curl \
+        tcl tcl-dev tcl-doc tclthread tclreadline \
+        freebsd-buildutils binutils libc6-dev perl \
+        doxygen swig cvs ed pax rlwrap rsync libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/local /opt/local
+
+ENV PATH="/opt/local/bin:$PATH"


### PR DESCRIPTION
We used @Korusuke's work as the basis to create a slightly more improved Docker image for MacPorts base and suggest to merge the image to the base where it makes most sense.

What's left to be done is:
* fix the `configure` arguments
* reduce the number of runtime dependencies to just the required ones (most of dependencies are probably just build dependencies, but this needs to be checked)
* fix `Portfiles` which fail at `portindex`