### PR TITLE
Require clang >= 500 for C11

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -1,6 +1,6 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
 #
-# Copyright (c) 2007 - 2015 The MacPorts Project
+# Copyright (c) 2007 - 2020 The MacPorts Project
 # Copyright (c) 2007 Markus W. Weissmann <mww@macports.org>
 # Copyright (c) 2002 - 2003 Apple Inc.
 # All rights reserved.
@@ -793,7 +793,7 @@ proc portconfigure::max_version {verA verB} {
 #|------------------------------------------------------------------|
 #| 1998 (C++98) |     -     |       -       |     -     |     -     |
 #| 2011 (C++11) |    3.3    |   500.2.75    |    5.0    |   4.8.1   |
-#| 2014 (C++14) |    3.4    |   602         |    6.3    |     5     |
+#| 2014 (C++14) |    3.4    |   602.0.49    |    6.3    |     5     |
 #| 2017 (C++17) |    5.0    |   902.0.39.1  |    9.3    |     7     |
 #--------------------------------------------------------------------
 #
@@ -854,7 +854,7 @@ proc portconfigure::get_min_command_line {compiler} {
             if {${compiler.cxx_standard} >= 2017} {
                 set min_value [max_version $min_value 902.0.39.1]
             } elseif {${compiler.cxx_standard} >= 2014} {
-                set min_value [max_version $min_value 602]
+                set min_value [max_version $min_value 602.0.49]
             } elseif {${compiler.cxx_standard} >= 2011} {
                 if {${compiler.thread_local_storage}} {
                     # macOS has supported thread-local storage since Mac OS X Lion.

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -770,6 +770,8 @@ proc portconfigure::max_version {verA verB} {
 }
 #
 # https://releases.llvm.org/3.1/docs/ClangReleaseNotes.html#cchanges
+# _Noreturn implemented in clang 3.3.0:
+# https://github.com/llvm/llvm-project/commit/debc59d1f360b1f7a041de72c02d76ed131370c6
 # https://gcc.gnu.org/c99status.html
 # https://gcc.gnu.org/wiki/C11Status
 # https://trac.macports.org/wiki/XcodeVersionInfo
@@ -778,7 +780,7 @@ proc portconfigure::max_version {verA verB} {
 #|------------------------------------------------------------------|
 #| 1989 (C89)   |     -     |        -      |     -     |     -     |
 #| 1999 (C99)   |     -     |        -      |     -     |    4.0    |
-#| 2011 (C11)   |    3.1    |    318.0.61   |    4.3    |    4.9    |
+#| 2011 (C11)   |    3.3    |   500.2.75    |    5.0    |    4.9    |
 #--------------------------------------------------------------------
 #
 # https://clang.llvm.org/cxx_status.html
@@ -847,7 +849,7 @@ proc portconfigure::get_min_command_line {compiler} {
                 return none
             }
             if {${compiler.c_standard} >= 2011} {
-                set min_value [max_version $min_value 318.0.61]
+                set min_value [max_version $min_value 500.2.75]
             }
             if {${compiler.cxx_standard} >= 2017} {
                 set min_value [max_version $min_value 902.0.39.1]


### PR DESCRIPTION
Currently MacPorts base considers clang 318 to be new enough to support C11. However in https://trac.macports.org/ticket/58919 fontforge failed to build because:

```
scripting.c:10698:1: error: unknown type name '_Noreturn'
```

This predated the existence of `compiler.c_standard` so clang < 318 was manually blacklisted, but this was not enough; it was fixed by blacklisting clang < 500.

Similarly in https://trac.macports.org/ticket/59066 it was determined that ipmitool requires C11 and `compiler.c_standard 2011` was added, but [this still fails to build](https://build.macports.org/builders/ports-10.7_x86_64-builder/builds/24322/steps/install-port/logs/stdio):

```
/opt/local/include/openssl/crypto.h:322:1: error: unknown type name '_Noreturn'
```

This PR proposes changing the minimum clang version for `compiler.c_standard 2011` to 500 so that support for `_Noreturn` (which seems to be [a standard part of C11](https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29#Changes_from_C99)) is guaranteed to be available.