### PR TITLE
Add use_autoreconf option to portfile man page

### DIFF
--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -386,6 +386,19 @@ files for use by
 .br
 .Sy Example:
 .Dl use_automake yes
+.It Ic use_autoreconf
+If set to yes, run the
+.Cm autoreconf
+target to generate GNU build system files.
+.br
+.Sy Type:
+.Em optional
+.br
+.Sy Default:
+.Em no
+.br
+.Sy Example:
+.Dl use_autoreconf yes
 .It Ic use_autoconf
 If set to yes, run the
 .Cm autoconf


### PR DESCRIPTION
`use_automake` and `use_autoconf` were already in there, but `use_autoreconf` got left out somehow.