### PR TITLE
Abort 'port test' early if test.run is set to no

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2227,6 +2227,14 @@ proc mportexec {mport target} {
         set log_needs_pop yes
     }
 
+    if {$target eq "test"} {
+        # Before continuing with dependents, verify test.run is present and yes
+        set test_valid [catch {_mportkey $mport test.run} res]
+        if {$test_valid != 0 || $res ne "yes"} {
+            return -code error [format [msgcat::mc "%s has no tests turned on. see 'test.run' in portfile(7)"] $portname]
+        }
+    }
+
     # Use _target_needs_toolchain as a proxy for whether we're going to build
     # and will therefore need to check Xcode version and supported_archs.
     if {[macports::_target_needs_toolchain $workername $target]} {

--- a/tests/test/checksums-1/Portfile
+++ b/tests/test/checksums-1/Portfile
@@ -32,6 +32,7 @@ destroot {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     # test is actually running checksum target
 }

--- a/tests/test/dependencies-a/Portfile
+++ b/tests/test/dependencies-a/Portfile
@@ -27,6 +27,7 @@ variant i_want_b {
     depends_lib-append  port:dependencies-b
 }
 
+test.run    yes
 test {
     # testing consists in processing dependencies
 }

--- a/tests/test/dependencies-b/Portfile
+++ b/tests/test/dependencies-b/Portfile
@@ -21,6 +21,7 @@ destroot {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     # testing consists in processing dependencies
 }

--- a/tests/test/dependencies-c/Portfile
+++ b/tests/test/dependencies-c/Portfile
@@ -27,6 +27,7 @@ variant i_want_a {
     depends_lib-append  port:dependencies-a
 }
 
+test.run    yes
 test {
     # testing consists in processing dependencies
 }

--- a/tests/test/dependencies-d/Portfile
+++ b/tests/test/dependencies-d/Portfile
@@ -29,6 +29,7 @@ depends_lib     port:-i_want_b:dependencies-a
 # Check that macports doesn't chunk on this junk, but just generates a warning.
 depends {configure {dependencies-a +i_want_b >= 1}}
 
+test.run    yes
 test {
     # testing consists in processing dependencies
 }

--- a/tests/test/dependencies-e/Portfile
+++ b/tests/test/dependencies-e/Portfile
@@ -27,6 +27,7 @@ depends_build   port:docbook-xml-4.1.2 \
                 port:docbook-xml-4.4 \
                 port:docbook-xml-4.5
 
+test.run    yes
 test {
     # testing consists in processing dependencies
 }

--- a/tests/test/envvariables/Portfile
+++ b/tests/test/envvariables/Portfile
@@ -21,6 +21,7 @@ destroot {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     puts $env(ENVA)
     puts $env(ENVB)

--- a/tests/test/setuid/Portfile
+++ b/tests/test/setuid/Portfile
@@ -28,6 +28,7 @@ destroot {
     touch ${destroot}${prefix}/lib/${name}
 }
 
+test.run    yes
 test {
     # test is actually running build target
 }

--- a/tests/test/site-tags/Portfile
+++ b/tests/test/site-tags/Portfile
@@ -33,6 +33,7 @@ destroot {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     # test is actually running the fetch target
 }

--- a/tests/test/trace/Portfile
+++ b/tests/test/trace/Portfile
@@ -21,6 +21,7 @@ destroot {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     proc fails {operation} {
         if {![catch $operation]} {

--- a/tests/test/variants/Portfile
+++ b/tests/test/variants/Portfile
@@ -21,6 +21,7 @@ destroot {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     # test is actually installing this.
 }

--- a/tests/test/xcodeversion/Portfile
+++ b/tests/test/xcodeversion/Portfile
@@ -19,6 +19,7 @@ destroot    {
     system "touch ${destroot}${prefix}/lib/${name}"
 }
 
+test.run    yes
 test {
     if {$xcodeversion != "" && [vercmp $xcodeversion 2.1] >= 0} {
         ui_msg "xcodeversion >= 2.1"


### PR DESCRIPTION
This will avoid installing dependencies if tests is not enabled.

Closes: https://trac.macports.org/ticket/45010