### PR TITLE
Fix Tcl bug 98af80f133: unsafe buffer lifetime

### DIFF
--- a/vendor/patches/tcl/fix-unsafe-buffer-lifetime.patch
+++ b/vendor/patches/tcl/fix-unsafe-buffer-lifetime.patch
@@ -1,0 +1,33 @@
+"Fix unsafe buffer lifetime" (Tcl bug exposed by LLVM Clang 13 optimization)
+https://core.tcl-lang.org/tcl/info/98af80f133
+
+Index: generic/tclIO.c
+==================================================================
+--- a/vendor/tcl8.5.19/generic/tclIO.c
++++ b/vendor/tcl8.5.19/generic/tclIO.c
+@@ -3811,10 +3811,11 @@
+ {
+     ChannelState *statePtr = chanPtr->state;
+ 				/* State info for channel */
+     char *nextNewLine = NULL;
+     int endEncoding, saved = 0, total = 0, flushed = 0, needNlFlush = 0;
++    char safe[BUFFER_PADDING];
+ 
+     if (srcLen) {
+         WillWrite(chanPtr);
+     }
+ 
+@@ -3829,11 +3830,11 @@
+ 	nextNewLine = memchr(src, '\n', srcLen);
+     }
+ 
+     while (srcLen + saved + endEncoding > 0) {
+ 	ChannelBuffer *bufPtr;
+-	char *dst, safe[BUFFER_PADDING];
++	char *dst;
+ 	int result, srcRead, dstLen, dstWrote, srcLimit = srcLen;
+ 
+ 	if (nextNewLine) {
+ 	    srcLimit = nextNewLine - src;
+ 	}
+

--- a/vendor/tcl8.5.19/generic/tclIO.c
+++ b/vendor/tcl8.5.19/generic/tclIO.c
@@ -3765,6 +3765,7 @@ Write(
 				/* State info for channel */
     char *nextNewLine = NULL;
     int endEncoding, saved = 0, total = 0, flushed = 0, needNlFlush = 0;
+    char safe[BUFFER_PADDING];
 
     if (srcLen) {
         WillWrite(chanPtr);
@@ -3783,7 +3784,7 @@ Write(
 
     while (srcLen + saved + endEncoding > 0) {
 	ChannelBuffer *bufPtr;
-	char *dst, safe[BUFFER_PADDING];
+	char *dst;
 	int result, srcRead, dstLen, dstWrote, srcLimit = srcLen;
 
 	if (nextNewLine) {


### PR DESCRIPTION
An old bug in Tcl was exposed by an optimization in LLVM Clang 13: see https://core.tcl-lang.org/tcl/info/24b9181478 and https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258392

I have not attempted to observe the issue or verify this patch myself, but would suggest it be applied before this eventually becomes a more widespread issue when MacPorts base is compiled with LLVM Clang 13 and future versions of Xcode Clang derived from it.