### PR TITLE
Don't add extra quoting to startupitems key values

### DIFF
--- a/src/port1.0/portstartupitem.tcl
+++ b/src/port1.0/portstartupitem.tcl
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 # portstartupitem.tcl
 #
-# Copyright (c) 2004-2012 The MacPorts Project
+# Copyright (c) 2004-2014, 2016-2018, 2020 The MacPorts Project
 # Copyright (c) 2006-2007 James D. Berry
 # Copyright (c) 2004,2005 Markus W. Weissman <mww@macports.org>
 # All rights reserved.
@@ -146,7 +146,7 @@ proc portstartupitem::foreach_startupitem {body} {
                 lappend startupitems_dict($curname) uniquename $uniquename
                 lappend startupitems_dict($curname) plist ${uniquename}.plist
             }
-            lappend startupitems_dict($curname) $key [list $val]
+            lappend startupitems_dict($curname) $key $val
         }
     } else {
         global startupitem.name

--- a/src/port1.0/tests/portstartupitem.test
+++ b/src/port1.0/tests/portstartupitem.test
@@ -20,25 +20,81 @@ macports_worker_init
 package require port 1.0
 package require portstartupitem 1.0
 
-test startupitems {
-    startupitems unit test. Check that the name seen in foreach_startupitem\
-    is the same whether set via the startupitem.name option or via key+value\
-    in the startupitems option.
+
+test startupitems_executable {
+    Check that setting the startupitem.executable option behaves the\
+    same as setting executable via the startupitems option.
 } -setup {
     set system_options(startupitem_install) yes
 } -body {
-    startupitem.name    testname
+    startupitem.executable  ${prefix}/sbin/mydaemon -flag1 "quoted string"
     portstartupitem::foreach_startupitem {
-        set single_result $si_name
+        set single_result [list {*}$si_executable]
     }
-    startupitems        name testname
+    startupitems \
+                name        testname \
+                executable  "${prefix}/sbin/mydaemon -flag1 \"quoted string\""
     portstartupitem::foreach_startupitem {
-        set multi_result $si_name
+        set multi_result [list {*}$si_executable]
     }
     if {$single_result ne $multi_result} {
         return "ERROR: single_result = '$single_result' but multi_result = '$multi_result'"
     }
-    return "startupitems successful."
-} -result "startupitems successful."
+    return "startupitems_executable successful."
+} -cleanup {
+    startupitems
+} -result "startupitems_executable successful."
+
+
+test startupitems_name {
+    Check that setting the startupitem.name option behaves the\
+    same as setting name via the startupitems option.
+} -setup {
+    set system_options(startupitem_install) yes
+} -body {
+    startupitem.name        testname
+    portstartupitem::foreach_startupitem {
+        set single_result [list {*}$si_name]
+    }
+    startupitems \
+                name        testname
+    portstartupitem::foreach_startupitem {
+        set multi_result [list {*}$si_name]
+    }
+    if {$single_result ne $multi_result} {
+        return "ERROR: single_result = '$single_result' but multi_result = '$multi_result'"
+    }
+    return "startupitems_name successful."
+} -cleanup {
+    startupitems
+} -result "startupitems_name successful."
+
+
+test startupitems_start {
+    Check that setting the startupitem.start option behaves the\
+    same as setting start via the startupitems option.
+} -setup {
+    set system_options(startupitem_install) yes
+} -body {
+    startupitem.start       "${prefix}/sbin/daemon1 start -flag1 \"quoted string\"" \
+                            "${prefix}/sbin/daemon2 start -flag2 -flag3"
+    portstartupitem::foreach_startupitem {
+        set single_result [list {*}$si_start]
+    }
+    startupitems \
+                name        testname \
+                start       "\"${prefix}/sbin/daemon1 start -flag1 \\\"quoted string\\\"\" \
+                            \"${prefix}/sbin/daemon2 start -flag2 -flag3\""
+    portstartupitem::foreach_startupitem {
+        set multi_result [list {*}$si_start]
+    }
+    if {$single_result ne $multi_result} {
+        return "ERROR: single_result = '$single_result' but multi_result = '$multi_result'"
+    }
+    return "startupitems_start successful."
+} -cleanup {
+    startupitems
+} -result "startupitems_start successful."
+
 
 cleanupTests


### PR DESCRIPTION
This allows multi-command start, stop and init values to work and allows executable values with arguments to work and gives the startupitems keyword feature parity with the older startupitem keywords.

Unfortunately it is also a change in syntax for existing users of the start, stop, init and executable keys of the startupitems keyword if the values of those keys contain whitespace. Additional quoting is now required.

See my question on the mailing list:

https://lists.macports.org/pipermail/macports-dev/2020-June/041973.html

Fortunately the list of affected ports using this syntax is small. The only affected ports I found are:

* [adblock2privoxy](https://github.com/macports/macports-ports/blob/master/www/adblock2privoxy/Portfile#L107-L139)
* [clamav-server](https://github.com/macports/macports-ports/blob/master/sysutils/clamav-server/Portfile#L47-L133)
* [macos-fortress](https://github.com/macports/macports-ports/blob/master/net/macos-fortress/Portfile#L287-L314)
* [mail-server](https://github.com/macports/macports-ports/blob/master/mail/mail-server/Portfile#L827-L877)
