### PR TITLE
Skip any inaccessible file:// source links

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2676,6 +2676,11 @@ proc mportsync {{optionslist {}}} {
         switch -regexp -- [macports::getprotocol $source] {
             {^file$} {
                 set portdir [macports::getportdir $source]
+                if {![file exists ${portdir}]} {
+                    ui_info "Could not access contents of $portdir"
+                    incr numfailed
+                    continue
+                }
                 if {[_source_is_obsolete_svn_repo $portdir]} {
                     set obsoletesvn 1
                 }


### PR DESCRIPTION
This allows continuing to next source quicker and avoids outputting a
lot of debug lines.