### PR TITLE
portconfigure.tcl: use clang5+ for cxx11+ if not libc++

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -903,9 +903,19 @@ proc portconfigure::get_min_clang {} {
     if {${compiler.cxx_standard} >= 2017} {
         set min_value [max_version $min_value 5.0]
     } elseif {${compiler.cxx_standard} >= 2014} {
-        set min_value [max_version $min_value 3.4]
+        if {[option configure.cxx_stdlib] eq "libc++"} {
+            set min_value [max_version $min_value 3.4]
+        } else {
+            # macports-libstdc++ only macports-clang compilers >= 5.0 support this
+            set min_value [max_version $min_value 5.0]
+        }
     } elseif {${compiler.cxx_standard} >= 2011} {
-        set min_value [max_version $min_value 3.3]
+        if {[option configure.cxx_stdlib] eq "libc++"} {
+            set min_value [max_version $min_value 3.3]
+        } else {
+            # macports-libstdc++ only macports-clang compilers >= 5.0 support this
+            set min_value [max_version $min_value 5.0]
+        }
     }
     if {[vercmp ${compiler.openmp_version} 4.0] >= 0} {
         set min_value [max_version $min_value 6.0]


### PR DESCRIPTION
only macports-clang-5+ clang compilers will accept macports-libstdc++

closes: https://trac.macports.org/ticket/59717

Presently, when a build calls for cxx_standard 2011, base will try to use clang-3.4 or clang-3.7 on PPC and on Intel if defaults are not to libc++.

This always fails, and either tries to call in libcxx on PPC (fails) or tries to send ```-stdlib=macports-libstdc++``` to clang 3.4 or clang-3.7 (fails).
