### PR TITLE
Fix machinsta1.0 test by removing ', reexport' from the otool output

### DIFF
--- a/src/machista1.0/tests/libmachista-test.c
+++ b/src/machista1.0/tests/libmachista-test.c
@@ -174,18 +174,23 @@ static bool compare_to_otool_output(char *path, const macho_t *ref) {
 			char lib_path[_POSIX_PATH_MAX];
 			char lib_comp_version[256];
 			char lib_curr_version[256];
+			char lib_curr_version_tmp[256];
 
 			// read loadcommand output line from otool
-			if (3 != fscanf(tmpf, "%*[\n]%*[\t]%255s (compatibility version %255[^,], current version %255[^)]))", lib_path, lib_comp_version, lib_curr_version)) {
+			if (3 != fscanf(tmpf, "%*[\n]%*[\t]%255s (compatibility version %255[^,], current version %255[^)]))", lib_path, lib_comp_version, lib_curr_version_tmp)) {
 				// error out silently, probably been the last line
 				break;
 			}
 
 			nullterminate(lib_path);
 			nullterminate(lib_comp_version);
-			nullterminate(lib_curr_version);
+			nullterminate(lib_curr_version_tmp);
 
-			//printf("\t\t%s, %s, %s\n", lib_path, lib_comp_version, lib_curr_version);
+			//printf("\t\t%s, %s, %s\n", lib_path, lib_comp_version, lib_curr_version_tmp);
+
+			// Remove any extra after version (e.g. ', reexport' in 10.15)
+			sscanf(lib_curr_version_tmp, "%255[^,]", lib_curr_version);
+			nullterminate(lib_comp_version);
 
 			// try to find the library in this architecture's list of loadcommands
 			macho_loadcmd_t *mlt;


### PR DESCRIPTION
In Catalina 10.15, the output of otool changed.
This fixes the machista1.0 test 'parsing libSystem.B.dylib'.

Library current version mismatch. Expected `83.0.0, reexport', was
    `83.0.0'

10.13 example:
/usr/lib/system/libxpc.dylib (compatibility version 1.0.0,
    current version 1205.70.15)

10.15 example:
/usr/lib/system/libxpc.dylib (compatibility version 1.0.0,
    current version 1738.120.8, reexport)

Tested in 10.13 and 10.15.

Closes: https://trac.macports.org/ticket/60580