### PR TITLE
Set macosx_version to the full macOS version (e.g. 10.15.5)

### DIFF
--- a/src/macports1.0/diagnose.tcl
+++ b/src/macports1.0/diagnose.tcl
@@ -91,7 +91,7 @@ namespace eval diagnose {
 
         array set config_options    [list]
         set parser_options          [list macports_location profile_path shell_location \
-                                    xcode_version_${macports::macosx_version} xcode_build]
+                                    xcode_version_${macports::macosx_major_version} xcode_build]
 
         set user_config_path        "${macports::autoconf::macports_conf_path}/port_diagnose.ini"
         set xcode_config_path       [macports::getdefaultportresourcepath "macports1.0/xcode_versions.ini"]
@@ -150,7 +150,7 @@ namespace eval diagnose {
 
         output "command line tools"
 
-        set version ${macports::macosx_version}
+        set version ${macports::macosx_major_version}
 
         if {$version eq "10.9"} {
 
@@ -491,7 +491,7 @@ namespace eval diagnose {
         # Returns:
         #           None
 
-        if {${macports::macosx_version} eq "10.6"} {
+        if {${macports::macosx_major_version} eq "10.6"} {
             output "X11.app on Mac OS X 10.6 systems"
 
             if {[file exists /Applications/X11.app]} {
@@ -587,7 +587,7 @@ namespace eval diagnose {
 
         upvar $config_options config
 
-        set mac_version     ${macports::macosx_version}
+        set mac_version     ${macports::macosx_major_version}
         set xcode_current   ${macports::xcodeversion}
         if {[info exists config(xcode_version_$mac_version)]} {
             set xcode_versions  $config(xcode_version_$mac_version)

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -68,7 +68,7 @@ namespace eval macports {
         configureccache ccache_dir ccache_size configuredistcc configurepipe buildnicevalue buildmakejobs \
         applications_dir applications_dir_frozen current_phase frameworks_dir frameworks_dir_frozen \
         developer_dir universal_archs build_arch os_arch os_endian os_version os_major os_minor \
-        os_platform os_subplatform macosx_version macosx_sdk_version macosx_deployment_target \
+        os_platform os_subplatform macosx_version macosx_major_version macosx_sdk_version macosx_deployment_target \
         packagemaker_path default_compilers sandbox_enable sandbox_network delete_la_files cxx_stdlib \
         pkg_post_unarchive_deletions $user_options"
 
@@ -673,6 +673,7 @@ proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
         macports::os_platform \
         macports::os_subplatform \
         macports::macosx_version \
+        macports::macosx_major_version \
         macports::macosx_sdk_version \
         macports::macosx_deployment_target \
         macports::archivefetch_pubkeys \
@@ -711,7 +712,8 @@ proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
             set os_subplatform macosx
             if {[file executable /usr/bin/sw_vers]} {
                 try -pass_signal {
-                    set macosx_version [exec /usr/bin/sw_vers -productVersion | cut -f1,2 -d.]
+                    set macosx_version [exec /usr/bin/sw_vers -productVersion]
+                    set macosx_major_version [join [lrange [split $macosx_version "."] 0 end-1] "."]
                 } catch {* ec result} {
                     ui_debug "sw_vers exists but running it failed: $result"
                 }
@@ -1127,10 +1129,10 @@ match macports.conf.default."
     }
 
     if {![info exists macports::macosx_deployment_target]} {
-        set macports::macosx_deployment_target $macosx_version
+        set macports::macosx_deployment_target $macosx_major_version
     }
     if {![info exists macports::macosx_sdk_version]} {
-        set macports::macosx_sdk_version $macosx_version
+        set macports::macosx_sdk_version $macosx_major_version
     }
 
     if {![info exists macports::revupgrade_autorun]} {

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -469,7 +469,7 @@ proc portconfigure::configure_get_ld_archflags {} {
 }
 
 proc portconfigure::configure_get_sdkroot {sdk_version} {
-    global developer_dir macosx_version xcodeversion os.arch os.platform use_xcode
+    global developer_dir macosx_version macosx_major_version xcodeversion os.arch os.platform use_xcode
 
     # This is only relevant for macOS
     if {${os.platform} ne "darwin"} {
@@ -477,12 +477,12 @@ proc portconfigure::configure_get_sdkroot {sdk_version} {
     }
 
     # Special hack for Tiger/ppc, since the system libraries do not contain intel slices
-    if {${os.arch} eq "powerpc" && $macosx_version eq "10.4" && [variant_exists universal] && [variant_isset universal]} {
+    if {${os.arch} eq "powerpc" && $macosx_major_version eq "10.4" && [variant_exists universal] && [variant_isset universal]} {
         return ${developer_dir}/SDKs/MacOSX10.4u.sdk
     }
 
     # Use the DevSDK (eg: /usr/include) if present and the requested SDK version matches the host version
-    if {$sdk_version eq $macosx_version && [file exists /usr/include]} {
+    if {$sdk_version eq $macosx_major_version && [file exists /usr/include]} {
         return {}
     }
 

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3261,10 +3261,10 @@ proc check_supported_archs {} {
 
 # check if the installed xcode version is new enough
 proc _check_xcode_version {} {
-    global os.subplatform os.major macosx_version xcodeversion use_xcode subport
+    global os.subplatform os.major macosx_version macosx_major_version xcodeversion use_xcode subport
 
     if {${os.subplatform} eq "macosx"} {
-        switch $macosx_version {
+        switch $macosx_major_version {
             10.4 {
                 set min 2.0
                 set ok 2.4.1
@@ -3341,10 +3341,10 @@ proc _check_xcode_version {} {
                 return 1
             }
         } elseif {[vercmp $xcodeversion $min] < 0} {
-            ui_error "The installed version of Xcode (${xcodeversion}) is too old to use on the installed OS version. Version $rec or later is recommended on macOS ${macosx_version}."
+            ui_error "The installed version of Xcode (${xcodeversion}) is too old to use on the installed OS version. Version $rec or later is recommended on macOS ${macosx_major_version}."
             return 1
         } elseif {[vercmp $xcodeversion $ok] < 0} {
-            ui_warn "The installed version of Xcode (${xcodeversion}) is known to cause problems. Version $rec or later is recommended on macOS ${macosx_version}."
+            ui_warn "The installed version of Xcode (${xcodeversion}) is known to cause problems. Version $rec or later is recommended on macOS ${macosx_major_version}."
         }
 
         # Xcode 4.3 and above requires the command-line utilities package to be installed.


### PR DESCRIPTION
Previously macosx_version was set to the major version (e.g. 10.5). A
new variable macosx_major_version is added to avoid numerious splits
and joins.
Any checks using vercmp will still work.

Closes: https://trac.macports.org/ticket/56252