### PR TITLE
Do not pass -stdlib with gcc 10+ in PPC builds

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -80,10 +80,13 @@ proc portconfigure::should_add_stdlib {} {
     # GCC also supports -stdlib starting with GCC 10 (and devel)
     set is_gcc_with_stdlib no
     if { [string match *g*-mp-* [option configure.cxx]] } {
-        # Extract gcc version from value after last -
-        set gcc_ver [lindex [split [option configure.cxx] "-"] end]
-        if { ${gcc_ver} eq "devel" || ${gcc_ver} >= 10 } {
-            set is_gcc_with_stdlib yes
+        # -stdlib is not available with PPC builds
+        if { [option configure.build_arch] ni [list ppc ppc64] } {
+            # Extract gcc version from value after last -
+            set gcc_ver [lindex [split [option configure.cxx] "-"] end]
+            if { ${gcc_ver} eq "devel" || ${gcc_ver} >= 10 } {
+                set is_gcc_with_stdlib yes
+            }
         }
     }
     return [expr {$has_stdlib && ($is_clang || $is_gcc_with_stdlib)}]


### PR DESCRIPTION
https://github.com/macports/macports-base/commit/ebd226139d5ba8389367606761658ad0e3bb5cce

Added support for -stdlib with gcc10+, but neglected the fact this is not available on PPC.

See also https://trac.macports.org/ticket/66246