### PR TITLE
Add opt-in Altivec (ppc7400) architecture

### DIFF
--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -343,7 +343,7 @@ lt lt.
 T{
 \fBRegular architectures include:\fR
 T}:T{
-ppc, i386, ppc64, x86_64, arm64
+ppc, ppc7400, ppc64, i386, x86_64, arm64
 T}
 T{
 \fBDefault (11 and later):\fR
@@ -376,7 +376,7 @@ lt lt.
 T{
 \fBRegular architectures include:\fR
 T}:T{
-ppc, i386, ppc64, x86_64, arm64
+ppc, ppc7400, ppc64, i386, x86_64, arm64
 T}
 T{
 \fBDefault (11 and later):\fR

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -124,7 +124,7 @@ keeplogs::
 
 build_arch::
     The machine architecture to try to build for in normal use.
-    *Regular architectures include:*;; ppc, i386, ppc64, x86_64, arm64
+    *Regular architectures include:*;; ppc, ppc7400, ppc64, i386, x86_64, arm64
     *Default (11 and later):*;; arm64 or x86_64 depending on hardware
     *Default (10.6-10.15):*;; x86_64 or i386 depending on hardware
     *Default (10.5 and earlier):*;; i386 or ppc depending on hardware
@@ -133,7 +133,7 @@ universal_archs::
     The machine architectures to use for +universal variant (multiple
     architecture entries should be space separated). Should contain at
     least two entries, or be empty to disable universal building.
-    *Regular architectures include:*;; ppc, i386, ppc64, x86_64, arm64
+    *Regular architectures include:*;; ppc, ppc7400, ppc64, i386, x86_64, arm64
     *Default (11 and later):*;; arm64 x86_64
     *Default (10.6-10.13):*;; x86_64 i386
     *Default (10.5 and earlier):*;; i386 ppc

--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -230,6 +230,7 @@ Archs currently supported by macOS are:
 .Em i386 ,
 .Em ppc ,
 .Em ppc64 ,
+.Em ppc7400 ,
 and
 .Em x86_64 .
 If this option is not set, it is assumed that the port can build for all
@@ -255,10 +256,10 @@ In this case, the port will be built in 32-bit mode.
 .Em optional
 .br
 .Sy Values:
-.Em i386 x86_64 ppc ppc64 noarch
+.Em arm64 i386 x86_64 ppc ppc7400 ppc64 noarch
 .br
 .Sy Default:
-.Em i386 x86_64 ppc ppc64
+.Em arm64 i386 x86_64 ppc ppc64
 .br
 .Sy Examples:
 .Dl supported_archs i386 x86_64

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1142,7 +1142,11 @@ match macports.conf.default."
                 }
             } else {
                 if {$os_arch eq "powerpc"} {
-                    set macports::build_arch ppc
+                    if {[sysctl hw.vectorunit] == 1} {
+                        set macports::build_arch ppc7400
+                    } else {
+                        set macports::build_arch ppc
+                    }
                 } else {
                     set macports::build_arch i386
                 }

--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -412,6 +412,7 @@ proc portlint::lint_main {args} {
                 arm64 arm
                 intel i386
                 ppc powerpc
+                ppc7400 powerpc
                 ppc64 powerpc
                 x86_64 i386
             } {

--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -118,8 +118,8 @@ default distname {${name}-${version}}
 default worksrcdir {$distname}
 default filespath {[file join $portpath [join $filesdir]]}
 default worksrcpath {[file join $workpath [join $worksrcdir]]}
-# empty list means all archs are supported
-default supported_archs {}
+# Exclude ppc7400, which is an opt-in architecture
+default supported_archs {ppc ppc64 i386 x86_64 arm64}
 default depends_skip_archcheck {}
 default add_users {}
 


### PR DESCRIPTION
Address https://github.com/macports/macports-ports/pull/11625 with a modest proposal to add a new `ppc7400` architecture. The idea is that this Altivec-enabled architecture will be preferred on G4/G5 machines but fall back to regular `ppc` if not available. When properly implemented in Portfiles, G3 users should no longer see the dreaded `incompatible cpu subtype` run-time error message.

Support for the `ppc7400` architecture is completely controlled by the individual Portfiles, which need to declare support in `supported_archs` and then pass appropriate configure and compiler flags for Altivec (`ppc7400`) and non-Altivec (`ppc`) builds. Existing Portfiles do not require modification (it's OK if `ppc` builds are secretly Altivec builds), but this PR will provide the tools for maintainers to replace run-time hardware detection with branching on `${configure.build_arch}`, or to declare that a port absolutely, positively requires Altivec on PowerPC (e.g. `mpg123`). See the commit message for a more complete explanation and rationale.

Rudimentary testing performed but I do not have access to a G4/G5, and I also have no idea if universal builds will work here. Earlier, someone suggested supporting ppc + ppc7400 universal builds, which would be a neat trick for binary distributions.

Opening this PR as a draft to discuss the concept and field suggestions. Note that this general strategy might also be used for advanced Intel ISAs (e.g. AVX2 and AVX-512) though that's outside the current scope here.