### PR TITLE
Set SOURCE_DATE_EPOCH

### DIFF
--- a/src/port1.0/portextract.tcl
+++ b/src/port1.0/portextract.tcl
@@ -165,6 +165,7 @@ proc portextract::extract_main {args} {
         if {[llength $worksubdirs] == 1} {
             set origpath [lindex $worksubdirs 0]
             set newpath [file join $workpath $distname]
+            set_source_date_epoch [lindex $worksubdirs 0]
             if {$newpath ne $origpath} {
                 ui_debug [format [msgcat::mc "extract.rename: Renaming %s -> %s"] [file tail $origpath] $distname]
                 move $origpath $newpath
@@ -174,6 +175,9 @@ proc portextract::extract_main {args} {
         } else {
             return -code error "extract.rename: multiple directories exist in ${workpath}: $worksubdirs"
         }
+    } else {
+        global worksrcpath
+        set_source_date_epoch $worksrcpath
     }
 
     return 0


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/59672

This PR allows base to define the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) environment variable to assist with reproducible builds. The value can be manually set in a portfile via the `source_date_epoch` variable.

If the variable isn't assigned, its value is set to the greatest Unix timestamp of the files present in the source code (credit to Ryan for [implementation details](https://trac.macports.org/ticket/59672#comment:3)).