### PR TITLE
Make the reinplace warning an error

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1062,7 +1062,7 @@ proc reinplace {args}  {
         close $tmpfd
 
         if {!$quiet && ![catch {exec -ignorestderr cmp -s $file $tmpfile}]} {
-            ui_warn "[format [msgcat::mc "reinplace %1\$s didn't change anything in %2\$s"] $pattern $file]"
+            return -code error "[format [msgcat::mc "reinplace %1\$s didn't change anything in %2\$s"] $pattern $file]"
         }
 
         set attributes [file attributes $file]

--- a/src/port1.0/tests/portutil.test
+++ b/src/port1.0/tests/portutil.test
@@ -308,6 +308,30 @@ test reinplace {
     }
     close $f
 
+    # If no changes are made, nothing is printed out.  This should
+    # generate an error.
+    if {![catch {reinplace s/notfound/test/1 $file}]} {
+        return "FAIL: reinplace with no changes should generate an error."
+    }
+    catch {set f [open $file r]}
+    set cont [read -nonewline $f]
+    if { $cont != "" } {
+        return "FAIL: reinplace with no changes should not alter file."
+    }
+    close $f
+
+    # If no changes are made, nothing is printed out.  This should
+    # not generate an error due to -q.
+    if {[catch {reinplace -q s/notfound/test/1 $file}]} {
+        return "FAIL: reinplace (-q) with no changes should not generate an error."
+    }
+    catch {set f [open $file r]}
+    set cont [read -nonewline $f]
+    if { $cont != "" } {
+        return "FAIL: reinplace (-q) with no changes should not alter file."
+    }
+    close $f
+
     return "Reinplace successful."
 
 } -cleanup {


### PR DESCRIPTION
This changes the warning "reinplace didn't change anything in" to an error.  This will force maintainers to fix these issues.  This can be bypassed by using the quiet (-q) option.  Two tests are added to verify the code.

Closes: https://trac.macports.org/ticket/60844