### PR TITLE
portconfigure: Add support for Macports Clang versions 10+

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -340,30 +340,26 @@ proc portconfigure::configure_start {args} {
 
     set compiler [option configure.compiler]
     set valid_compilers {
-        {^apple-gcc-(4\.[02])$}             {MacPorts Apple GCC %s}
-        {^cc$}                              {System cc}
-        {^clang$}                           {Xcode Clang}
-        {^gcc$}                             {System GCC}
-        {^gcc-(3\.3|4\.[02])$}              {Xcode GCC %s}
-        {^llvm-gcc-4\.2$}                   {Xcode LLVM-GCC 4.2}
-        {^macports-clang$}                  {MacPorts Clang (port select)}
-        {^macports-clang-(\d+\.\d+)$}       {MacPorts Clang %s}
-        {^macports-gcc$}                    {MacPorts GCC (port select)}
-        {^macports-gcc-(\d+(?:\.\d+)?)$}    {MacPorts GCC %s}
-        {^macports-llvm-gcc-4\.2$}          {MacPorts LLVM-GCC 4.2}
-        {^macports-g95$}                    {MacPorts G95}
-        {^macports-mpich-default$}          {MacPorts MPICH Wrapper for MacPorts' Default C/C++ Compiler}
-        {^macports-openmpi-default$}        {MacPorts Open MPI Wrapper for MacPorts' Default C/C++ Compiler}
-        {^macports-mpich-clang$}            {MacPorts MPICH Wrapper for Xcode Clang}
-        {^macports-openmpi-clang$}          {MacPorts Open MPI Wrapper for Xcode Clang}
-        {^macports-mpich-clang-(\d+\.\d+)$}
-            {MacPorts MPICH Wrapper for Clang %s}
-        {^macports-openmpi-clang-(\d+\.\d+)$}
-            {MacPorts Open MPI Wrapper for Clang %s}
-        {^macports-mpich-gcc-(\d+(?:\.\d+)?)$}
-            {MacPorts MPICH Wrapper for GCC %s}
-        {^macports-openmpi-gcc-(\d+(?:\.\d+)?)$}
-            {MacPorts Open MPI Wrapper for GCC %s}
+        {^apple-gcc-(4\.[02])$}                    {MacPorts Apple GCC %s}
+        {^cc$}                                     {System cc}
+        {^clang$}                                  {Xcode Clang}
+        {^gcc$}                                    {System GCC}
+        {^gcc-(3\.3|4\.[02])$}                     {Xcode GCC %s}
+        {^llvm-gcc-4\.2$}                          {Xcode LLVM-GCC 4.2}
+        {^macports-clang$}                         {MacPorts Clang (port select)}
+        {^macports-clang-(\d+(?:\.\d+)?)$}         {MacPorts Clang %s}
+        {^macports-gcc$}                           {MacPorts GCC (port select)}
+        {^macports-gcc-(\d+(?:\.\d+)?)$}           {MacPorts GCC %s}
+        {^macports-llvm-gcc-4\.2$}                 {MacPorts LLVM-GCC 4.2}
+        {^macports-g95$}                           {MacPorts G95}
+        {^macports-mpich-default$}                 {MacPorts MPICH Wrapper for MacPorts' Default C/C++ Compiler}
+        {^macports-openmpi-default$}               {MacPorts Open MPI Wrapper for MacPorts' Default C/C++ Compiler}
+        {^macports-mpich-clang$}                   {MacPorts MPICH Wrapper for Xcode Clang}
+        {^macports-openmpi-clang$}                 {MacPorts Open MPI Wrapper for Xcode Clang}
+        {^macports-mpich-clang-(\d+(?:\.\d+)?)$}   {MacPorts MPICH Wrapper for Clang %s}
+        {^macports-openmpi-clang-(\d+(?:\.\d+)?)$} {MacPorts Open MPI Wrapper for Clang %s}
+        {^macports-mpich-gcc-(\d+(?:\.\d+)?)$}     {MacPorts MPICH Wrapper for GCC %s}
+        {^macports-openmpi-gcc-(\d+(?:\.\d+)?)$}   {MacPorts Open MPI Wrapper for GCC %s}
     }
     foreach {re fmt} $valid_compilers {
         if {[set matches [regexp -inline $re $compiler]] ne ""} {
@@ -631,11 +627,12 @@ proc portconfigure::arch_flag_supported {compiler {multiple_arch_flags no}} {
 proc portconfigure::compiler_port_name {compiler} {
     set valid_compiler_ports {
         {^apple-gcc-(\d+)\.(\d+)$}                          {apple-gcc%s%s}
-        {^macports-clang-(\d+\.\d+)$}                       {clang-%s}
+        {^macports-clang-(\d+(?:\.\d+)?)$}                  {clang-%s}
         {^macports-(llvm-)?gcc-(\d+)(?:\.(\d+))?$}          {%sgcc%s%s}
         {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-default$}                {%s-default}
         {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-clang$}                  {%s-clang}
         {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-clang-(\d+)\.(\d+)$}     {%s-clang%s%s}
+        {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-clang-(\d+)$}            {%s-clang%s}
         {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-gcc-(\d+)(?:\.(\d+))?$}  {%s-gcc%s%s}
         {^macports-g95$}                                    {g95}
     }
@@ -1319,7 +1316,7 @@ proc portconfigure::configure_get_compiler {type {compiler {}}} {
             cxx     -
             objcxx  { return ${prefix_frozen}/bin/clang++${suffix} }
         }
-    } elseif {[regexp {^macports-clang(-\d+\.\d+)$} $compiler -> suffix]} {
+    } elseif {[regexp {^macports-clang(-\d+(?:\.\d+)?)$} $compiler -> suffix]} {
         set suffix "-mp${suffix}"
         switch $type {
             cc      -
@@ -1363,7 +1360,7 @@ proc portconfigure::configure_get_compiler {type {compiler {}}} {
             cxx     -
             objcxx  { return ${prefix_frozen}/bin/mpicxx-${mpi}-clang }
         }
-    } elseif {[regexp {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-clang-(\d+\.\d+)$} $compiler -> mpi version]} {
+    } elseif {[regexp {^macports-(mpich|openmpi|mpich-devel|openmpi-devel)-clang-(\d+(?:\.\d+)?)$} $compiler -> mpi version]} {
         set suffix [join [split ${version} .] ""]
         switch $type {
             cc      -
@@ -1481,7 +1478,7 @@ proc portconfigure::add_compiler_port_dependencies {compiler} {
                 depends_lib-delete $libgcc_dep
                 depends_lib-append $libgcc_dep
             }
-        } elseif {[regexp {^macports-clang(?:-(\d+\.\d+))$} $compiler -> clang_version]} {
+        } elseif {[regexp {^macports-clang(?:-(\d+(?:\.\d+)?))$} $compiler -> clang_version]} {
             if {[option configure.cxx_stdlib] eq "macports-libstdc++"} {
                 # see https://trac.macports.org/ticket/54766
                 ui_debug "Adding depends_lib path:lib/libgcc/libgcc_s.1.dylib:libgcc"


### PR DESCRIPTION
Minor update to `portconfigure.tcl` to extend the regex used to detect macports provide clang compiler to support the dropping of the minor version from the port name, starting with `clang-10` (https://github.com/macports/macports-ports/pull/6902).

Note that the changes here do not require any changes in the ports tree, either to add the `clang-10` compiler or to the resources to add it to the known lists, so can be applied before they are done. However the changes here are required to be available before `macports-clang-10` can be used as a compiler option.

Once merged I would propose cherry-picking this to the 2.6 release branch, such as to make it available in the next release from that branch.