### PR TITLE
reclaim: remove portdbpath/build directory

### DIFF
--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -112,13 +112,22 @@ namespace eval reclaim {
         # The root build folder location
         set root_build      [file join ${macports::portdbpath} build]
 
-        try -pass_signal {
-            if {[macports::global_option_isset ports_dryrun]} {
-                ui_msg "Deleting... (dry run)"
-                ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
-            } else {
-                ui_info [msgcat::mc "Deleting %s" $root_build]
-                file delete -force $root_build
+        ui_msg "$macports::ui_prefix Build location: ${root_build}"
+
+        set retval 0
+        if {[info exists macports::ui_options(questions_yesno)]} {
+            set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete the entire build directory (including the default ccache location)?"]
+        }
+
+        if {${retval} == 0} {
+            try -pass_signal {
+                if {[macports::global_option_isset ports_dryrun]} {
+                    ui_msg "Deleting... (dry run)"
+                    ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
+                } else {
+                    ui_info [msgcat::mc "Deleting %s" $root_build]
+                    file delete -force $root_build
+                }
             }
         }
     }

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -76,6 +76,7 @@ namespace eval reclaim {
         uninstall_unrequested
         uninstall_inactive
         remove_distfiles
+        remove_builds
 
         if {![macports::global_option_isset ports_dryrun]} {
             set last_run_contents [read_last_run_file]
@@ -100,6 +101,24 @@ namespace eval reclaim {
             }
             if {$last_run_contents ne "disabled"} {
                 update_last_run
+            }
+        }
+    }
+
+    proc remove_builds {} {
+        # Delete portdbpath/build
+        global macports::portdbpath
+
+        # The root build folder location
+        set root_build      [file join ${macports::portdbpath} build]
+
+        try -pass_signal {
+            if {[macports::global_option_isset ports_dryrun]} {
+                ui_msg "Deleting... (dry run)"
+                ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
+            } else {
+                ui_info [msgcat::mc "Deleting %s" $root_build]
+                file delete -force $root_build
             }
         }
     }


### PR DESCRIPTION
This removes the entire build folder which also removes the default
ccache location.

Closes: https://trac.macports.org/ticket/60126