### PR TITLE
Do not interpose functions before initialization

### DIFF
--- a/src/darwintracelib1.0/access.c
+++ b/src/darwintracelib1.0/access.c
@@ -39,6 +39,10 @@
 #include <unistd.h>
 
 static int _dt_access(const char *path, int amode) {
+	if (!__darwintrace_initialized) {
+		return access(path, amode);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/darwintracelib1.0/close.c
+++ b/src/darwintracelib1.0/close.c
@@ -48,6 +48,10 @@
  * will be set to the FD to be closed when closing should be allowed.
  */
 static int _dt_close(int fd) {
+	if (!__darwintrace_initialized) {
+		return close(fd);
+	}
+
 	__darwintrace_setup();
 
 	FILE *stream = __darwintrace_sock();

--- a/src/darwintracelib1.0/darwintrace.h
+++ b/src/darwintracelib1.0/darwintrace.h
@@ -130,6 +130,12 @@ void __darwintrace_close();
  */
 bool __darwintrace_is_in_sandbox(const char *path, int flags);
 
+/**
+ * Whether darwintrace has been fully initialized or not. Do not interpose if
+ * this has not been set to true.
+ */
+volatile bool __darwintrace_initialized;
+
 #ifdef DARWINTRACE_USE_PRIVATE_API
 #include <errno.h>
 #include <stdlib.h>
@@ -182,4 +188,22 @@ static inline void __darwintrace_sock_set(FILE *stream) {
 		abort();
 	}
 }
+
+/**
+ * Initialize TLS variables.
+ */
+void __darwintrace_setup_tls();
+
+/**
+ * Grab environment variables at startup.
+ */
+void __darwintrace_store_env();
+
+/**
+ * Runs our "constructors". By this point all of the system libraries we link
+ * against should be fully initialized, so we can call their functions safely.
+ * Once our initialization is complete we may begin interposing.
+ */
+void __darwintrace_run_constructors() __attribute__((constructor));
+
 #endif /* defined(DARWINTRACE_USE_PRIVATE_API) */

--- a/src/darwintracelib1.0/dup2.c
+++ b/src/darwintracelib1.0/dup2.c
@@ -46,6 +46,10 @@
  * FDs are numbered in ascending order.
  */
 static int _dt_dup2(int filedes, int filedes2) {
+	if (!__darwintrace_initialized) {
+		return dup2(filedes, filedes2);
+	}
+
 	__darwintrace_setup();
 
 	FILE *stream = __darwintrace_sock();

--- a/src/darwintracelib1.0/mkdir.c
+++ b/src/darwintracelib1.0/mkdir.c
@@ -51,6 +51,10 @@
  * outside the sandbox that already exist.
  */
 static int _dt_mkdir(const char *path, mode_t mode) {
+	if (!__darwintrace_initialized) {
+		return mkdir(path, mode);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/darwintracelib1.0/open.c
+++ b/src/darwintracelib1.0/open.c
@@ -46,6 +46,15 @@
  * when attempting to create a file, i.e., when \c O_CREAT is set.
  */
 static int _dt_open(const char *path, int flags, ...) {
+	if (!__darwintrace_initialized) {
+		va_list args;
+		va_start(args, flags);
+		mode_t mode = va_arg(args, int);
+		va_end(args);
+
+		return open(path, flags, mode);
+	}
+
 	__darwintrace_setup();
 	int result = 0;
 

--- a/src/darwintracelib1.0/readdir.c
+++ b/src/darwintracelib1.0/readdir.c
@@ -67,6 +67,10 @@ struct dirent64  {
 size_t __getdirentries64(int fd, void *buf, size_t bufsize, __darwin_off_t *basep);
 
 static size_t _dt_getdirentries64(int fd, void *buf, size_t bufsize, __darwin_off_t *basep) {
+	if (!__darwintrace_initialized) {
+		return __getdirentries64(fd, buf, bufsize, basep);
+	}
+
 	__darwintrace_setup();
 
 	size_t sz = __getdirentries64(fd, buf, bufsize, basep);
@@ -123,6 +127,10 @@ struct dirent32 {
 int getdirentries(int fd, char *buf, int nbytes, long *basep);
 
 static int _dt_getdirentries(int fd, char *buf, int nbytes, long *basep) {
+	if (!__darwintrace_initialized) {
+		return getdirentries(fd, buf, nbytes, basep);
+	}
+
 	__darwintrace_setup();
 
 	size_t sz = getdirentries(fd, buf, nbytes, basep);

--- a/src/darwintracelib1.0/readlink.c
+++ b/src/darwintracelib1.0/readlink.c
@@ -43,6 +43,10 @@
  * Deny \c readlink(2) if the file is not within the sandbox bounds.
  */
 static ssize_t _dt_readlink(const char *path, char *buf, size_t bufsiz) {
+	if (!__darwintrace_initialized) {
+		return readlink(path, buf, bufsiz);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/darwintracelib1.0/rename.c
+++ b/src/darwintracelib1.0/rename.c
@@ -44,6 +44,10 @@
  * sandbox.
  */
 static int _dt_rename(const char *from, const char *to) {
+	if (!__darwintrace_initialized) {
+		return rename(from, to);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/darwintracelib1.0/rmdir.c
+++ b/src/darwintracelib1.0/rmdir.c
@@ -44,6 +44,10 @@
  * sandbox.
  */
 static int _dt_rmdir(const char *path) {
+	if (!__darwintrace_initialized) {
+		return rmdir(path);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/darwintracelib1.0/stat.c
+++ b/src/darwintracelib1.0/stat.c
@@ -50,6 +50,10 @@ int stat(const char *path, void *sb);
  * sandbox.
  */
 static int _dt_stat(const char *path, void *sb) {
+	if (!__darwintrace_initialized) {
+		return stat(path, sb);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;
@@ -75,6 +79,10 @@ int stat64(const char *path, void *sb);
 int stat$INODE64(const char *path, void *sb);
 
 static int _dt_stat64(const char *path, void *sb) {
+	if (!__darwintrace_initialized) {
+		return stat64(path, sb);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;
@@ -99,6 +107,10 @@ DARWINTRACE_INTERPOSE(_dt_stat64, stat$INODE64);
 int lstat(const char *path, void *sb);
 
 static int _dt_lstat(const char *path, void *sb) {
+	if (!__darwintrace_initialized) {
+		return lstat(path, sb);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;
@@ -125,6 +137,10 @@ int lstat64(const char *path, void *sb);
 int lstat$INODE64(const char *path, void *sb);
 
 static int _dt_lstat64(const char *path, void *sb) {
+	if (!__darwintrace_initialized) {
+		return lstat64(path, sb);
+	}
+
 	__darwintrace_setup();
 
 	int result = 0;

--- a/src/darwintracelib1.0/unlink.c
+++ b/src/darwintracelib1.0/unlink.c
@@ -44,6 +44,10 @@
  * of the sandbox and simulate non-existence of the file instead.
  */
 static int _dt_unlink(const char *path) {
+	if (!__darwintrace_initialized) {
+		return unlink(path);
+	}
+	
 	__darwintrace_setup();
 
 	int result = 0;


### PR DESCRIPTION
Static initializers have no defined order in which they are run; interposed functions, however, take effect at program initialization. In some cases, our interposed functions would be called by libSystem's constructors and prior to *our* constructors, and this would lead to crashes in trace mode as we would be in an uninitialized state. All our interposers now immediately delegate to their interposees until the are sure initialization has been performed.