### PR TITLE
Abort when a port includes a nonexistent PortGroup

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -2580,7 +2580,7 @@ proc PortGroup {group version} {
         ui_debug "Sourcing PortGroup $group $version from $groupFile"
     } else {
         ui_error "${subport}: PortGroup ${group} ${version} could not be located. ${group}-${version}.tcl does not exist."
-        return -code error "Invalid PortGroup found"
+        return -code error "PortGroup not found"
     }
 }
 

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -2558,7 +2558,7 @@ proc set_ui_prefix {} {
 
 # Use a specified group/version.
 proc PortGroup {group version} {
-    global porturl PortInfo _portgroup_search_dirs
+    global porturl PortInfo _portgroup_search_dirs subport
 
     if {[info exists _portgroup_search_dirs]} {
         foreach dir $_portgroup_search_dirs {
@@ -2579,8 +2579,8 @@ proc PortGroup {group version} {
         uplevel "source $groupFile"
         ui_debug "Sourcing PortGroup $group $version from $groupFile"
     } else {
-        lappend PortInfo(portgroups) [list $group $version ""]
-        ui_warn "PortGroup ${group} ${version} could not be located. ${group}-${version}.tcl does not exist."
+        ui_error "${subport}: PortGroup ${group} ${version} could not be located. ${group}-${version}.tcl does not exist."
+        return -code error "Invalid PortGroup found"
     }
 }
 


### PR DESCRIPTION
Currently, only a warning is printed and the processing of the port
continues. This typically results in a port not completing later.
After this patch, an error is printed with the port name added and
then the port processing aborts.

closes https//trac.macports.org/ticket/59787