### PR TITLE
manpages: portfile: document keywords startupitem.user/startupitem.group

### DIFF
--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -2026,6 +2026,34 @@ machine's network state is detected.
 .br
 .Sy Example:
 .Dl startupitem.netchange yes
+.It Ic startupitem.user
+Run the daemon via the specified user.
+.br
+.Sy Type:
+.Em optional
+.br
+.Sy Default:
+.Em none
+.br
+.Sy Values:
+.Em username
+.br
+.Sy Example:
+.Dl startupitem.user my_daemon_username
+.It Ic startupitem.group
+Run the daemon via the specified group.
+.br
+.Sy Type:
+.Em optional
+.br
+.Sy Default:
+.Em none
+.br
+.Sy Values:
+.Em groupname
+.br
+.Sy Example:
+.Dl startupitem.group my_daemon_groupname
 .It Ic startupitems
 Used when a port needs to install more than one startupitem, this option
 consists of a list where alternating elements represent keys and values.


### PR DESCRIPTION
Add info for keywords `startupitem.user` and `startupitem.group`, which are presently undocumented:

```
     startupitem.user
         Run the daemon via the specified user.
         Type: optional
         Default: none
         Values: username
         Example:
               startupitem.user my_daemon_username

     startupitem.group
         Run the daemon via the specified group.
         Type: optional
         Default: none
         Values: groupname
         Example:
               startupitem.group my_daemon_groupname
```

If anyone would like to add/change the description, please speak up ASAP. Otherwise let's merge this, and at least ensure they're included in our documentation. (We can always refine this later, if folks want to add more.)

Corresponding PR, for the MacPorts Guide:

[PR 59 - guide: startupitem: document keywords startupitem.user/startupitem.group](https://github.com/macports/macports-guide/pull/59)
