### PR TITLE
allow Portfile to turn off verbose logging

### DIFF
--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -55,7 +55,7 @@ options prefix name version revision epoch categories maintainers \
         macosx_deployment_target universal_variant os.universal_supported \
         supported_archs depends_skip_archcheck installs_libs \
         license_noconflict copy_log_files \
-        compiler.cpath compiler.library_path \
+        compiler.cpath compiler.library_path compiler.log_verbose_output \
         add_users use_xcode
 
 proc portmain::check_option_integer {option action args} {
@@ -149,6 +149,7 @@ if {[option os.platform] eq "darwin" && [option os.subplatform] eq "macosx"} {
 
 default compiler.cpath {${prefix}/include}
 default compiler.library_path {${prefix}/lib}
+default compiler.log_verbose_output yes
 
 # Record initial euid/egid
 set euid [geteuid]

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -417,8 +417,10 @@ proc command_exec {command args} {
     if {[option macosx_deployment_target] ne ""} {
         set ${varprefix}.env_array(MACOSX_DEPLOYMENT_TARGET) [option macosx_deployment_target]
     }
-    set ${varprefix}.env_array(CC_PRINT_OPTIONS) "YES"
-    set ${varprefix}.env_array(CC_PRINT_OPTIONS_FILE) [file join [option workpath] ".CC_PRINT_OPTIONS"]
+    if {[option compiler.log_verbose_output]} {
+        set ${varprefix}.env_array(CC_PRINT_OPTIONS) "YES"
+        set ${varprefix}.env_array(CC_PRINT_OPTIONS_FILE) [file join [option workpath] ".CC_PRINT_OPTIONS"]
+    }
     if {[option compiler.cpath] ne ""} {
         set ${varprefix}.env_array(CPATH) [join [option compiler.cpath] :]
     }


### PR DESCRIPTION
Setting CC_PRINT_OPTIONS and CC_PRINT_OPTIONS_FILE changes how Clang
handles the compiler flags -v and -Wl,-v.
If a port relies on the default behavior (e.g. FindOpenMP in CMake),
then errors can ensue.