### PR TITLE
Add 2020 as known c++ standard

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -853,14 +853,15 @@ proc portconfigure::max_version {verA verB} {
 # https://en.cppreference.com/w/cpp/compiler_support
 # Xcode release notes
 # https://trac.macports.org/wiki/XcodeVersionInfo
-#--------------------------------------------------------------------
-#| C++ Standard |   Clang   |  Xcode Clang  |   Xcode   |    GCC    |
-#|------------------------------------------------------------------|
-#| 1998 (C++98) |     -     |       -       |     -     |     -     |
-#| 2011 (C++11) |    3.3    |   500.2.75    |    5.0    |   4.8.1   |
-#| 2014 (C++14) |    3.4    |   602.0.49    |    6.3    |     5     |
-#| 2017 (C++17) |    5.0    |  1000.11.45.2 |   10.0    |     7     |
-#--------------------------------------------------------------------
+#-----------------------------------------------------------------------
+#| C++ Standard |   Clang   |  Xcode Clang   |   Xcode   |     GCC     |
+#|---------------------------------------------------------------------|
+#| 1998 (C++98) |     -     |       -        |     -     |      -      |
+#| 2011 (C++11) |    3.3    |   500.2.75     |    5.0    |    4.8.1    |
+#| 2014 (C++14) |    3.4    |   602.0.49     |    6.3    |      5      |
+#| 2017 (C++17) |    5.0    |  1000.11.45.2  |   10.0    |      7      |
+#| 2020 (C++20) |    14     |  1400.0.29.102 |   14.0    |     11      |
+#-----------------------------------------------------------------------
 #
 # https://openmp.llvm.org
 # https://gcc.gnu.org/wiki/openmp
@@ -913,12 +914,14 @@ proc portconfigure::get_min_command_line {compiler} {
                 # no Xcode clang can build against libc++ on < 10.7
                 return none
             }
-            if {${compiler.c_standard} >= 2017} {
+            if       {${compiler.c_standard} >= 2017} {
                 set min_value [max_version $min_value 1000.11.45.2]
             } elseif {${compiler.c_standard} >= 2011} {
                 set min_value [max_version $min_value 500.2.75]
             }
-            if {${compiler.cxx_standard} >= 2017} {
+            if       {${compiler.cxx_standard} >= 2020} {
+                set min_value [max_version $min_value 1400.0.29.102]
+            } elseif {${compiler.cxx_standard} >= 2017} {
                 set min_value [max_version $min_value 1000.11.45.2]
             } elseif {${compiler.cxx_standard} >= 2014} {
                 set min_value [max_version $min_value 602.0.49]
@@ -966,12 +969,14 @@ proc portconfigure::get_min_command_line {compiler} {
 proc portconfigure::get_min_clang {} {
     global compiler.c_standard compiler.cxx_standard compiler.openmp_version compiler.thread_local_storage
     set min_value 1.0
-    if {${compiler.c_standard} >= 2017} {
+    if       {${compiler.c_standard} >= 2017} {
         set min_value [max_version $min_value 6.0]
     } elseif {${compiler.c_standard} >= 2011} {
         set min_value [max_version $min_value 3.1]
     }
-    if {${compiler.cxx_standard} >= 2017} {
+    if       {${compiler.cxx_standard} >= 2020} {
+        set min_value [max_version $min_value 14]
+    } elseif {${compiler.cxx_standard} >= 2017} {
         set min_value [max_version $min_value 5.0]
     } elseif {${compiler.cxx_standard} >= 2014} {
         if {[option configure.cxx_stdlib] eq "libc++"} {
@@ -1012,14 +1017,16 @@ proc portconfigure::get_min_gcc {} {
     }
 
     set min_value 1.0
-    if {${compiler.c_standard} >= 2017} {
+    if       {${compiler.c_standard} >= 2017} {
         set min_value [max_version $min_value 8]
     } elseif {${compiler.c_standard} >= 2011} {
         set min_value [max_version $min_value 4.3]
-    }  elseif {${compiler.c_standard} >= 1999} {
+    } elseif {${compiler.c_standard} >= 1999} {
         set min_value [max_version $min_value 4.0]
     }
-    if {${compiler.cxx_standard} >= 2017} {
+    if       {${compiler.cxx_standard} >= 2020} {
+        set min_value [max_version $min_value 11]
+    } elseif {${compiler.cxx_standard} >= 2017} {
         set min_value [max_version $min_value 7]
     } elseif {${compiler.cxx_standard} >= 2014} {
         set min_value [max_version $min_value 5]


### PR DESCRIPTION
Compiler support has I think reached a level it make sense to add as a known standard.

As always, support is a gradual process with compilers. The versions here are a preliminary estimate of when the compilers first support the *primary* c++20 features, which of course is a bit subjective.