### PR TITLE
Fixes to HTTP compression behavior

### DIFF
--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -44,6 +44,8 @@
 #include <sys/select.h>
 #include <utime.h>
 
+#include <AvailabilityMacros.h>
+
 #include <curl/curl.h>
 
 #include <tcl.h>
@@ -59,10 +61,15 @@
 #define _CURL_MINIMUM_XFER_TIMEOUT	((long)(60))		/* 1 minute */
 #define _CURL_MINIMUM_PROGRESS_INTERVAL ((double)(0.2)) /* 0.2 seconds */
 
+/* pre-10.8 curl does not appear to support compression out of the box */
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_8
+
 #if defined CURLOPT_ACCEPT_ENCODING
 #define _CURL_ENCODING CURLOPT_ACCEPT_ENCODING
 #elif defined CURLOPT_ENCODING
 #define _CURL_ENCODING CURLOPT_ENCODING
+#endif
+
 #endif
 
 /* ========================================================================= **

--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -163,7 +163,7 @@ SetResultFromCurlMErrorCode(Tcl_Interp *interp, CURLMcode inErrorCode)
 /**
  * curl fetch subcommand entry point.
  *
- * syntax: curl fetch [--disable-epsv] [--ignore-ssl-cert] [--remote-time] [-u userpass] [--effective-url lasturlvar] [--progress "builtin"|callback] [--disable-compression] url filename
+ * syntax: curl fetch [--disable-epsv] [--ignore-ssl-cert] [--remote-time] [-u userpass] [--effective-url lasturlvar] [--progress "builtin"|callback] [--enable-compression] url filename
  *
  * @param interp		current interpreter
  * @param objc			number of parameters
@@ -204,7 +204,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
 		struct curl_slist *headers = NULL;
 		struct CURLMsg *info = NULL;
 		int running; /* number of running transfers */
-		char* acceptEncoding = "";
+		char* acceptEncoding = NULL;
 
 		/* we might have options and then the url and the file */
 		/* let's process the options first */
@@ -290,8 +290,8 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
 					theResult = TCL_ERROR;
 					break;
 				}
-         } else if (strcmp(theOption, "--disable-compression") == 0) {
-				acceptEncoding = NULL;
+         } else if (strcmp(theOption, "--enable-compression") == 0) {
+				acceptEncoding = "";
 			} else {
 				Tcl_ResetResult(interp);
 				Tcl_AppendResult(interp, "curl fetch: unknown option ", theOption, NULL);
@@ -503,8 +503,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
 			}
 		}
 
-		/* we want compression by default, but can optionally disable it.
-		 * a CURLOPT_ACCEPT_ENCODING of "" means to let cURL write the
+		/* a CURLOPT_ACCEPT_ENCODING of "" means to let cURL write the
 		 * Accept-Encoding header for you, based on what the library
 		 * was compiled to support.
 		 * A value of NULL disables all attemps at decompressing responses.

--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -44,8 +44,6 @@
 #include <sys/select.h>
 #include <utime.h>
 
-#include <AvailabilityMacros.h>
-
 #include <curl/curl.h>
 
 #include <tcl.h>
@@ -61,15 +59,10 @@
 #define _CURL_MINIMUM_XFER_TIMEOUT	((long)(60))		/* 1 minute */
 #define _CURL_MINIMUM_PROGRESS_INTERVAL ((double)(0.2)) /* 0.2 seconds */
 
-/* pre-10.8 curl does not appear to support compression out of the box */
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_8
-
 #if defined CURLOPT_ACCEPT_ENCODING
 #define _CURL_ENCODING CURLOPT_ACCEPT_ENCODING
-#elif defined CURLOPT_ENCODING
+#else
 #define _CURL_ENCODING CURLOPT_ENCODING
-#endif
-
 #endif
 
 /* ========================================================================= **

--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -290,7 +290,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
 					theResult = TCL_ERROR;
 					break;
 				}
-         } else if (strcmp(theOption, "--enable-compression") == 0) {
+			} else if (strcmp(theOption, "--enable-compression") == 0) {
 				acceptEncoding = "";
 			} else {
 				Tcl_ResetResult(interp);

--- a/src/pextlib1.0/tests/curl.tcl
+++ b/src/pextlib1.0/tests/curl.tcl
@@ -12,16 +12,16 @@ proc main {pextlibname} {
 	curl fetch --ignore-ssl-cert $dummyroot/dummy $tempfile
 	
 	# check the md5 sum of the file.
-	test {[md5 file $tempfile] == "5421fb0f76c086a1e14bf33d25b292d4"}
+	test "md5sum" {[md5 file $tempfile] == "5421fb0f76c086a1e14bf33d25b292d4"}
 
 	# check we indeed get a 404 a dummy file over HTTP.
-	test {[catch {curl fetch --ignore-ssl-cert $dummyroot/404 $tempfile}]}
+	test "dummy404" {[catch {curl fetch --ignore-ssl-cert $dummyroot/404 $tempfile}]}
 	
 	# check the modification date of the dummy file.
 	set seconds [clock scan 2007-06-16Z]
-	test {[curl isnewer --ignore-ssl-cert $dummyroot/dummy [clock scan 2007-06-16Z]]}
+	test "mtime1" {[curl isnewer --ignore-ssl-cert $dummyroot/dummy [clock scan 2007-06-16Z]]}
 	set seconds [clock scan 2007-06-17Z]
-	test {![curl isnewer --ignore-ssl-cert $dummyroot/dummy [clock scan 2007-06-17Z]]}
+	test "mtime2" {![curl isnewer --ignore-ssl-cert $dummyroot/dummy [clock scan 2007-06-17Z]]}
 	
 	# use --disable-epsv
 	#curl fetch --disable-epsv ftp://ftp.cup.hp.com/dist/networking/benchmarks/netperf/archive/netperf-2.2pl5.tar.gz $tempfile
@@ -41,9 +41,9 @@ proc main {pextlibname} {
 	file delete -force $tempfile
 }
 
-proc test {args} {
+proc test {test_name args} {
 	if {[catch {uplevel 1 expr $args} result] || !$result} {
-		puts "[uplevel 1 subst -nocommands $args] == $result"
+		puts "test $test_name failed: [uplevel 1 subst -nocommands $args] == $result"
 		exit 1
 	}
 }
@@ -57,7 +57,7 @@ proc grepper {filepath regex} {
 		}
 	}
 	close $fd
-	test {$hasMatch == 1}
+	test "grepper $regex" {$hasMatch == 1}
 }
 
 main $argv

--- a/src/pextlib1.0/tests/curl.tcl
+++ b/src/pextlib1.0/tests/curl.tcl
@@ -32,10 +32,10 @@ proc main {pextlibname} {
 	#curl fetch -u "I accept www.opensource.org/licenses/cpl:." http://www.research.att.com/~gsf/download/tgz/sfio.2005-02-01.tgz $tempfile
 	#test {[md5 file $tempfile] == "48f45c7c77c23ab0ccca48c22b3870de"}
 	
-	curl fetch https://www.whatsmyip.org/http-compression-test/ $tempfile
+	curl fetch --enable-compression https://www.whatsmyip.org/http-compression-test/ $tempfile
 	grepper $tempfile {gz_yes}
 
-	curl fetch --disable-compression https://www.whatsmyip.org/http-compression-test/ $tempfile
+	curl fetch https://www.whatsmyip.org/http-compression-test/ $tempfile
 	grepper $tempfile {gz_no}
 
 	file delete -force $tempfile

--- a/src/port1.0/portlivecheck.tcl
+++ b/src/port1.0/portlivecheck.tcl
@@ -45,7 +45,7 @@ namespace eval portlivecheck {
 }
 
 # define options
-options livecheck.url livecheck.type livecheck.md5 livecheck.regex livecheck.name livecheck.distname livecheck.version livecheck.ignore_sslcert livecheck.curloptions
+options livecheck.url livecheck.type livecheck.md5 livecheck.regex livecheck.name livecheck.distname livecheck.version livecheck.ignore_sslcert livecheck.compression livecheck.curloptions
 
 # defaults
 default livecheck.url {$homepage}
@@ -56,11 +56,13 @@ default livecheck.name default
 default livecheck.distname default
 default livecheck.version {$version}
 default livecheck.ignore_sslcert no
+default livecheck.compression yes
 default livecheck.curloptions {"--append-http-header" "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}
 
 proc portlivecheck::livecheck_main {args} {
     global livecheck.url livecheck.type livecheck.md5 livecheck.regex livecheck.name livecheck.distname livecheck.version \
            livecheck.ignore_sslcert \
+           livecheck.compression \
            livecheck.curloptions \
            homepage portpath workpath \
            master_sites name subport distfiles
@@ -80,6 +82,9 @@ proc portlivecheck::livecheck_main {args} {
     set curl_options ${livecheck.curloptions}
     if {[tbool livecheck.ignore_sslcert]} {
         lappend curl_options "--ignore-ssl-cert"
+    }
+    if {[tbool livecheck.compression]} {
+        lappend curl_options "--enable-compression"
     }
 
     # Check _resources/port1.0/livecheck for available types.


### PR DESCRIPTION
- Fix build on old MacOS X
- Leave compression OFF by default
- For livecheck, turn it ON by default
- Expose livecheck compression toggle to portfile via livecheck.compression