### PR TITLE
Adjust messages to clarify what is being fetched.

### DIFF
--- a/src/package1.0/portarchivefetch.tcl
+++ b/src/package1.0/portarchivefetch.tcl
@@ -246,7 +246,7 @@ proc portarchivefetch::fetchfiles {args} {
                     file delete -force "${incoming_path}/${archive}.TMP"
                     throw
                 } catch {{*} eCode eMessage} {
-                    ui_debug [msgcat::mc "Fetching archive failed: %s" $eMessage]
+                    ui_debug [msgcat::mc "Fetching binary archive failed: %s" $eMessage]
                     set lastError $eMessage
                     file delete -force "${incoming_path}/${archive}.TMP"
                     incr failed_sites
@@ -326,7 +326,7 @@ proc portarchivefetch::archivefetch_start {args} {
         portarchivefetch::checkfiles archivefetch_urls
     }
     if {[info exists all_archive_files] && [llength $all_archive_files] > 0} {
-        ui_msg "$UI_PREFIX [format [msgcat::mc "Fetching archive for %s"] $subport]"
+        ui_msg "$UI_PREFIX [format [msgcat::mc "Fetching binary archive for %s"] $subport]"
     } elseif {[tbool ports_binary_only]} {
         error "Binary-only mode requested with no usable archive sites configured"
     }

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -567,7 +567,7 @@ proc portfetch::fetchfiles {args} {
                     set fetched 1
                     break
                 } catch {{*} eCode eMessage} {
-                    ui_debug [msgcat::mc "Fetching distfile failed: %s" $eMessage]
+                    ui_debug [msgcat::mc "Fetching source code failed: %s" $eMessage]
                     set lastError $eMessage
                 } finally {
                     file delete -force "${distpath}/${distfile}.TMP"
@@ -617,7 +617,7 @@ proc portfetch::fetch_init {args} {
 proc portfetch::fetch_start {args} {
     global UI_PREFIX subport distpath
 
-    ui_notice "$UI_PREFIX [format [msgcat::mc "Fetching distfiles for %s"] $subport]"
+    ui_notice "$UI_PREFIX [format [msgcat::mc "Fetching source code for %s"] $subport]"
 
     # create and chown $distpath
     if {![file isdirectory $distpath]} {


### PR DESCRIPTION
Add 'binary' and 'source' to the fetching message so users will
understand what is being fetched.

See: https://trac.macports.org/ticket/60756