### PR TITLE
tests: Fix curl isnewer test broken by braeburn update

### DIFF
--- a/src/pextlib1.0/tests/curl.tcl
+++ b/src/pextlib1.0/tests/curl.tcl
@@ -8,20 +8,18 @@ proc main {pextlibname} {
 	set tempfile /tmp/macports-pextlib-testcurl
 
 	# download a dummy file over HTTP.
-	set dummyroot http://svn.macports.org/repository/macports/users/eridius/curltest
-	curl fetch --ignore-ssl-cert $dummyroot/dummy $tempfile
+	set dummyfile http://distfiles.macports.org/MacPorts/MacPorts-2.6.2.tar.gz.asc
+	curl fetch $dummyfile $tempfile
 	
 	# check the md5 sum of the file.
-	test "md5sum" {[md5 file $tempfile] == "5421fb0f76c086a1e14bf33d25b292d4"}
+	test "md5sum" {[md5 file $tempfile] == "41023b6070d3dda3b5d34b7e773b40fc"}
 
 	# check we indeed get a 404 a dummy file over HTTP.
-	test "dummy404" {[catch {curl fetch --ignore-ssl-cert $dummyroot/404 $tempfile}]}
+	test "dummy404" {[catch {curl fetch $dummyfile/404 $tempfile}]}
 	
 	# check the modification date of the dummy file.
-	set seconds [clock scan 2007-06-16Z]
-	test "mtime1" {[curl isnewer --ignore-ssl-cert $dummyroot/dummy [clock scan 2007-06-16Z]]}
-	set seconds [clock scan 2007-06-17Z]
-	test "mtime2" {![curl isnewer --ignore-ssl-cert $dummyroot/dummy [clock scan 2007-06-17Z]]}
+	test "mtime1" {[curl isnewer $dummyfile [clock scan 2019-10-20Z]]}
+	test "mtime2" {![curl isnewer $dummyfile [clock scan 2019-10-21Z]]}
 	
 	# use --disable-epsv
 	#curl fetch --disable-epsv ftp://ftp.cup.hp.com/dist/networking/benchmarks/netperf/archive/netperf-2.2pl5.tar.gz $tempfile


### PR DESCRIPTION
Updating braeburn to a subversion version >= 1.10.0 broke this test, because the subversion backend no longer delivers the `Last-Modified` header.

Switch to a URL under our control that does and, adjust the other tests as required, update the timestamps to check in the `curl isnewer` testcases, and drop unused variables.

Ideally, we wouldn't be relying on a remote server for this test and start a local one, but Apple doesn't ship `/usr/bin/python3` on modern systems, we should probably not rely on `/usr/bin/python` being around for very much longer, and I'm not aware of any other quick-and-dirty
webservers we could start for the test short of writing our own.

Closes: https://trac.macports.org/ticket/60630