### PR TITLE
For install action, abort if any @version is provided on command line

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -4765,6 +4765,13 @@ proc process_cmd { argv } {
             }
         }
 
+        if {$action eq "install"} {
+            array set portinfo [lindex $portlist 0]
+            if {[info exists portinfo(version)] && $portinfo(version) ne "" } {
+                fatal "install ignores the provided version $portinfo(version); remove it to continue."
+            }
+        }
+
         # execute the action
         set action_status [$action_proc $action $portlist [array get global_options]]
 


### PR DESCRIPTION
The install action has always ignored any @version provided on the
command line.  This causes confusion for users so change to abort the
command and force user to remove the @version.

Closes: https://trac.macports.org/ticket/60454