### PR TITLE
Adjust lint --niptick on patchfiles to allow *.diff or *.patch

### DIFF
--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -819,8 +819,10 @@ proc portlint::lint_main {args} {
 
     if {$nitpick && [info exists patchfiles]} {
         foreach patchfile $patchfiles {
-            if {![string match "patch-*.diff" $patchfile] && [file exists "$portpath/files/$patchfile"]} {
-                ui_warn "Patchfile $patchfile does not follow the source patch naming policy \"patch-*.diff\""
+            if {!([string match "*.diff" $patchfile] ||
+                  [string match "*.patch" $patchfile]) &&
+                 [file exists "$portpath/files/$patchfile"]} {
+                ui_warn "Patchfile $patchfile does not follow the source patch naming policy \"*.diff\" or \"*.patch\""
                 incr warnings
             }
         }


### PR DESCRIPTION
The current behavior is to only allow patch-*.diff patchfiles.

Ryan Schmidt's comment on ticket 59695:
The lint warning was originally added to discourage users from adding
patchfiles that had neither the .diff nor the .patch extension, since
that resulted in incorrect syntax coloring in text editors that
determine the filetype from the extension.

closes https://trac.macports.org/ticket/59695