### PR TITLE
darwintracelib: variable '__darwintrace_initialized' was defined in header causing duplicated symbol in link time

### DIFF
--- a/src/darwintracelib1.0/darwintrace.h
+++ b/src/darwintracelib1.0/darwintrace.h
@@ -134,7 +134,7 @@ bool __darwintrace_is_in_sandbox(const char *path, int flags);
  * Whether darwintrace has been fully initialized or not. Do not interpose if
  * this has not been set to true.
  */
-volatile bool __darwintrace_initialized;
+extern volatile bool __darwintrace_initialized;
 
 #ifdef DARWINTRACE_USE_PRIVATE_API
 #include <errno.h>


### PR DESCRIPTION
Variable `__darwintrace_initialized` was defined in `darwintrace.h`, rather than just a declaration; this makes the variable failed to function as intended (every translation unit that uses this header will have its own independent variable), and causes a link error when associated object files are compiled by GCC.

```
gcc-10 -dynamiclib -g -O2 -std=c99 -Wextra -Wall   -fPIC -arch x86_64  -Wl,-single_module access.o close.o darwintrace.o dup2.o mkdir.o open.o proc.o readdir.o readlink.o rename.o rmdir.o sip_copy_proc.o stat.o unlink.o -o darwintrace.dylib  -arch x86_64 -install_name /opt/ports/libexec/macports/lib/darwintrace1.0/darwintrace.dylib  
duplicate symbol '___darwintrace_initialized' in:
    access.o
    rmdir.o
duplicate symbol '___darwintrace_initialized' in:
    access.o
    close.o
...
duplicate symbol '___darwintrace_initialized' in:
    access.o
    stat.o
duplicate symbol '___darwintrace_initialized' in:
    access.o
    unlink.o
ld: 12 duplicate symbols for architecture x86_64
collect2: error: ld returned 1 exit status
make[2]: *** [darwintrace.dylib] Error 1
make[1]: *** [all] Error 1
make: *** [all] Error 1
```