### PR TITLE
Set correct `os_arch` on additional archs

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -699,12 +699,19 @@ proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
     # set up platform info variables
     set os_arch $tcl_platform(machine)
     # Set os_arch to match `uname -p`
-    if {$os_arch eq "Power Macintosh"} {
-        set os_arch "powerpc"
-    } elseif {$os_arch eq "i586" || $os_arch eq "i686" || $os_arch eq "x86_64"} {
-        set os_arch "i386"
-    } elseif {$os_arch eq "arm64"} {
-        set os_arch "arm"
+    switch -glob $os_arch {
+       "Power Macintosh" -
+       ppc* {
+           set os_arch powerpc
+       }
+       i[3-7]86 -
+       x86_64 {
+           set os_arch i386
+       }
+       arm* -
+       aarch* {
+           set os_arch arm
+       }
     }
     set os_version $tcl_platform(osVersion)
     set os_major [lindex [split $os_version .] 0]
@@ -1148,11 +1155,24 @@ match macports.conf.default."
                 }
             }
         } else {
-            # List of currently supported CPU architectures
-            if {$tcl_platform(machine) in [list arm64 x86_64 i386 ppc]} {
-                set macports::build_arch $tcl_platform(machine)
-            } else {
-                set macports::build_arch {}
+            switch -glob $tcl_platform(machine) {
+               "Power Macintosh" -
+               ppc* {
+                   set macports::build_arch ppc
+               }
+               i[3-7]86 {
+                   set macports::build_arch i386
+               }
+               x86_64 {
+                   set macports::build_arch x86_64
+               }
+               arm* -
+               aarch* {
+                   set macports::build_arch arm64
+               }
+               default {
+                   set macports::build_arch {}
+               }
             }
         }
     } else {


### PR DESCRIPTION
Whilst running MacPorts on a Raspberry Pi with an armv7l processor, I noticed that MacPorts set the incorrect `os_arch`.

This PR aims to improve MacPorts support on some more architectures by setting the correct `os_arch`. For a given architecture, the new functionality is:

- `Power Macintosh` and anything that begins with `ppc` is set as `powerpc`.
- ` i386`-`i786` and `x86_64` is mapped to `i386`.
- Any architecture that begins with `arm` or `aarch` will be mapped to `arm`.

Closes: https://trac.macports.org/ticket/64863