### PR TITLE
Fix c++17 compiler selection to blacklist incomplete mac10.13 versions

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -849,7 +849,7 @@ proc portconfigure::max_version {verA verB} {
 #| 1998 (C++98) |     -     |       -       |     -     |     -     |
 #| 2011 (C++11) |    3.3    |   500.2.75    |    5.0    |   4.8.1   |
 #| 2014 (C++14) |    3.4    |   602.0.49    |    6.3    |     5     |
-#| 2017 (C++17) |    5.0    |   902.0.39.1  |    9.3    |     7     |
+#| 2017 (C++17) |    5.0    |  1000.11.45.2 |   10.0    |     7     |
 #--------------------------------------------------------------------
 #
 # https://openmp.llvm.org
@@ -909,7 +909,7 @@ proc portconfigure::get_min_command_line {compiler} {
                 set min_value [max_version $min_value 500.2.75]
             }
             if {${compiler.cxx_standard} >= 2017} {
-                set min_value [max_version $min_value 902.0.39.1]
+                set min_value [max_version $min_value 1000.11.45.2]
             } elseif {${compiler.cxx_standard} >= 2014} {
                 set min_value [max_version $min_value 602.0.49]
             } elseif {${compiler.cxx_standard} >= 2011} {


### PR DESCRIPTION
Triggered by a discussion at

https://github.com/macports/macports-ports/pull/7243

The clang blacklisting is currently allowing some versions on 10.13 (Xcode 9/10) that are either missing std::optional or for which the implementation is incomplete or broken.

Consider the basic test application, using `std::optional`

```
 > cat test.cpp
#include <optional>
int main() {
  std::optional<int> i = 0;
  return i.value();
}
```

on macOS 10.13 with Xcode 9.4.1 this fails to build with

```
 > clang++ -std=c++17 ./test.cpp
./test.cpp:1:10: fatal error: 'optional' file not found
#include <optional>
         ^~~~~~~~~~
1 error generated.

 > clang++ --version
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

then, again on macOS 10.13 but with Xcode 10.1

```
  > clang++ -std=c++17 ./test.cpp 
./test.cpp:4:12: error: call to unavailable member function 'value': introduced in macOS 10.14
  return i.value();
         ~~^~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/optional:942:27: note: candidate function has been
      explicitly made unavailable
    constexpr value_type& value() &
                          ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/optional:933:33: note: candidate function has been
      explicitly made unavailable
    constexpr value_type const& value() const&
                                ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/optional:951:28: note: candidate function not viable: no
      known conversion from 'optional<...>' to 'optional<...>' for object argument
    constexpr value_type&& value() &&
                           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/optional:960:34: note: candidate function not viable: no
      known conversion from 'optional<...>' to 'const optional<...>' for object argument
    constexpr value_type const&& value() const&&
                                 ^
1 error generated.

> clang++ --version
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Finally, on macOS 10.14, Xcode 10.3

```
MacVM1014 ~/Downloads > clang++ -std=c++17 ./test.cpp 
MacVM1014 ~/Downloads > ./a.out 
MacVM1014 ~/Downloads > 
```

As a compiler cannot be relied upon as a fully functional c++17 compiler if it fails to implement (a commonly used) part of that standard, this MR increases the versions blacklisted to exclude these versions.

