### PR TITLE
cregistry: replace nested statements with a loop

### DIFF
--- a/src/cregistry/entry.c
+++ b/src/cregistry/entry.c
@@ -257,72 +257,52 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
     errPtr->free = NULL;
 
     sqlite3_stmt* ports = NULL;
-    sqlite3_stmt* files = NULL;
-    sqlite3_stmt* dependencies = NULL;
-    sqlite3_stmt* portgroups = NULL;
+    sqlite3_stmt* followups[] = { NULL, NULL, NULL };
+    sqlite3_stmt** pFiles = &followups[0];
+    sqlite3_stmt** pDependencies = &followups[1];
+    sqlite3_stmt** pPortgroups = &followups[2];
     char* ports_query = "DELETE FROM registry.ports WHERE id=?";
     char* files_query = "DELETE FROM registry.files WHERE id=?";
     char* dependencies_query = "DELETE FROM registry.dependencies WHERE id=?";
     char* portgroups_query = "DELETE FROM registry.portgroups WHERE id=?";
     if ((sqlite3_prepare_v2(reg->db, ports_query, -1, &ports, NULL) == SQLITE_OK)
             && (sqlite3_bind_int64(ports, 1, entry->id) == SQLITE_OK)
-            && (sqlite3_prepare_v2(reg->db, files_query, -1, &files, NULL)
+            /* follow-ups */
+            && (sqlite3_prepare_v2(reg->db, files_query, -1, pFiles, NULL)
                 == SQLITE_OK)
-            && (sqlite3_bind_int64(files, 1, entry->id) == SQLITE_OK)
-            && (sqlite3_prepare_v2(reg->db, dependencies_query, -1, &dependencies,
+            && (sqlite3_bind_int64(*pFiles, 1, entry->id) == SQLITE_OK)
+            && (sqlite3_prepare_v2(reg->db, dependencies_query, -1, pDependencies,
                     NULL) == SQLITE_OK)
-            && (sqlite3_bind_int64(dependencies, 1, entry->id) == SQLITE_OK)
-            && (sqlite3_prepare_v2(reg->db, portgroups_query, -1, &portgroups,
+            && (sqlite3_bind_int64(*pDependencies, 1, entry->id) == SQLITE_OK)
+            && (sqlite3_prepare_v2(reg->db, portgroups_query, -1, pPortgroups,
                     NULL) == SQLITE_OK)
-            && (sqlite3_bind_int64(portgroups, 1, entry->id) == SQLITE_OK)) {
+            && (sqlite3_bind_int64(*pPortgroups, 1, entry->id) == SQLITE_OK)) {
         int r;
         do {
             r = sqlite3_step(ports);
             switch (r) {
                 case SQLITE_DONE:
                     if (sqlite3_changes(reg->db) > 0) {
-                        do {
-                            r = sqlite3_step(files);
-                            switch (r) {
-                                case SQLITE_DONE:
-                                    do {
-                                        r = sqlite3_step(dependencies);
-                                        switch (r) {
-                                            case SQLITE_DONE:
-                                                do {
-                                                    r = sqlite3_step(portgroups);
-                                                    switch (r) {
-                                                        case SQLITE_DONE:
-                                                            result = 1;
-                                                            break;
-                                                        case SQLITE_BUSY:
-                                                            break;
-                                                        case SQLITE_ERROR:
-                                                        default:
-                                                            reg_sqlite_error(reg->db,
-                                                                    errPtr, NULL);
-                                                            break;
-                                                    }
-                                                } while (r == SQLITE_BUSY);
-                                                break;
-                                            case SQLITE_BUSY:
-                                                break;
-                                            case SQLITE_ERROR:
-                                            default:
-                                                reg_sqlite_error(reg->db,
-                                                        errPtr, NULL);
-                                                break;
-                                        }
-                                    } while (r == SQLITE_BUSY);
-                                    break;
-                                case SQLITE_BUSY:
-                                    break;
-                                case SQLITE_ERROR:
-                                default:
-                                    reg_sqlite_error(reg->db, errPtr, NULL);
-                                    break;
-                            }
-                        } while (r == SQLITE_BUSY);
+                        result = 1;
+                        for (size_t i = 0; i < sizeof(followups)/sizeof(followups[0]); i++) {
+                            do {
+                                r = sqlite3_step(followups[i]);
+                                switch (r) {
+                                    case SQLITE_DONE:
+                                        break;
+                                    case SQLITE_BUSY:
+                                        break;
+                                    case SQLITE_ERROR:
+                                    default:
+                                        reg_sqlite_error(reg->db,
+                                                errPtr, NULL);
+                                        result = 0;
+                                        goto stmt_finish;
+                                        break;
+                                }
+                            } while (r == SQLITE_BUSY);
+                        }
+stmt_finish:
                         break;
                     } else {
                         errPtr->code = REG_INVALID;
@@ -344,14 +324,10 @@ int reg_entry_delete(reg_entry* entry, reg_error* errPtr) {
     if (ports) {
         sqlite3_finalize(ports);
     }
-    if (files) {
-        sqlite3_finalize(files);
-    }
-    if (dependencies) {
-        sqlite3_finalize(dependencies);
-    }
-    if (portgroups) {
-        sqlite3_finalize(portgroups);
+    for (size_t i = 0; i < sizeof(followups)/sizeof(followups[0]); i++) {
+        if (followups[i]) {
+            sqlite3_finalize(followups[i]);
+        }
     }
     return result;
 }


### PR DESCRIPTION
with the necessary evil of `goto`