### PR TITLE
darwintracelib1.0: check return value before use

### DIFF
--- a/src/darwintracelib1.0/darwintrace.c
+++ b/src/darwintracelib1.0/darwintrace.c
@@ -623,6 +623,9 @@ static char *__send(const char *buf, uint32_t len, int answer) {
 	}
 
 	recv_buf = malloc(recv_len + 1);
+	if (recv_buf == NULL) {
+		return NULL;
+	}
 	recv_buf[recv_len] = '\0';
 	frecv(recv_buf, recv_len);
 

--- a/src/darwintracelib1.0/proc.c
+++ b/src/darwintracelib1.0/proc.c
@@ -214,6 +214,9 @@ static inline int check_interpreter(const char *restrict path) {
 	 *   bytes left before the end-of-file, but in no other case.
 	 * That _does_ save us another ugly loop to get things right. */
 	bytes_read = read(fd, buffer, sizeof(buffer) - 1);
+	if (bytes_read < 0) {
+		return errno;
+	}
 	buffer[bytes_read] = '\0';
 	close(fd);
 


### PR DESCRIPTION
Check for malloc() and read() errors.