### PR TITLE
Fix shellescape to work on Tiger

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -5,7 +5,7 @@
 # Copyright (c) 2004 - 2005 Paul Guyot, <pguyot@kallisys.net>.
 # Copyright (c) 2004 - 2006 Ole Guldberg Jensen <olegb@opendarwin.org>.
 # Copyright (c) 2004 - 2005 Robert Shaw <rshaw@opendarwin.org>
-# Copyright (c) 2004 - 2016 The MacPorts Project
+# Copyright (c) 2004 - 2020 The MacPorts Project
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -5557,18 +5557,10 @@ proc macports::get_archive_sites_conf_values {} {
 # @param arg The argument that should be escaped for use in a POSIX shell
 # @return A quoted version of the argument
 proc macports::shellescape {arg} {
-    set mapping {}
-    # Replace each backslash by a double backslash. Apparently Bash treats Backslashes in single-quoted strings
-    # differently depending on whether is was invoked as sh or bash: echo 'using \backslashes' preserves the backslash
-    # in bash mode, but interprets it in sh mode. Since the `system' command uses sh, escape backslashes.
-    lappend mapping "\\" "\\\\"
-    # Replace each single quote with a single quote (closing the currently open string), an escaped single quote \'
-    # (additional backslash needed to escape the backslash in Tcl), and another single quote (opening a new quoted
-    # string).
-    lappend mapping "'" "'\\''"
-
-    # Add a single quote at the start, escape all single quotes in the argument, and add a single quote at the end
-    return "'[string map $mapping $arg]'"
+    # Put a bashslash in front of every character that is not safe. This
+    # may not be an exhaustive list of safe characters but it is allowed
+    # to put a backslash in front of safe characters too.
+    return [regsub -all -- {[^A-Za-z0-9.:@%/+=_-]} $arg {\\&}]
 }
 
 ##

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -1042,10 +1042,10 @@ test shellescaping {
     set first "yes"
     foreach test $shellescapeTests {
         if {$first eq "yes"} {
-            system "echo [macports::shellescape $test]  >$outputfile"
+            system "printf '%s\n' [macports::shellescape $test]  >$outputfile"
             set first "no"
         } else {
-            system "echo [macports::shellescape $test] >>$outputfile"
+            system "printf '%s\n' [macports::shellescape $test] >>$outputfile"
         }
     }
 


### PR DESCRIPTION
Fix shellescape to work on Tiger

Closes: https://trac.macports.org/ticket/56626

The previous code relied on the fact that we use `sh` for `system` and `sh` is supposed to be a POSIX shell but on Tiger it isn't; Leopard was the first POSIX compliant Mac OS X version