### PR TITLE
show if the port is installed in the info and the search command

### DIFF
--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2162,6 +2162,9 @@ proc action_info { action portlist opts } {
                 if {[info exists portinfo(categories)]} {
                     append inf " ([join $portinfo(categories) ", "])"
                 }
+                if {![catch {registry::installed $portinfo(name) {}}]} {
+                    append inf " \[installed\]"
+                }
             } elseif {$opt eq "fullname"} {
                 set inf "$portinfo(name) @"
                 append inf [composite_version $portinfo(version) $portinfo(active_variants)]
@@ -3838,6 +3841,9 @@ proc action_search { action portlist opts } {
                     }
                     if {[info exists portinfo(categories)]} {
                         puts -nonewline " ([join $portinfo(categories) ", "])"
+                    }
+                    if {![catch {registry::installed $portinfo(name) {}}]} {
+                        puts -nonewline " \[installed\]"
                     }
                     puts ""
                     puts [wrap [join $portinfo(description)] 0 [string repeat " " 4]]


### PR DESCRIPTION
This is a small enhancement that I found useful: it adds an `[installed]` tag in the info and search command.
In the info the tag is shown only with the heading print.
In the search the tag is shown only in multiline print.

Can be also useful to implement it in the other modes? Maybe, they are used only in scripting and therefore you can call `port installed`
Can be also useful to take in account the active status?
