### PR TITLE
Fix c++17 compiler selection for macOS10.13

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -849,7 +849,7 @@ proc portconfigure::max_version {verA verB} {
 #| 1998 (C++98) |     -     |       -       |     -     |     -     |
 #| 2011 (C++11) |    3.3    |   500.2.75    |    5.0    |   4.8.1   |
 #| 2014 (C++14) |    3.4    |   602.0.49    |    6.3    |     5     |
-#| 2017 (C++17) |    5.0    |   902.0.39.1  |    9.3    |     7     |
+#| 2017 (C++17) |    5.0    |  1000.11.45.2 |   10.0    |     7     |
 #--------------------------------------------------------------------
 #
 # https://openmp.llvm.org
@@ -909,7 +909,7 @@ proc portconfigure::get_min_command_line {compiler} {
                 set min_value [max_version $min_value 500.2.75]
             }
             if {${compiler.cxx_standard} >= 2017} {
-                set min_value [max_version $min_value 902.0.39.1]
+                set min_value [max_version $min_value 1000.11.45.2]
             } elseif {${compiler.cxx_standard} >= 2014} {
                 set min_value [max_version $min_value 602.0.49]
             } elseif {${compiler.cxx_standard} >= 2011} {


### PR DESCRIPTION
(cherry picked from commit e641f42a9f6d93e1768bd91785d19467c30ddb02)