### PR TITLE
portconfigure.tcl - set sdk to "/" if that's what we're using

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -483,7 +483,7 @@ proc portconfigure::configure_get_sdkroot {sdk_version} {
 
     # Use the DevSDK (eg: /usr/include) if present and the requested SDK version matches the host version
     if {$sdk_version eq $macosx_version && [file exists /usr/include]} {
-        return {}
+        return {"/"}
     }
 
     set cltpath /Library/Developer/CommandLineTools


### PR DESCRIPTION
leaving it as an empty string causes each individual port
to check whether it is empty and set it to "/" if so

closes: https://trac.macports.org/ticket/59798