### PR TITLE
sandbox: handle /opt/local on separate mountpoint

### DIFF
--- a/src/port1.0/portsandbox.tcl
+++ b/src/port1.0/portsandbox.tcl
@@ -29,6 +29,7 @@
 
 package provide portsandbox 1.0
 package require porttrace 1.0
+package require portutil 1.0
 
 namespace eval portsandbox {
 }
@@ -44,7 +45,7 @@ default portsandbox_profile {}
 proc portsandbox::set_profile {target} {
     global os.major portsandbox_profile workpath distpath \
         package.destpath configure.ccache ccache_dir \
-        sandbox_network configure.distcc porttrace
+        sandbox_network configure.distcc porttrace prefix
 
     switch $target {
         activate -
@@ -98,6 +99,20 @@ proc portsandbox::set_profile {target} {
     set perms [list file-write*]
     if {${os.major} >= 17} {
         lappend perms file-write-setugid
+    }
+
+
+    # If ${prefix} is own its own volume, grant access to its
+    # temporary items directory, used by Xcode tools
+    set mountpoint [get_mountpoint ${prefix}]
+
+    if {$mountpoint != "/"} {
+        set extradir [file join $mountpoint ".TemporaryItems"]
+
+        if {[file isdirectory $extradir]} {
+            ui_debug "adding $extradir to allowed Sandbox paths"
+            lappend allow_dirs $extradir
+        }
     }
 
     foreach dir $allow_dirs {

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3469,3 +3469,22 @@ proc _archive_available {} {
     set archive_available_result 0
     return 0
 }
+
+# get the mountpoint providing a given directory
+proc get_mountpoint {target_dir} {
+    file stat ${target_dir} target_stat
+
+    set parentdir ${target_dir}
+
+    while {$parentdir ne "/"} {
+        file stat [file dirname $parentdir] stat
+
+        if {$stat(dev) != $target_stat(dev)} {
+            return $parentdir
+        }
+
+        set parentdir [file dirname $parentdir]
+    }
+
+    return $parentdir
+}


### PR DESCRIPTION
Some Xcode builds will fail when /opt is on a separate volume. The nature of the errors vary, for example `tiffutil` will frequently fail. They're all permission-related errors, though.

Looking at the system logs, I noticed this:

```
localhost kernel[0]: (Sandbox) Sandbox: tiffutil(99434) deny(1) file-write-create /opt/.TemporaryItems/folders.502/TemporaryItems/(A Document Being Saved By tiffutil)
```

To address this, I added some code that should detect the mountpoint for `${prefix}`, and add its `.TemporaryItems` to the allowed directories.

It's worth noting that I haven't tested this in the normal setup; the code _ought_ to work, but I'd appreciate the confirmation!