### PR TITLE
configure: remove a bash-ism in daemondo check

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -843,10 +843,10 @@ AC_DEFUN([MP_PROG_DAEMONDO],[
 	result=no
 	case $host_os in
 		darwin*)
-			if test "x$mp_cv_have_framework_corefoundation" == "xyes" &&
-			   test "x$mp_cv_have_framework_systemconfiguration" == "xyes" &&
-			   test "x$mp_cv_have_framework_iokit" == "xyes" &&
-			   test "x$mp_cv_have_function_cfnotificationcentergetdarwinnotifycenter" == "xyes"; then
+			if test "x$mp_cv_have_framework_corefoundation" = "xyes" &&
+			   test "x$mp_cv_have_framework_systemconfiguration" = "xyes" &&
+			   test "x$mp_cv_have_framework_iokit" = "xyes" &&
+			   test "x$mp_cv_have_function_cfnotificationcentergetdarwinnotifycenter" = "xyes"; then
 				result=yes
 				EXTRA_PROGS="$EXTRA_PROGS daemondo"
 				AC_CONFIG_FILES([src/programs/daemondo/Makefile])

--- a/configure
+++ b/configure
@@ -6117,10 +6117,10 @@ $as_echo_n "checking for whether we will build daemondo... " >&6; }
 	result=no
 	case $host_os in
 		darwin*)
-			if test "x$mp_cv_have_framework_corefoundation" == "xyes" &&
-			   test "x$mp_cv_have_framework_systemconfiguration" == "xyes" &&
-			   test "x$mp_cv_have_framework_iokit" == "xyes" &&
-			   test "x$mp_cv_have_function_cfnotificationcentergetdarwinnotifycenter" == "xyes"; then
+			if test "x$mp_cv_have_framework_corefoundation" = "xyes" &&
+			   test "x$mp_cv_have_framework_systemconfiguration" = "xyes" &&
+			   test "x$mp_cv_have_framework_iokit" = "xyes" &&
+			   test "x$mp_cv_have_function_cfnotificationcentergetdarwinnotifycenter" = "xyes"; then
 				result=yes
 				EXTRA_PROGS="$EXTRA_PROGS daemondo"
 				ac_config_files="$ac_config_files src/programs/daemondo/Makefile"


### PR DESCRIPTION
Using '==' with 'test' is not part of the POSIX shell specification, and 'dash' doesn't support it.