### PR TITLE
allow compiler to use environment variables only

### DIFF
--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -56,6 +56,9 @@ options prefix name version revision epoch categories maintainers \
         supported_archs depends_skip_archcheck installs_libs \
         license_noconflict copy_log_files \
         compiler.cpath compiler.library_path compiler.log_verbose_output \
+        compiler.limit_flags \
+        compiler.support_environment_paths \
+        compiler.support_environment_sdkroot \
         add_users use_xcode
 
 proc portmain::check_option_integer {option action args} {
@@ -150,6 +153,9 @@ if {[option os.platform] eq "darwin" && [option os.subplatform] eq "macosx"} {
 default compiler.cpath {${prefix}/include}
 default compiler.library_path {${prefix}/lib}
 default compiler.log_verbose_output yes
+default compiler.limit_flags no
+default compiler.support_environment_paths no
+default compiler.support_environment_sdkroot no
 
 # Record initial euid/egid
 set euid [geteuid]


### PR DESCRIPTION
For many ports, the compiler flags
  -I${prefix}/include,
  -L${prefix}/lib,
  -isysroot${configure.sdkroot}, and
  -Wl,-syslibroot,${configure.sdkroot}
are unnecessary because of the environment variables
  CPATH,
  LIBRARY_PATH, and
  SDKROOT.
compiler.limit_flags prevents MacPorts from attempting to add
unnecessary compiler flags, which can cause problems.

See https://trac.macports.org/wiki/CompilerEnvironmentVariables
for details.