### PR TITLE
Replicate make 'and' function for GNU Make 3.80

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -159,8 +159,21 @@ distclean: clean
 %.html: %.soelim
 	ln -sf $(shell basename $$(awk '{print $$2}' < $<)).html $@
 
-# Define these rules only if both asciidoc and xsltproc are available
-ifneq ($(and $(ASCIIDOC),$(XSLTPROC),$(DOCBOOK_XSL)),)
+# Define these rules only if asciidoc, xsltproc, and docbook_zsl are
+# all available. GNU Make 3.80 (MacOSX 10.4) 'and' does not work, so
+# do the check manually. 'and' works in GNU Make 3.81 (MacOSX 10.5+).
+ifeq ("$(MAKE_VERSION)","3.80")
+ ifneq ($(ASCIIDOC),)
+  ifneq ($(XSLTPROC),)
+   ifneq ($(DOCBOOK_XSL),)
+    HAVE_DOCS_REQS= 1
+   endif
+  endif
+ endif
+else
+ HAVE_DOCS_REQS= $(and $(ASCIIDOC),$(XSLTPROC),$(DOCBOOK_XSL))
+endif
+ifneq ($(HAVE_DOCS_REQS),)
 %: %.xml manpage.xsl
 	$(XSLTPROC) $(XSLTFLAGS) manpage.xsl $<
 


### PR DESCRIPTION
MacOS X 10.4 has this version of GNU Make; MacOS X 10.5 to current provides version 3.81, which has a working 'and' function.

I honestly don't know if this is the best solution, but it works robustly in my testing on 10.4, 10.5, 10.12, and 11.3-beta. The 3 latter have GNU Make version 3.81, while the first has 3.80 & thus this issue.