### PR TITLE
portfetch: require MacPorts svn on >= Catalina

### DIFF
--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -188,7 +188,8 @@ proc portfetch::set_fetch_type {option action args} {
             }
             svn {
                 # Sierra is the first macOS version whose svn supports modern TLS cipher suites.
-                if {${os.major} >= 16 || ${os.platform} ne "darwin"} {
+                # Catalina's svn exists but is non-functional and hands off to another svn
+                if {(${os.major} >= 16 && ${os.major} <= 18) || ${os.platform} ne "darwin"} {
                     depends_fetch-append bin:svn:subversion
                 } else {
                     depends_fetch-append port:subversion


### PR DESCRIPTION
there is a /usr/bin/svn on Catalina, but it is
only a small forwarding binary and is non-functional

```
 % /usr/bin/svn
svn: error: Failed to locate 'svn'.
svn: error: The subversion command line tools are no longer provided by Xcode.
```

closes: https://trac.macports.org/ticket/61981

(Note: personally I would probably rather just require macports' subversion on all systems for simplicity)