### PR TITLE
cregistry: Avoid segfault on extended result codes

### DIFF
--- a/src/cregistry/entry.c
+++ b/src/cregistry/entry.c
@@ -251,6 +251,11 @@ reg_entry* reg_entry_open(reg_registry* reg, char* name, char* version,
 int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
     reg_registry* reg = entry->reg;
     int result = 0;
+
+    errPtr->code = REG_SQLITE_ERROR;
+    errPtr->description = "an unknown sqlite error occurred";
+    errPtr->free = NULL;
+
     sqlite3_stmt* ports = NULL;
     sqlite3_stmt* files = NULL;
     sqlite3_stmt* dependencies = NULL;
@@ -293,6 +298,7 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
                                                         case SQLITE_BUSY:
                                                             break;
                                                         case SQLITE_ERROR:
+                                                        default:
                                                             reg_sqlite_error(reg->db,
                                                                     errPtr, NULL);
                                                             break;
@@ -302,6 +308,7 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
                                             case SQLITE_BUSY:
                                                 break;
                                             case SQLITE_ERROR:
+                                            default:
                                                 reg_sqlite_error(reg->db,
                                                         errPtr, NULL);
                                                 break;
@@ -311,6 +318,7 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
                                 case SQLITE_BUSY:
                                     break;
                                 case SQLITE_ERROR:
+                                default:
                                     reg_sqlite_error(reg->db, errPtr, NULL);
                                     break;
                             }
@@ -325,6 +333,7 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
                 case SQLITE_BUSY:
                     break;
                 case SQLITE_ERROR:
+                default:
                     reg_sqlite_error(reg->db, errPtr, NULL);
                     break;
             }
@@ -1137,6 +1146,7 @@ int reg_entry_activate(reg_entry* entry, char** files, char** as_files,
                                         case SQLITE_BUSY:
                                             break;
                                         case SQLITE_ERROR:
+                                        default:
                                             reg_sqlite_error(reg->db, errPtr,
                                                     update_query);
                                             result = 0;
@@ -1147,6 +1157,7 @@ int reg_entry_activate(reg_entry* entry, char** files, char** as_files,
                             case SQLITE_BUSY:
                                 break;
                             case SQLITE_ERROR:
+                            default:
                                 reg_sqlite_error(reg->db, errPtr, select_query);
                                 result = 0;
                                 break;


### PR DESCRIPTION
When an SQLite call returned one of the extended result codes (see https://sqlite.org/rescode.html#extended_result_code_list), the existing switch/case did not handle that, `errPtr` remained uninitialized, and following code crashed with a segmentation fault.

Avoid this by handling the extended result codes just like we're handling `SQLITE_ERROR`. Additionally, default-initialize the `errPtr` structure to avoid crashes in the future.

This manifested itself when attempting to uninstall ports from a database that returned `SQLITE_CORRUPT_INDEX` (779).