### PR TITLE
manpages: portfile: document keyword use_dmg

### DIFF
--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1054,6 +1054,37 @@ to
 .br
 .Sy Example:
 .Dl use_7z yes
+.It Ic use_dmg
+Use a disk image (dmg).
+Note that the arguments passed to 'hdiutil' are extensive, and can vary based
+on the Darwin release, other options, etc.
+As such, ports should not attempt to manipulate 'extract.post_args'.
+.br
+Sets
+.Ic extract.suffix
+to
+.Dq .dmg .
+.br
+Sets
+.Ic extract.cmd
+to
+.Dq hdiutil .
+.br
+Sets
+.Ic extract.pre_args
+to
+.Dq attach .
+.br
+Sets
+.Ic extract.post_args
+to
+.Dq -private -readonly -nobrowse -mountpoint ...etc... .
+.br
+.Sy Type:
+.Em optional
+.br
+.Sy Example:
+.Dl use_dmg yes
 .It Ic dist_subdir
 Create a sub-directory in
 .Ic distpath


### PR DESCRIPTION
Add info for keyword `use_dmg`, which is presently undocumented:

```
     use_dmg
         Use a disk image (dmg).
         Sets extract.suffix to ``.dmg''.
         Sets extract.cmd to ``hdiutil''.
         Sets extract.pre_args to ``attach''.
         Sets extract.post_args to ``-private -readonly -nobrowse -mountpoint ...etc...''.
         Type: optional
         Example:
               use_dmg yes
```

There's just one caveat, for `extract.post_args`: The number of arguments is significant, and things vary slightly due to necessary logic behind it:

```
set dmg_tmp_dir [exec mktemp -d -q "/tmp/mports.XXXXXXXX"]
set dmg_mount ${dmg_tmp_dir}/${worksrcdir}
file mkdir ${dmg_mount}
option extract.cmd [binaryInPath "hdiutil"]
option extract.pre_args attach
option extract.post_args "-private -readonly -nobrowse -mountpoint  ${dmg_mount} && [binaryInPath "cp"] -Rp ${dmg_mount}  ${extract.dir} && ${extract.cmd} detach ${dmg_mount} &&  [binaryInPath "rmdir"] ${dmg_mount} ${dmg_tmp_dir}"
```

As a result, I truncated the details for `extract.post_args`. But thoughts welcome as to what we should include for that.

Corresponding PR, for MacPorts Guide:

[PR 61 - guide: phase: document use_dmg](https://github.com/macports/macports-guide/pull/61)