### PR TITLE
add libomp  library dependency with OpenMP and Clang

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -1423,6 +1423,11 @@ proc portconfigure::add_compiler_port_dependencies {compiler} {
                 depends_lib-delete "port:libcxx"
                 depends_lib-append "port:libcxx"
             }
+            if {[option compiler.openmp_version] ne ""} {
+                ui_debug "Adding depends_lib port:libomp"
+                depends_lib-delete "port:libomp"
+                depends_lib-append "port:libomp"
+            }
         }
     }
 


### PR DESCRIPTION
`clang++-mp-X.Y -fopenmp ...` links against libraries in libomp.