### PR TITLE
reclaim: separate removing build and ccache locations

### DIFF
--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -110,7 +110,7 @@ namespace eval reclaim {
         # Delete portdbpath/build directories
         global macports::portdbpath
 
-        # The root build folder location
+        # The root build directory location
         set root_build      [file join ${macports::portdbpath} build]
 
         ui_msg "$macports::ui_prefix Build location: ${root_build}"
@@ -127,7 +127,7 @@ namespace eval reclaim {
                     ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
                 } else {
                     ui_info [msgcat::mc "Deleting %s" $root_build]
-                    set builddirs [glob -nocomplain -types d [file join $root_build *]]
+                    set builddirs [glob -nocomplain -directory $root_build *]
                     catch {file delete -force -- {*}$builddirs}
                 }
             }
@@ -159,7 +159,7 @@ namespace eval reclaim {
                 }
             }
         } else {
-            ui_info [msgcat::mc "Skipping deletion of ccache folders %s not found." $macports::ccache_dir]
+            ui_info [msgcat::mc "Skipping deletion of ccache directory: %s does not exist." $macports::ccache_dir]
         }
     }
 

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -128,7 +128,14 @@ namespace eval reclaim {
                 } else {
                     ui_info [msgcat::mc "Deleting %s" $root_build]
                     set builddirs [glob -nocomplain -directory $root_build *]
-                    catch {file delete -force -- {*}$builddirs}
+                    if {[llength $builddirs] > 0} {
+                        try -pass_signal {
+                            file delete -force -- {*}$builddirs
+                        } catch {{*} eCode eMessage} {
+                            ui_debug "$::errorInfo"
+                            ui_error "$eMessage"
+                        }
+                    }
                 }
             }
         }
@@ -154,7 +161,14 @@ namespace eval reclaim {
                     } else {
                         ui_info [msgcat::mc "Deleting %s" $macports::ccache_dir]
                         set ccachedirs [glob -nocomplain [file join $macports::ccache_dir *]]
-                        catch {file delete -force -- {*}$ccachedirs}
+                        if {[llength $ccachedirs] > 0} {
+                            try -pass_signal {
+                                file delete -force -- {*}$ccachedirs
+                            } catch {{*} eCode eMessage} {
+                                ui_debug "$::errorInfo"
+                                ui_error "$eMessage"
+                            }
+                        }
                     }
                 }
             }

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -160,7 +160,7 @@ namespace eval reclaim {
                         ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $macports::ccache_dir]
                     } else {
                         ui_info [msgcat::mc "Deleting %s" $macports::ccache_dir]
-                        set ccachedirs [glob -nocomplain [file join $macports::ccache_dir *]]
+                        set ccachedirs [glob -nocomplain -directory $macports::ccache_dir *]
                         if {[llength $ccachedirs] > 0} {
                             try -pass_signal {
                                 file delete -force -- {*}$ccachedirs

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -115,28 +115,30 @@ namespace eval reclaim {
 
         ui_msg "$macports::ui_prefix Build location: ${root_build}"
 
+        if {[macports::global_option_isset ports_dryrun]} {
+            ui_msg "Deleting... (dry run)"
+            ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
+            return
+        }
+
+        set builddirs [glob -nocomplain -directory $root_build *]
+        if {[llength $builddirs] == 0} {
+            ui_info [msgcat::mc "No build directories to delete"]
+            return
+        }
+
         set retval 0
         if {[info exists macports::ui_options(questions_yesno)]} {
             set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete all the build directories?"]
         }
 
         if {${retval} == 0} {
+            ui_info [msgcat::mc "Deleting %s" $root_build]
             try -pass_signal {
-                if {[macports::global_option_isset ports_dryrun]} {
-                    ui_msg "Deleting... (dry run)"
-                    ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
-                } else {
-                    ui_info [msgcat::mc "Deleting %s" $root_build]
-                    set builddirs [glob -nocomplain -directory $root_build *]
-                    if {[llength $builddirs] > 0} {
-                        try -pass_signal {
-                            file delete -force -- {*}$builddirs
-                        } catch {{*} eCode eMessage} {
-                            ui_debug "$::errorInfo"
-                            ui_error "$eMessage"
-                        }
-                    }
-                }
+                file delete -force -- {*}$builddirs
+            } catch {{*} eCode eMessage} {
+                ui_debug "$::errorInfo"
+                ui_error "$eMessage"
             }
         }
     }
@@ -145,35 +147,38 @@ namespace eval reclaim {
         # Delete everything under ccache directory - default is build/.ccache
         global macports::ccache_dir
 
-        if {[file exists ${macports::ccache_dir}]} {
-            ui_msg "$macports::ui_prefix ccache location: ${macports::ccache_dir}"
-
-            set retval 0
-            if {[info exists macports::ui_options(questions_yesno)]} {
-                set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete all the ccache directories?"]
-            }
-
-            if {${retval} == 0} {
-                try -pass_signal {
-                    if {[macports::global_option_isset ports_dryrun]} {
-                        ui_msg "Deleting... (dry run)"
-                        ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $macports::ccache_dir]
-                    } else {
-                        ui_info [msgcat::mc "Deleting %s" $macports::ccache_dir]
-                        set ccachedirs [glob -nocomplain -directory $macports::ccache_dir *]
-                        if {[llength $ccachedirs] > 0} {
-                            try -pass_signal {
-                                file delete -force -- {*}$ccachedirs
-                            } catch {{*} eCode eMessage} {
-                                ui_debug "$::errorInfo"
-                                ui_error "$eMessage"
-                            }
-                        }
-                    }
-                }
-            }
-        } else {
+        if {![file exists ${macports::ccache_dir}]} {
             ui_info [msgcat::mc "Skipping deletion of ccache directory: %s does not exist." $macports::ccache_dir]
+            return
+        }
+
+        ui_msg "$macports::ui_prefix ccache location: ${macports::ccache_dir}"
+
+        if {[macports::global_option_isset ports_dryrun]} {
+            ui_msg "Deleting... (dry run)"
+            ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $macports::ccache_dir]
+            return
+        }
+
+        set ccachedirs [glob -nocomplain -directory $macports::ccache_dir *]
+        if {[llength $ccachedirs] == 0} {
+            ui_info [msgcat::mc "No ccache directories to delete"]
+            return
+        }
+
+        set retval 0
+        if {[info exists macports::ui_options(questions_yesno)]} {
+            set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete all the ccache directories?"]
+        }
+
+        if {${retval} == 0} {
+            ui_info [msgcat::mc "Deleting %s" $macports::ccache_dir]
+            try -pass_signal {
+                file delete -force -- {*}$ccachedirs
+            } catch {{*} eCode eMessage} {
+                ui_debug "$::errorInfo"
+                ui_error "$eMessage"
+            }
         }
     }
 

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -117,7 +117,7 @@ namespace eval reclaim {
 
         set retval 0
         if {[info exists macports::ui_options(questions_yesno)]} {
-            set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete everything under the build directory (except the default ccache location)?"]
+            set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete all the build directories?"]
         }
 
         if {${retval} == 0} {
@@ -143,7 +143,7 @@ namespace eval reclaim {
 
             set retval 0
             if {[info exists macports::ui_options(questions_yesno)]} {
-                set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete everything under the ccache directory?"]
+                set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete all the ccache directories?"]
             }
 
             if {${retval} == 0} {

--- a/src/macports1.0/reclaim.tcl
+++ b/src/macports1.0/reclaim.tcl
@@ -117,7 +117,7 @@ namespace eval reclaim {
 
         if {[macports::global_option_isset ports_dryrun]} {
             ui_msg "Deleting... (dry run)"
-            ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $root_build]
+            ui_info [msgcat::mc "Skipping deletion of all build directories under %s (dry run)" $root_build]
             return
         }
 
@@ -133,7 +133,7 @@ namespace eval reclaim {
         }
 
         if {${retval} == 0} {
-            ui_info [msgcat::mc "Deleting %s" $root_build]
+            ui_info [msgcat::mc "Deleting all build directories under %s" $root_build]
             try -pass_signal {
                 file delete -force -- {*}$builddirs
             } catch {{*} eCode eMessage} {
@@ -156,7 +156,7 @@ namespace eval reclaim {
 
         if {[macports::global_option_isset ports_dryrun]} {
             ui_msg "Deleting... (dry run)"
-            ui_info [msgcat::mc "Skipping deletion of %s (dry run)" $macports::ccache_dir]
+            ui_info [msgcat::mc "Skipping deletion of everything under %s (dry run)" $macports::ccache_dir]
             return
         }
 
@@ -168,11 +168,11 @@ namespace eval reclaim {
 
         set retval 0
         if {[info exists macports::ui_options(questions_yesno)]} {
-            set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete all the ccache directories?"]
+            set retval [$macports::ui_options(questions_yesno) "" "" "" "y" 0 "Would you like to delete everything under the ccache directory?"]
         }
 
         if {${retval} == 0} {
-            ui_info [msgcat::mc "Deleting %s" $macports::ccache_dir]
+            ui_info [msgcat::mc "Deleting everything under %s" $macports::ccache_dir]
             try -pass_signal {
                 file delete -force -- {*}$ccachedirs
             } catch {{*} eCode eMessage} {


### PR DESCRIPTION
Do not actually remove the build and ccache locations, only the files
and folders underneath.
A followup to the discussions in (#175)

See https://trac.macports.org/ticket/60126