### PR TITLE
aclocal.m4: Run distclean before config in subdirs

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -125,6 +125,14 @@ AC_DEFUN([MP_CONFIG_SUBDIR], [
 	if test "$no_recursion" != yes || test ! -f "$ac_srcdir/config.status"; then
 		AC_MSG_NOTICE([=== configuring in $ac_dir ($mp_popdir/$ac_dir)])
 		if test -f "$ac_srcdir/configure"; then
+			# Run 'make distclean' first, ignoring errors; unfortunately some
+			# of our projects are not reconfigure-safe and will not correctly
+			# pick up modified configure variables or recompile files affected
+			# by such variables. See
+			# https://github.com/macports/macports-base/pull/79 and
+			# https://github.com/macports/macports-base/pull/80
+			make distclean || true
+
 			mp_sub_configure_args=
 			mp_sub_configure_keys=
 			# Compile a list of keys that have been given to the MP_CONFIG_SUBDIR

--- a/configure
+++ b/configure
@@ -7720,6 +7720,14 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&5
 $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 		if test -f "$ac_srcdir/configure"; then
+			# Run 'make distclean' first, ignoring errors; unfortunately some
+			# of our projects are not reconfigure-safe and will not correctly
+			# pick up modified configure variables or recompile files affected
+			# by such variables. See
+			# https://github.com/macports/macports-base/pull/79 and
+			# https://github.com/macports/macports-base/pull/80
+			make distclean || true
+
 			mp_sub_configure_args=
 			mp_sub_configure_keys=
 			# Compile a list of keys that have been given to the MP_CONFIG_SUBDIR
@@ -8038,6 +8046,14 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&5
 $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 		if test -f "$ac_srcdir/configure"; then
+			# Run 'make distclean' first, ignoring errors; unfortunately some
+			# of our projects are not reconfigure-safe and will not correctly
+			# pick up modified configure variables or recompile files affected
+			# by such variables. See
+			# https://github.com/macports/macports-base/pull/79 and
+			# https://github.com/macports/macports-base/pull/80
+			make distclean || true
+
 			mp_sub_configure_args=
 			mp_sub_configure_keys=
 			# Compile a list of keys that have been given to the MP_CONFIG_SUBDIR
@@ -8351,6 +8367,14 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&5
 $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 		if test -f "$ac_srcdir/configure"; then
+			# Run 'make distclean' first, ignoring errors; unfortunately some
+			# of our projects are not reconfigure-safe and will not correctly
+			# pick up modified configure variables or recompile files affected
+			# by such variables. See
+			# https://github.com/macports/macports-base/pull/79 and
+			# https://github.com/macports/macports-base/pull/80
+			make distclean || true
+
 			mp_sub_configure_args=
 			mp_sub_configure_keys=
 			# Compile a list of keys that have been given to the MP_CONFIG_SUBDIR
@@ -8666,6 +8690,14 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&5
 $as_echo "$as_me: === configuring in $ac_dir ($mp_popdir/$ac_dir)" >&6;}
 		if test -f "$ac_srcdir/configure"; then
+			# Run 'make distclean' first, ignoring errors; unfortunately some
+			# of our projects are not reconfigure-safe and will not correctly
+			# pick up modified configure variables or recompile files affected
+			# by such variables. See
+			# https://github.com/macports/macports-base/pull/79 and
+			# https://github.com/macports/macports-base/pull/80
+			make distclean || true
+
 			mp_sub_configure_args=
 			mp_sub_configure_keys=
 			# Compile a list of keys that have been given to the MP_CONFIG_SUBDIR


### PR DESCRIPTION
Some of our vendored dependencies are not reconfigure-safe without a distclean when changing, for example, `--prefix`. Specifically, this applies to Tcl, which does not recompile some of the files that contain the hardcoded prefix.

This leads to incorrect behavior when such a reconfigured MacPorts build directory is installed – the bundled Tcl interpreter may end up loading its packages from the previously configured `--prefix`.

Avoid this by always running `make distclean` in the build directory before running configure, but ignoring any errors, e.g. if the tree was not yet configured, or no distclean target exists in the Makefile.

See https://github.com/macports/macports-base/pull/79 and https://github.com/macports/macports-base/pull/80 for previous discussion of the issue.