### PR TITLE
Fix various checks for OSX10.4 to check minor AND major OS version

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -79,7 +79,7 @@ ifeq ($(DESTDIR),)
                 echo "Not updating home directory location for user \"${RUNUSR}\" (not root)" ; \
             fi ; \
         fi ; \
-        if test `sw_vers -productVersion | /usr/bin/awk -F . '{print $$1}'` -eq 10 -a `sw_vers -productVersion | /usr/bin/awk -F . '{print $$2}'` -eq 4 -a `id -u` -eq 0; then \
+        if test `uname -r | /usr/bin/awk -F . '{print $$1}'` -eq 8 -a `id -u` -eq 0; then \
             GID=`${DSCL} -q . -read "/Groups/${RUNUSR}" PrimaryGroupID | /usr/bin/awk '{print $$2}'` ; \
             if test "`${DSCL} -q . -read "/Users/${RUNUSR}" PrimaryGroupID 2>/dev/null | /usr/bin/awk '{print $$2}'`" != "$$GID"; then \
                 echo "Fixing PrimaryGroupID for user \"${RUNUSR}\"" ; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -79,7 +79,7 @@ ifeq ($(DESTDIR),)
                 echo "Not updating home directory location for user \"${RUNUSR}\" (not root)" ; \
             fi ; \
         fi ; \
-        if test `sw_vers -productVersion | /usr/bin/awk -F . '{print $$2}'` -eq 4 -a `id -u` -eq 0; then \
+        if test `sw_vers -productVersion | /usr/bin/awk -F . '{print $$1}'` -eq 10 -a `sw_vers -productVersion | /usr/bin/awk -F . '{print $$2}'` -eq 4 -a `id -u` -eq 0; then \
             GID=`${DSCL} -q . -read "/Groups/${RUNUSR}" PrimaryGroupID | /usr/bin/awk '{print $$2}'` ; \
             if test "`${DSCL} -q . -read "/Users/${RUNUSR}" PrimaryGroupID 2>/dev/null | /usr/bin/awk '{print $$2}'`" != "$$GID"; then \
                 echo "Fixing PrimaryGroupID for user \"${RUNUSR}\"" ; \

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -182,14 +182,13 @@ function create_run_user {
         ${DSCL} -q . -create "/Users/${RUNUSR}" NFSHomeDirectory "${PREFIX}/var/macports/home"
         ${DSCL} -q . -create "/Users/${RUNUSR}" UserShell /usr/bin/false
     fi
-    if [[ $(sw_vers -productVersion | /usr/bin/awk -F . '{print $1}') -eq 10 ]]; then
-        if [[ $(sw_vers -productVersion | /usr/bin/awk -F . '{print $2}') -eq 4 ]]; then
-            GID=$(${DSCL} -q . -read "/Groups/${RUNUSR}" PrimaryGroupID | /usr/bin/awk '{print $2}')
-            if [[ "$(${DSCL} -q . -read "/Users/${RUNUSR}" PrimaryGroupID 2>/dev/null | /usr/bin/awk '{print $2}')" != "$GID" ]]; then
-                echo "Fixing PrimaryGroupID for user \"${RUNUSR}\""
-                ${DSCL} -q . -create "/Users/${RUNUSR}" PrimaryGroupID "$GID"
-                ${DSCL} -q . -create "/Users/${RUNUSR}" RealName MacPorts
-            fi
+    # Check for OSX10.4 (Darwin8)
+    if [[ $(uname -r | /usr/bin/awk -F . '{print $1}') -eq 8 ]]; then
+        GID=$(${DSCL} -q . -read "/Groups/${RUNUSR}" PrimaryGroupID | /usr/bin/awk '{print $2}')
+        if [[ "$(${DSCL} -q . -read "/Users/${RUNUSR}" PrimaryGroupID 2>/dev/null | /usr/bin/awk '{print $2}')" != "$GID" ]]; then
+            echo "Fixing PrimaryGroupID for user \"${RUNUSR}\""
+            ${DSCL} -q . -create "/Users/${RUNUSR}" PrimaryGroupID "$GID"
+            ${DSCL} -q . -create "/Users/${RUNUSR}" RealName MacPorts
         fi
     fi
     if [[ "$(${DSCL} -q . -read "/Users/${RUNUSR}" NFSHomeDirectory)" = "NFSHomeDirectory: /var/empty" ]]; then
@@ -280,8 +279,8 @@ if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" > /dev/null; then
     fi
 fi
 
-# Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
-if (($(sw_vers -productVersion | awk -F . '{print $1}') >= 11)) || (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || /usr/bin/su "${USER}" -l -c "/usr/bin/printenv DISPLAY" > /dev/null > /dev/null; then
+# Adding a DISPLAY variable only if we're running on Tiger (Darwin8) or less and if it doesn't already exist:
+if (($(uname -r | awk -F . '{print $1}') >= 9)) || /usr/bin/su "${USER}" -l -c "/usr/bin/printenv DISPLAY" > /dev/null > /dev/null; then
     echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
 else
     write_setting DISPLAY ":0"

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -279,7 +279,7 @@ if /usr/bin/su "${USER}" -l -c "/usr/bin/printenv MANPATH" > /dev/null; then
 fi
 
 # Adding a DISPLAY variable only if we're running on Tiger or less and if it doesn't already exist:
-if (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || /usr/bin/su "${USER}" -l -c "/usr/bin/printenv DISPLAY" > /dev/null > /dev/null; then
+if (($(sw_vers -productVersion | awk -F . '{print $1}') >= 11)) || (($(sw_vers -productVersion | awk -F . '{print $2}') >= 5)) || /usr/bin/su "${USER}" -l -c "/usr/bin/printenv DISPLAY" > /dev/null > /dev/null; then
     echo "Your shell already has the right DISPLAY environment variable for use with MacPorts!"
 else
     write_setting DISPLAY ":0"

--- a/portmgr/dmg/postflight.in
+++ b/portmgr/dmg/postflight.in
@@ -182,12 +182,14 @@ function create_run_user {
         ${DSCL} -q . -create "/Users/${RUNUSR}" NFSHomeDirectory "${PREFIX}/var/macports/home"
         ${DSCL} -q . -create "/Users/${RUNUSR}" UserShell /usr/bin/false
     fi
-    if [[ $(sw_vers -productVersion | /usr/bin/awk -F . '{print $2}') -eq 4 ]]; then
-        GID=$(${DSCL} -q . -read "/Groups/${RUNUSR}" PrimaryGroupID | /usr/bin/awk '{print $2}')
-        if [[ "$(${DSCL} -q . -read "/Users/${RUNUSR}" PrimaryGroupID 2>/dev/null | /usr/bin/awk '{print $2}')" != "$GID" ]]; then
-            echo "Fixing PrimaryGroupID for user \"${RUNUSR}\""
-            ${DSCL} -q . -create "/Users/${RUNUSR}" PrimaryGroupID "$GID"
-            ${DSCL} -q . -create "/Users/${RUNUSR}" RealName MacPorts
+    if [[ $(sw_vers -productVersion | /usr/bin/awk -F . '{print $1}') -eq 10 ]]; then
+        if [[ $(sw_vers -productVersion | /usr/bin/awk -F . '{print $2}') -eq 4 ]]; then
+            GID=$(${DSCL} -q . -read "/Groups/${RUNUSR}" PrimaryGroupID | /usr/bin/awk '{print $2}')
+            if [[ "$(${DSCL} -q . -read "/Users/${RUNUSR}" PrimaryGroupID 2>/dev/null | /usr/bin/awk '{print $2}')" != "$GID" ]]; then
+                echo "Fixing PrimaryGroupID for user \"${RUNUSR}\""
+                ${DSCL} -q . -create "/Users/${RUNUSR}" PrimaryGroupID "$GID"
+                ${DSCL} -q . -create "/Users/${RUNUSR}" RealName MacPorts
+            fi
         fi
     fi
     if [[ "$(${DSCL} -q . -read "/Users/${RUNUSR}" NFSHomeDirectory)" = "NFSHomeDirectory: /var/empty" ]]; then


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/61649

First noticed via above ticket.

postflight has a check that is supposed to, on Tiger and older, set `DISPLAY` to `:0` if not already set.

The OS version check though is currently broken on BigSur, as it only checks if the minor version is 5 or higher. This PR adds a check on the major version as well.

Should be ported to the 2.6.x branch once merged, as users running the installer on Big Sur are being affected by this. 

Searching the code base I found two other uses of sw_ver that was checking for OSX10.4 but only checking the minor version. So would incorrectly match on macOS 11.4. Fixes added for these as well.
