### PR TITLE
Set `configure.cxx_stdlib` on Linux

### DIFF
--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -228,12 +228,16 @@ for {set i 0} {$i < $argc} {incr i} {
                         } else {
                             set cxx_stdlib libc++
                         }
+                    } elseif {$os_platform eq "linux"} {
+                        set cxx_stdlib libstdc++
                     }
                     set os_arch [lindex $platlist 2]
                 }
                 if {$os_platform eq "macosx"} {
                     lappend port_options os.subplatform $os_platform os.universal_supported yes cxx_stdlib $cxx_stdlib
                     set os_platform darwin
+                } elseif {$os_platform eq "linux"} {
+                    lappend cxx_stdlib $cxx_stdlib
                 }
                 lappend port_options os.platform $os_platform os.major $os_major os.arch $os_arch
             } elseif {$arg eq "-f"} { # Completely rebuild index


### PR DESCRIPTION
See: https://trac.macports.org/ticket/48957
See: https://github.com/macports/macports-ports/pull/14323#discussion_r835618657

This also means one less thing is required in @kencu's [MacPorts Ubuntu guide](https://trac.macports.org/wiki/InstallingMacPortsOnUbuntuLinux):

```
cxx_stdlib             libstdc++        # configure.cxx_stdlib is not yet working on Ubuntu, this fills in appropriate default
```

`libstdc++` was chosen over`libc++` since it is [more complete on Linux](https://stackoverflow.com/a/16788372/10763533).