### PR TITLE
Fix sysctl implementation on non-Darwin

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1148,7 +1148,12 @@ match macports.conf.default."
                 }
             }
         } else {
-            set macports::build_arch {}
+            # List of currently supported CPU architectures
+            if {$tcl_platform(machine) in [list arm64 x86_64 i386 ppc]} {
+                set macports::build_arch $tcl_platform(machine)
+            } else {
+                set macports::build_arch {}
+            }
         }
     } else {
         set macports::build_arch [lindex $macports::build_arch 0]


### PR DESCRIPTION
I'm pretty sure that I shouldn't use exec here, so any suggestions are appreciated :)

`sysctl` works slightly different on Linux, and so [`nproc`](https://man7.org/linux/man-pages/man1/nproc.1.html) was chosen to determine the number of processing units. Since `sysctl` might work on some BSDs as well as Darwin, it was left in a default `else` statment.

```
> /sbin/sysctl -n hw.activecpu 
sysctl: cannot stat /proc/sys/hw/activecpu: No such file or directory
```

```
> nproc --all
4
```