### PR TITLE
manpages: portfile: document keyword configure.sdkroot

### DIFF
--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1507,6 +1507,17 @@ macOS SDK version to build against.
 .br
 .Sy Example:
 .Dl configure.sdk_version 10.8
+.It Ic configure.sdkroot
+The path to the macOS SDK to build against.
+.br
+.Sy Type:
+.Em optional
+.br
+.Sy Default:
+.Em Automatically set by MacPorts; varies by macOS release, whether Xcode installed, etc.
+.br
+.Sy Example:
+.Dl configure.sdkroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
 .\" FOOBAR
 .El
 .Ss UNIVERSAL TARGET HOOKS


### PR DESCRIPTION
Document keyword `configure.sdkroot`:

```
     configure.sdkroot
         The path to the macOS SDK to build against.
         Type: optional
         Default: Automatically set by MacPorts; varies by macOS release, whether Xcode installed, etc.
         Example:
               configure.sdkroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
```

Note that this keyword is already documented in the MacPorts Guide, so no updates are needed for the latter.