### PR TITLE
trace mode: Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ src/*
 src/*/*_autoconf.tcl
 src/cregistry/macports.sqlext
 src/darwintracelib1.0/*.d
+src/darwintracelib1.0/tests/*.d
+src/darwintracelib1.0/tests/lstat
+src/darwintracelib1.0/tests/readdir
+src/darwintracelib1.0/tests/stat
 src/darwintracelib1.0/sip_copy_proc.[ch]
 src/machista1.0/tests/libmachista-test
 src/port/*

--- a/configure
+++ b/configure
@@ -9387,7 +9387,7 @@ printf "%s\n" "yes" >&6; }
 
 
 # Output
-ac_config_files="$ac_config_files Doxyfile Makefile Mk/macports.autoconf.mk doc/Makefile doc/base.mtree doc/macosx.mtree doc/macports.conf doc/prefix.mtree doc/pubkeys.conf portmgr/dmg/postflight setupenv.bash src/Makefile src/cregistry/Makefile src/compat/Makefile src/darwintracelib1.0/Makefile src/machista1.0/Makefile src/macports1.0/Makefile src/macports1.0/macports_autoconf.tcl src/macports1.0/macports_test_autoconf.tcl src/mpcommon1.0/Makefile src/package1.0/Makefile src/package1.0/package_test_autoconf.tcl src/pextlib1.0/Makefile src/port/Makefile src/port1.0/Makefile src/port1.0/port_autoconf.tcl src/port1.0/port_test_autoconf.tcl src/programs/Makefile src/registry2.0/Makefile src/registry2.0/registry_autoconf.tcl tests/Makefile tests/test.tcl tests/test/library.tcl tests/test/trace/test.tcl vendor/Makefile"
+ac_config_files="$ac_config_files Doxyfile Makefile Mk/macports.autoconf.mk doc/Makefile doc/base.mtree doc/macosx.mtree doc/macports.conf doc/prefix.mtree doc/pubkeys.conf portmgr/dmg/postflight setupenv.bash src/Makefile src/cregistry/Makefile src/compat/Makefile src/darwintracelib1.0/Makefile src/darwintracelib1.0/tests/Makefile src/machista1.0/Makefile src/macports1.0/Makefile src/macports1.0/macports_autoconf.tcl src/macports1.0/macports_test_autoconf.tcl src/mpcommon1.0/Makefile src/package1.0/Makefile src/package1.0/package_test_autoconf.tcl src/pextlib1.0/Makefile src/port/Makefile src/port1.0/Makefile src/port1.0/port_autoconf.tcl src/port1.0/port_test_autoconf.tcl src/programs/Makefile src/registry2.0/Makefile src/registry2.0/registry_autoconf.tcl tests/Makefile tests/test.tcl tests/test/library.tcl tests/test/trace/test.tcl vendor/Makefile"
 
 
 ac_config_files="$ac_config_files vendor/tclsh"
@@ -10105,6 +10105,7 @@ do
     "src/cregistry/Makefile") CONFIG_FILES="$CONFIG_FILES src/cregistry/Makefile" ;;
     "src/compat/Makefile") CONFIG_FILES="$CONFIG_FILES src/compat/Makefile" ;;
     "src/darwintracelib1.0/Makefile") CONFIG_FILES="$CONFIG_FILES src/darwintracelib1.0/Makefile" ;;
+    "src/darwintracelib1.0/tests/Makefile") CONFIG_FILES="$CONFIG_FILES src/darwintracelib1.0/tests/Makefile" ;;
     "src/machista1.0/Makefile") CONFIG_FILES="$CONFIG_FILES src/machista1.0/Makefile" ;;
     "src/macports1.0/Makefile") CONFIG_FILES="$CONFIG_FILES src/macports1.0/Makefile" ;;
     "src/macports1.0/macports_autoconf.tcl") CONFIG_FILES="$CONFIG_FILES src/macports1.0/macports_autoconf.tcl" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -410,6 +410,7 @@ AC_CONFIG_FILES([
 	src/cregistry/Makefile
 	src/compat/Makefile
 	src/darwintracelib1.0/Makefile
+	src/darwintracelib1.0/tests/Makefile
 	src/machista1.0/Makefile
 	src/macports1.0/Makefile
 	src/macports1.0/macports_autoconf.tcl

--- a/src/darwintracelib1.0/.gitignore
+++ b/src/darwintracelib1.0/.gitignore
@@ -1,0 +1,3 @@
+report.html
+dtrace.*.rawprof
+dtrace.profdata

--- a/src/darwintracelib1.0/Makefile.in
+++ b/src/darwintracelib1.0/Makefile.in
@@ -3,6 +3,8 @@ VPATH  = @srcdir@
 
 include ../../Mk/macports.autoconf.mk
 
+SUBDIR = tests
+
 # This Makefile will only be run on Darwin systems; we can safely use
 # Apple-specifics here
 SRCS = \
@@ -77,6 +79,7 @@ install:: all
 	$(INSTALL)    -o "$(DSTUSR)" -g "$(DSTGRP)" -m 444 "$(SHLIB_NAME)" "$(DESTDIR)$(INSTALLDIR)"
 
 test::
+	$(MAKE) -C tests/ test
 
 ifeq (,$(findstring clean,$(MAKECMDGOALS)))
 # Include dependency information

--- a/src/darwintracelib1.0/coverage.sh
+++ b/src/darwintracelib1.0/coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -x
+
+make CC=clang-mp-17 LD=clang-mp-17 CFLAGS="-g -O2 -std=c99 -Wextra -Wall -fPIC -arch arm64 -arch x86_64 -DHAVE_CONFIG_H -fprofile-instr-generate -fcoverage-mapping"
+
+export LLVM_PROFILE_FILE="${PWD}/dtrace.%p.rawprof"
+rm -f "${PWD}"/*.rawprof
+make test CC=clang-mp-17 LD=clang-mp-17
+
+llvm-profdata-mp-17 merge -sparse "${PWD}"/*.rawprof -o "${PWD}/dtrace.profdata"
+llvm-cov-mp-17 show -arch x86_64 -format=html darwintrace.dylib -instr-profile="${PWD}/dtrace.profdata" > report.html
+llvm-cov-mp-17 report -arch x86_64 darwintrace.dylib -instr-profile="${PWD}/dtrace.profdata"

--- a/src/darwintracelib1.0/darwintrace.c
+++ b/src/darwintracelib1.0/darwintrace.c
@@ -713,65 +713,299 @@ static inline bool __darwintrace_sandbox_check(const char *path, int flags) {
 	return false;
 }
 
-/* Private struct for __darwintrace_is_in_sandbox */
+
+/**
+ * Structure to represent a filesystem path component, i.e., a single level of a path.
+ */
 typedef struct {
-	char *start;
+	char *path;
 	size_t len;
 } path_component_t;
 
-/*
- * Helper function for __darwintrace_is_in_sandbox.
- *
- * \param[in] token path to parse
- * \param[in] dst write position in normPath buffer
- * \param[in] numComponents number of parsed components
- * \param[in,out] pathComponents array of parsed components
- * \param[out] normPath output buffer
- * \return next numComponents
+/**
+ * Structure to represent a normalized filesystem path.
  */
-static size_t __parse_path_normalize(const char *token, char *dst, size_t numComponents, path_component_t *pathComponents, char *normPath) {
-	size_t idx;
-	while ((idx = strcspn(token, "/")) > 0) {
-		// found a token, process it
+typedef struct {
+	size_t num;
+	size_t capacity;
+	path_component_t *components;
+} path_t;
 
-		if (token[0] == '\0' || token[0] == '/') {
-			// empty entry, ignore
-		} else if (token[0] == '.' && (token[1] == '\0' || token[1] == '/')) {
-			// reference to current directory, ignore
-		} else if (token[0] == '.' && token[1] == '.' && (token[2] == '\0' || token[2] == '/')) {
-			// walk up one directory, but not if it's the last one, because /.. -> /
-			if (numComponents > 0) {
-				numComponents--;
-				if (numComponents > 0) {
-					// move dst back to the previous entry
-					path_component_t *lastComponent = pathComponents + (numComponents - 1);
-					dst = lastComponent->start + lastComponent->len + 1;
-				} else {
-					// we're at the top, move dst back to the beginning
-					dst = normPath + 1;
-				}
-			}
-		} else {
-			// copy token to normPath buffer (and null-terminate it)
-			strlcpy(dst, token, idx + 1);
-			dst[idx] = '\0';
-			// add descriptor entry for new token
-			pathComponents[numComponents].start = dst;
-			pathComponents[numComponents].len   = idx;
-			numComponents++;
+#define PATH_INITIAL_CAPACITY (PATH_MAX / 4 + 2)
 
-			// advance destination
-			dst += idx + 1;
-		}
+/**
+ * Allocate a new filesystem path structure.
+ *
+ * @return Pointer to the new path_t on success, NULL on error.
+ */
+static path_t *path_new() {
+	path_t *path = NULL;
 
-		if (token[idx] == '\0') {
-			break;
-		}
-		token += idx + 1;
+	path = malloc(sizeof(path_t));
+	if (!path) {
+		goto out;
 	}
 
-	return numComponents;
+	path->num = 0;
+	path->capacity = PATH_INITIAL_CAPACITY;
+	path->components = malloc(sizeof(path_component_t) * path->capacity);
+
+	if (!path->components) {
+		free(path);
+		path = NULL;
+	}
+
+out:
+	return path;
 }
+
+/**
+ * Free a filesystem path structure.
+ *
+ * @param[in] path The path to release.
+ */
+static void path_free(path_t *path) {
+	for (size_t idx = 0; idx < path->num; ++idx) {
+		free(path->components[idx].path);
+	}
+
+	free(path->components);
+	free(path);
+}
+
+/**
+ * Append a component (given as string) to an existing filesystem path while
+ * preserving normality.
+ *
+ * If the given component is empty, or ".", the path will remain unmodified. If
+ * the given component is "..", the last component of the path is deleted.
+ * Otherwise, the new component is appended to the end of the path. Note that
+ * component must NOT contain slashes.
+ *
+ * @param[in] path The path to which the component should be appended.
+ * @param[in] component The path component to append.
+ * @return true on success, false when memory allocation fails.
+ */
+static bool path_append(path_t *path, const char *component) {
+	if (*component == '\0') {
+		// ignore empty path components, i.e., consecutive slashes
+		return true;
+	} else if (component[0] == '.' && component[1] == '\0') {
+		// ignore self-referencing path components
+		return true;
+	} else if (component[0] == '.' && component[1] == '.' && component[2] == '\0') {
+		// walk up one path component, if possible
+		if (path->num > 0) {
+			free(path->components[path->num - 1].path);
+			path->num--;
+		}
+	} else {
+		if (path->num >= path->capacity) {
+			// need more space for components, realloc to make that space
+			size_t new_capacity = path->capacity + (PATH_INITIAL_CAPACITY / 2);
+			path_component_t *new_components = realloc(path->components, sizeof(path_component_t) * new_capacity);
+			if (!new_components) {
+				return false;
+			}
+
+			path->capacity = new_capacity;
+			path->components = new_components;
+		}
+
+		// initialize new path_component_t
+		size_t len = strlen(component);
+		path_component_t *new_component = &path->components[path->num];
+		new_component->len = len;
+		new_component->path = malloc(len + 1);
+		if (!new_component->path) {
+			return false;
+		}
+		strlcpy(new_component->path, component, len + 1);
+		path->num++;
+	}
+
+	return true;
+}
+
+/**
+ * Take the given input path as string, tokenize it into separate path
+ * components, then append them to the given path, normalizing the path in the
+ * process. Modifies the given inpath string.
+ *
+ * @param[in] path The path to which the new components should be appended.
+ * @param[in] inpath The string input path which will be tokenized and normalized.
+ * @return true on success, false on memory allocation failure.
+ */
+static bool path_tokenize(path_t *path, char *inpath) {
+	char *pos = inpath;
+	const char *token;
+
+	while ((token = strsep(&pos, "/")) != NULL) {
+		if (!path_append(path, token)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * The the given symbolic link as string, tokenize it into separate path
+ * components and normalize it in the context of the given path. If the
+ * symbolic link is absolute, this will replace the entire path, otherwise
+ * normalize the symlink relative to the current path. Modifies the given link.
+ *
+ * @param[in] path The path relative to which the symlink should be interpreted.
+ * @param[in] link The symbolic link contents obtained from readlink(2).
+ * @return true on success, false on memory allocation failure.
+ */
+static bool path_tokenize_symlink(path_t *path, char *link) {
+	if (*link == '/') {
+		// symlink is absolute, start fresh
+		for (size_t idx = 0; idx < path->num; idx++) {
+			free(path->components[idx].path);
+		}
+		path->num = 0;
+
+		return path_tokenize(path, link + 1);
+	}
+
+	// symlink is relative, remove last component
+	if (path->num > 0) {
+		free(path->components[path->num - 1].path);
+		path->num--;
+	}
+
+	return path_tokenize(path, link);
+}
+
+/**
+ * Strip a resource fork from the end of the path, if present.
+ *
+ * @param[in] path The path which should be checked for resource forks
+ */
+static void path_strip_resource_fork(path_t *path) {
+	if (path->num >= 2) {
+		if (   strcmp(path->components[path->num - 2].path, "..namedfork") == 0
+			&& strcmp(path->components[path->num - 1].path, "rsrc") == 0) {
+			free(path->components[path->num - 2].path);
+			free(path->components[path->num - 1].path);
+			path->num -= 2;
+		}
+	}
+}
+
+/**
+ * Return the length of the given path when represented as a native filesystem
+ * path with "/" separators, excluding the terminating \0 byte.
+ *
+ * @param[in] path The path whose length should be determined.
+ * @return The length of the path.
+ */
+static size_t path_len(const path_t *path) {
+	// One slash for each component
+	size_t len = path->num;
+
+	// Plus the length for each component
+	for (size_t idx = 0; idx < path->num; ++idx) {
+		len += path->components[idx].len;
+	}
+
+	return len;
+}
+
+/**
+ * Convert the given path into a string. The returned pointer is allocated and
+ * must be released with free(3).
+ *
+ * @param[in] path The path to convert to a string.
+ * @return An allocated string representation of the path on success, NULL on error.
+ */
+static char *path_str(const path_t *path) {
+	size_t len = path_len(path);
+
+	char *out = malloc(len + 1);
+	if (!out) {
+		return NULL;
+	}
+
+	out[0] = '/';
+	out[1] = '\0';
+	char *pos = out;
+	for (size_t idx = 0; idx < path->num; idx++) {
+		*pos = '/';
+		pos++;
+
+		path_component_t *component = &path->components[idx];
+		strlcpy(pos, component->path, component->len + 1);
+		pos += component->len;
+	}
+
+	return out;
+}
+
+/**
+ * Check whether the given path is a volfs path (i.e., /.vol/$fsnum/$inode),
+ * and return a non-volfs path if possible.
+ *
+ * If the return value is not the argument, the argument was correctly freed.
+ * Always use this function as
+ *
+ *   path = path_resolve_volfs(path);
+ *
+ * for this reason.
+ *
+ * @param[in] path The path to check for volfs paths
+ * @return The orginal path if no modification was required or expansion
+ *         failed. A fresh path if the path was a volfs path and was expanded.
+ */
+static path_t *path_resolve_volfs(path_t *path) {
+#ifdef ATTR_CMN_FULLPATH
+	if (path->num >= 3 && strcmp(path->components[0].path, ".vol") == 0) {
+		struct attrlist attrlist;
+		attrlist.bitmapcount = ATTR_BIT_MAP_COUNT;
+		attrlist.reserved = 0;
+		attrlist.commonattr = ATTR_CMN_FULLPATH;
+		attrlist.volattr = 0;
+		attrlist.dirattr = 0;
+		attrlist.fileattr = 0;
+		attrlist.forkattr = 0;
+
+		char attrbuf[sizeof(uint32_t) + sizeof(attrreference_t) + (PATH_MAX + 1)];
+		/*           attrlength         attrref_t for the name     UTF-8 name up to PATH_MAX chars */
+
+		char *path_native = path_str(path);
+		if (!path_native) {
+			goto out;
+		}
+
+		if (-1 == (getattrlist(path_native, &attrlist, attrbuf, sizeof(attrbuf), FSOPT_NOFOLLOW))) {
+			perror("darwintrace: getattrlist");
+			// ignore and just return the /.vol/ path
+		} else {
+			path_t *newpath = path_new();
+			if (!newpath) {
+				goto out;
+			}
+
+			attrreference_t *nameAttrRef = (attrreference_t *) (attrbuf + sizeof(uint32_t));
+			if (!path_tokenize(newpath, ((char *) nameAttrRef) + nameAttrRef->attr_dataoffset)) {
+				path_free(newpath);
+				goto out;
+			}
+
+			path_free(path);
+			path = newpath;
+		}
+
+out:
+		free(path_native);
+	}
+#endif /* defined(ATTR_CMN_FULLPATH) */
+
+	return path;
+}
+
 
 /**
  * Check a path against the current sandbox
@@ -795,27 +1029,24 @@ bool __darwintrace_is_in_sandbox(const char *path, int flags) {
 		return true;
 	}
 
-	char normPath[MAXPATHLEN];
-	normPath[0] = '/';
-	normPath[1] = '\0';
-
-	path_component_t pathComponents[MAXPATHLEN / 2 + 2];
-	size_t numComponents = 0;
-
-	// Make sure the path is absolute.
 	if (path == NULL || *path == '\0') {
 		// this is most certainly invalid, let the syscall deal with it
 		return true;
 	}
 
-	char *dst = NULL;
-	const char *token = NULL;
-	size_t idx;
+	path_t *normPath = path_new();
+	if (!normPath) {
+		perror("darwintrace: path_new");
+		abort();
+	}
+
+	size_t offset = 0;
+
 	if (*path != '/') {
 		/*
 		 * The path isn't absolute, start by populating pathcomponents with the
 		 * current working directory.
-		 * 
+		 *
 		 * However, we avoid getcwd(3) if we can and use getattrlist(2) with
 		 * ATTR_CMN_FULLPATH instead, because getcwd(3) will open all parent
 		 * directories, read them, search for the current component using its
@@ -833,133 +1064,67 @@ bool __darwintrace_is_in_sandbox(const char *path, int flags) {
 		attrlist.fileattr = 0;
 		attrlist.forkattr = 0;
 
-		char attrbuf[sizeof(uint32_t) + sizeof(attrreference_t) + (PATH_MAX + 1)];
-		/*           attrlength         attrref_t for the name     UTF-8 name up to PATH_MAX chars */
+		size_t attrbufSize = sizeof(uint32_t) + sizeof(attrreference_t) + (PATH_MAX + 1);
+		/*                   attrlength         attrref_t for the name     UTF-8 name up to PATH_MAX chars */
+		char *attrbuf = malloc(attrbufSize);
+		if (attrbuf == NULL) {
+			perror("darwintrace: malloc");
+			abort();
+		}
 
 		// FIXME This sometimes violates the stack canary
-		if (-1 == (getattrlist(".", &attrlist, attrbuf, sizeof(attrbuf), FSOPT_NOFOLLOW))) {
+		if (-1 == (getattrlist(".", &attrlist, attrbuf, attrbufSize, FSOPT_NOFOLLOW))) {
 			perror("darwintrace: getattrlist");
 			abort();
 		}
 		attrreference_t *nameAttrRef = (attrreference_t *) (attrbuf + sizeof(uint32_t));
-		strlcpy(normPath, ((char *) nameAttrRef) + nameAttrRef->attr_dataoffset, sizeof(normPath));
+		if (!path_tokenize(normPath, ((char *) nameAttrRef) + nameAttrRef->attr_dataoffset)) {
+			perror("darwintrace: path_tokenize");
+			abort();
+		}
 #		else /* defined(ATTR_CMN_FULLPATH) */
-		if (getcwd(normPath, sizeof(normPath)) == NULL) {
+		char *cwd = getcwd(NULL, 0);
+		if (cwd == NULL) {
 			perror("darwintrace: getcwd");
 			abort();
 		}
+		if (!path_tokenize(normPath, cwd)) {
+			perror("darwintrace: path_tokenize");
+			abort();
+		}
+		free(cwd);
 #		endif /* defined(ATTR_CMN_FULLPATH) */
-
-		char *writableToken = normPath + 1;
-		while ((idx = strcspn(writableToken, "/")) > 0) {
-			// found a token, tokenize and store it
-			pathComponents[numComponents].start = writableToken;
-			pathComponents[numComponents].len   = idx;
-			numComponents++;
-
-			bool final = writableToken[idx] == '\0';
-			writableToken[idx] = '\0';
-			if (final) {
-				break;
-			}
-			// advance token
-			writableToken += idx + 1;
-		}
-
-		// copy path after the CWD into the buffer and normalize it
-		if (numComponents > 0) {
-			path_component_t *lastComponent = pathComponents + (numComponents - 1);
-			dst = lastComponent->start + lastComponent->len + 1;
-		} else {
-			dst = normPath + 1;
-		}
-
-		// continue parsing at the begin of path
-		token = path;
 	} else {
 		// skip leading '/'
-		dst = normPath + 1;
-		*dst = '\0';
-		token = path + 1;
+		offset = 1;
 	}
 
-	/* Make sure the path is normalized. NOTE: Do _not_ use realpath(3) here.
-	 * Doing so _will_ lead to problems. This is essentially a very simple
-	 * re-implementation of realpath(3). */
-	numComponents = __parse_path_normalize(token, dst, numComponents, pathComponents, normPath);
-
-	// strip off resource forks
-	if (numComponents >= 2 &&
-		strcmp("..namedfork", pathComponents[numComponents - 2].start) == 0 &&
-		strcmp("rsrc", pathComponents[numComponents - 1].start) == 0) {
-		numComponents -= 2;
+	char *pathcopy = strdup(path + offset);
+	if (!pathcopy) {
+		perror("darwintrace: strdup");
+		abort();
 	}
-
-#	ifdef ATTR_CMN_FULLPATH
-	if (numComponents >= 3 && strncmp(".vol", pathComponents[0].start, pathComponents[0].len) == 0) {
-		// path in VOLFS, try to get inode -> name lookup from getattrlist(2).
-
-		// Add the slashes and the terminating \0
-		for (size_t i = 0; i < numComponents; ++i) {
-			if (i == numComponents - 1) {
-				pathComponents[i].start[pathComponents[i].len] = '\0';
-			} else {
-				pathComponents[i].start[pathComponents[i].len] = '/';
-			}
-		}
-
-		struct attrlist attrlist;
-		attrlist.bitmapcount = ATTR_BIT_MAP_COUNT;
-		attrlist.reserved = 0;
-		attrlist.commonattr = ATTR_CMN_FULLPATH;
-		attrlist.volattr = 0;
-		attrlist.dirattr = 0;
-		attrlist.fileattr = 0;
-		attrlist.forkattr = 0;
-
-		char attrbuf[sizeof(uint32_t) + sizeof(attrreference_t) + (PATH_MAX + 1)];
-		/*           attrlength         attrref_t for the name     UTF-8 name up to PATH_MAX chars */
-
-		if (-1 == (getattrlist(normPath, &attrlist, attrbuf, sizeof(attrbuf), FSOPT_NOFOLLOW))) {
-			perror("darwintrace: getattrlist");
-			// ignore and just return the /.vol/ path
-		} else {
-			attrreference_t *nameAttrRef = (attrreference_t *) (attrbuf + sizeof(uint32_t));
-			strlcpy(normPath, ((char *) nameAttrRef) + nameAttrRef->attr_dataoffset, sizeof(normPath));
-
-			numComponents = 0;
-			char *writableToken = normPath + 1;
-			while ((idx = strcspn(writableToken, "/")) > 0) {
-				// found a token, tokenize and store it
-				pathComponents[numComponents].start = writableToken;
-				pathComponents[numComponents].len   = idx;
-				numComponents++;
-
-				bool final = writableToken[idx] == '\0';
-				writableToken[idx] = '\0';
-				if (final) {
-					break;
-				}
-				// advance token
-				writableToken += idx + 1;
-			}
-		}
+	if (!path_tokenize(normPath, pathcopy)) {
+		perror("darwintrace: path_tokenize");
+		abort();
 	}
-#	endif
+	free(pathcopy);
+
+	// Handle resource forks (we ignore them)
+	path_strip_resource_fork(normPath);
+
+	// Handle /.vol/$devid/$inode volfs paths
+	normPath = path_resolve_volfs(normPath);
 
 	bool pathIsSymlink;
 	size_t loopCount = 0;
+	char *path_native = path_str(normPath);
+	if (!path_native) {
+		perror("darwintrace: path_str");
+		abort();
+	}
 	do {
 		pathIsSymlink = false;
-
-		// Add the slashes and the terminating \0
-		for (size_t i = 0; i < numComponents; ++i) {
-			if (i == numComponents - 1) {
-				pathComponents[i].start[pathComponents[i].len] = '\0';
-			} else {
-				pathComponents[i].start[pathComponents[i].len] = '/';
-			}
-		}
 
 		if ((flags & DT_FOLLOWSYMS) == 0) {
 			// only expand symlinks when the DT_FOLLOWSYMS flags is set;
@@ -978,46 +1143,62 @@ bool __darwintrace_is_in_sandbox(const char *path, int flags) {
 		// whether it is in the sandbox, expand it and do the same thing again.
 		struct stat st;
 		//debug_printf("checking for symlink: %s\n", normPath);
-		if (lstat(normPath, &st) != -1 && S_ISLNK(st.st_mode)) {
-			if (!__darwintrace_sandbox_check(normPath, flags)) {
+		if (lstat(path_native, &st) != -1 && S_ISLNK(st.st_mode)) {
+			if (!__darwintrace_sandbox_check(path_native, flags)) {
+				free(path_native);
 				return false;
 			}
 
-			char link[MAXPATHLEN];
-			pathIsSymlink = true;
-
-			ssize_t linksize;
-			if (-1 == (linksize = readlink(normPath, link, sizeof(link)))) {
-				perror("darwintrace: readlink");
+			size_t maxLinkLength = MAXPATHLEN / 2;
+			char *link = malloc(maxLinkLength);
+			if (link == NULL) {
+				free(path_native);
+				perror("darwintrace: malloc");
 				abort();
 			}
-			link[linksize] = '\0';
-			//debug_printf("readlink(%s) = %s\n", normPath, link);
+			pathIsSymlink = true;
 
-			if (*link == '/') {
-				// symlink is absolute, start fresh
-				numComponents = 0;
-				token = link + 1;
-				dst = normPath + 1;
-			} else {
-				// symlink is relative, remove last component
-				token = link;
-				if (numComponents > 0) {
-					numComponents--;
-					if (numComponents > 0) {
-						// move dst back to the previous entry
-						path_component_t *lastComponent = pathComponents + (numComponents - 1);
-						dst = lastComponent->start + lastComponent->len + 1;
-					} else {
-						// we're at the top, move dst back to the beginning
-						dst = normPath + 1;
-					}
+			while (true) {
+				ssize_t linksize;
+				if (-1 == (linksize = readlink(path_native, link, maxLinkLength - 1))) {
+					free(path_native);
+					perror("darwintrace: readlink");
+					abort();
 				}
+				link[linksize] = '\0';
+				if ((size_t) linksize < maxLinkLength - 1) {
+					// The link did fit the buffer
+					break;
+				}
+
+				maxLinkLength += MAXPATHLEN;
+				char *newlink = realloc(link, maxLinkLength);
+				if (!newlink) {
+					free(path_native);
+					free(link);
+					perror("darwintrace: realloc");
+					abort();
+				}
+				link = newlink;
 			}
 
-			numComponents = __parse_path_normalize(token, dst, numComponents, pathComponents, normPath);
+			if (!path_tokenize_symlink(normPath, link)) {
+				perror("darwintrace: path_tokenize_symlink");
+				abort();
+			}
+
+			free(link);
+			free(path_native);
+			path_native = path_str(normPath);
+			if (!path_native) {
+				perror("darwintrace: path_str");
+				abort();
+			}
 		}
 	} while (pathIsSymlink);
 
-	return __darwintrace_sandbox_check(normPath, flags);
+	bool result = __darwintrace_sandbox_check(path_native, flags);
+	free(path_native);
+	path_free(normPath);
+	return result;
 }

--- a/src/darwintracelib1.0/readdir.c
+++ b/src/darwintracelib1.0/readdir.c
@@ -36,11 +36,12 @@
 #include "darwintrace.h"
 
 #include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/dirent.h>
 #include <sys/param.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <string.h>
 
 /**
  * re-implementation of getdirent(2) and __getdirent64(2) preventing paths
@@ -74,11 +75,16 @@ static size_t _dt_getdirentries64(int fd, void *buf, size_t bufsize, __darwin_of
 	__darwintrace_setup();
 
 	size_t sz = __getdirentries64(fd, buf, bufsize, basep);
-	// FIXME Support longer paths
-	char dirname[MAXPATHLEN];
+	size_t maxDirname = MAXPATHLEN + 1 + NAME_MAX;
+	char *dirname = malloc(maxDirname);
+	if (dirname == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
 	size_t dnamelen;
 
 	if (-1 == fcntl(fd, F_GETPATH, dirname)) {
+		free(dirname);
 		errno = EBADF;
 		return -1;
 	}
@@ -90,13 +96,24 @@ static size_t _dt_getdirentries64(int fd, void *buf, size_t bufsize, __darwin_of
 		dnamelen++;
 	}
 
-	dnamelen = strlen(dirname);
 	size_t offset;
 	for (offset = 0; offset < sz;) {
 		struct dirent64 *dent = (struct dirent64 *)(((char *) buf) + offset);
+		size_t dentlen = strlen(dent->d_name);
+		if (maxDirname < dnamelen + dentlen + 1) {
+			char *new = realloc(dirname, dnamelen + dentlen + 1);
+			if (new == NULL) {
+				free(dirname);
+				errno = EBADF;
+				return -1;
+			}
+			dirname = new;
+			maxDirname = dnamelen + dentlen + 1;
+		}
+
 		dirname[dnamelen] = '\0';
-		// FIXME This crashes sometimes
-		strcat(dirname, dent->d_name);
+		strlcat(dirname, dent->d_name, maxDirname);
+
 		if (!__darwintrace_is_in_sandbox(dirname, DT_ALLOWDIR)) {
 			debug_printf("__getdirentries64: filtered %s\n", dirname);
 			dent->d_ino = 0;
@@ -106,6 +123,7 @@ static size_t _dt_getdirentries64(int fd, void *buf, size_t bufsize, __darwin_of
 		offset += dent->d_reclen;
 	}
 
+	free(dirname);
 	return sz;
 }
 
@@ -134,12 +152,18 @@ static int _dt_getdirentries(int fd, char *buf, int nbytes, long *basep) {
 	__darwintrace_setup();
 
 	size_t sz = getdirentries(fd, buf, nbytes, basep);
-	char dirname[MAXPATHLEN];
+	size_t maxDirname = MAXPATHLEN + 1 + NAME_MAX;
+	char *dirname = malloc(maxDirname);
+	if (dirname == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
 	size_t dnamelen;
 
 	if (-1 == fcntl(fd, F_GETPATH, dirname)) {
+		free(dirname);
 		errno = EBADF;
-		return 0;
+		return -1;
 	}
 
 	dnamelen = strlen(dirname);
@@ -152,8 +176,21 @@ static int _dt_getdirentries(int fd, char *buf, int nbytes, long *basep) {
 	size_t offset;
 	for (offset = 0; offset < sz;) {
 		struct dirent32 *dent = (struct dirent32 *)(buf + offset);
+		size_t dentlen = strlen(dent->d_name);
+		if (maxDirname < dnamelen + dentlen + 1) {
+			char *new = realloc(dirname, dnamelen + dentlen + 1);
+			if (new == NULL) {
+				free(dirname);
+				errno = EBADF;
+				return -1;
+			}
+			dirname = new;
+			maxDirname = dnamelen + dentlen + 1;
+		}
+
 		dirname[dnamelen] = '\0';
-		strcat(dirname, dent->d_name);
+		strlcat(dirname, dent->d_name, maxDirname);
+
 		if (!__darwintrace_is_in_sandbox(dirname, DT_ALLOWDIR)) {
 			debug_printf("getdirentries: filtered %s\n", dirname);
 			dent->d_ino = 0;
@@ -163,6 +200,7 @@ static int _dt_getdirentries(int fd, char *buf, int nbytes, long *basep) {
 		offset += dent->d_reclen;
 	}
 
+	free(dirname);
 	return sz;
 }
 

--- a/src/darwintracelib1.0/tests/.gitignore
+++ b/src/darwintracelib1.0/tests/.gitignore
@@ -1,0 +1,16 @@
+access
+close
+dup2
+env
+execve
+fork
+lstat
+mkdir
+open
+posix_spawn
+readdir
+readlink
+rename
+rmdir
+stat
+unlink

--- a/src/darwintracelib1.0/tests/Makefile.in
+++ b/src/darwintracelib1.0/tests/Makefile.in
@@ -7,6 +7,7 @@ SRCS = \
 	access.c \
 	close.c \
 	dup2.c \
+	env.c \
 	execve.c \
 	fork.c \
 	lstat.c \
@@ -25,14 +26,11 @@ OBJS = $(SRCS:%.c=%.o)
 BINS = $(SRCS:%.c=%)
 TESTS = $(sort $(wildcard *.test))
 
-# Create a copy of env that doesn't have Apple's restricted bits set in order
-# to preserve DYLD* variables.
-env:
-	dd if=/usr/bin/env of=env
-	chmod +x env
+env: env.o
+	$(CC) $(LDFLAGS) -o $@ $^
 
 %: %.o ../darwintrace.dylib
-	$(CC) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^
 
 # Generate dependency information
 %.d : %.c
@@ -47,7 +45,7 @@ clean::
 distclean:: clean
 	rm -f Makefile
 
-test:: env $(BINS)
+test:: $(BINS)
 	$(foreach test,$(TESTS),DARWINTRACE_SIP_WORKAROUND_PATH=@DARWINTRACE_SIP_WORKAROUND_PATH@ LC_ALL=C $(TCLSH) "$(srcdir)/$(test)";)
 
 ifeq (,$(findstring clean,$(MAKECMDGOALS)))

--- a/src/darwintracelib1.0/tests/Makefile.in
+++ b/src/darwintracelib1.0/tests/Makefile.in
@@ -1,0 +1,56 @@
+srcdir = @srcdir@
+VPATH  = @srcdir@
+
+include ../../../Mk/macports.autoconf.mk
+
+SRCS = \
+	access.c \
+	close.c \
+	dup2.c \
+	execve.c \
+	fork.c \
+	lstat.c \
+	mkdir.c \
+	open.c \
+	posix_spawn.c \
+	readdir.c \
+	readlink.c \
+	rename.c \
+	rmdir.c \
+	stat.c \
+	unlink.c
+
+
+OBJS = $(SRCS:%.c=%.o)
+BINS = $(SRCS:%.c=%)
+TESTS = $(sort $(wildcard *.test))
+
+# Create a copy of env that doesn't have Apple's restricted bits set in order
+# to preserve DYLD* variables.
+env:
+	dd if=/usr/bin/env of=env
+	chmod +x env
+
+%: %.o ../darwintrace.dylib
+	$(CC) -o $@ $^
+
+# Generate dependency information
+%.d : %.c
+	$(CC) -MM -MP $(CPPFLAGS) $< > $@
+
+.PHONY: all clean distclean install test codesign
+all::
+
+clean::
+	rm -f $(BINS) $(OBJS) $(SRCS:%.c=%.d)
+
+distclean:: clean
+	rm -f Makefile
+
+test:: env $(BINS)
+	$(foreach test,$(TESTS),DARWINTRACE_SIP_WORKAROUND_PATH=@DARWINTRACE_SIP_WORKAROUND_PATH@ LC_ALL=C $(TCLSH) "$(srcdir)/$(test)";)
+
+ifeq (,$(findstring clean,$(MAKECMDGOALS)))
+# Include dependency information
+-include $(SRCS:%.c=%.d)
+endif

--- a/src/darwintracelib1.0/tests/access.c
+++ b/src/darwintracelib1.0/tests/access.c
@@ -1,0 +1,26 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: access PATH...\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	for (int idx = 1; idx < argc; ++idx) {
+		if (-1 == access(argv[idx], F_OK)) {
+			fprintf(stderr, "access(%s): %s\n", argv[idx], strerror(errno));
+		}
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/access.test
+++ b/src/darwintracelib1.0/tests/access.test
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test access_allows_denied_dirs "Test that access(2) allows accesses to all directories" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect {}] \
+    -body {exec -ignorestderr -- ./access /usr /usr/bin /bin 2>@1} \
+    -result ""
+
+test access_denies_outside_sandbox "Test that access(2) hides files outside of the sandbox" \
+    -setup [setup {}] \
+    -cleanup [expect [list "$cwd/access"]] \
+    -body {exec -ignorestderr -- ./access ./access 2>@1} \
+    -result "access(./access): No such file or directory"
+
+test access_allowed_inside_sandbox "Test that access(2) does not hide files inside the sandbox" \
+    -setup [setup [list allow "$cwd/access"]] \
+    -cleanup [expect] \
+    -body {exec -ignorestderr -- ./access ./access 2>@1} \
+    -result ""
+
+test access_allowed_when_uninitialized "Test that access(2) does not hide files when darwintrace is uninitialized" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set output [exec -ignorestderr -- ./access ./access 2>@1]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $output
+    } \
+    -result ""
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/close.c
+++ b/src/darwintracelib1.0/tests/close.c
@@ -1,0 +1,37 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	(void) argc;
+	(void) argv;
+
+	__darwintrace_setup();
+
+	// close non-dt socket
+	close(255);
+
+	FILE *stream = __darwintrace_sock();
+	if (stream == NULL) {
+		fprintf(stderr, "__darwintrace_sock() returned NULL\n");
+		exit(EXIT_FAILURE);
+	}
+
+	int fd = fileno(stream);
+	if (-1 == close(fd)) {
+		fprintf(stderr, "close(%d): %s\n", fd, strerror(errno));
+	}
+
+	__darwintrace_initialized = false;
+	if (-1 == close(fd)) {
+		fprintf(stderr, "uninitialized close(%d): %s\n", fd, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/close.test
+++ b/src/darwintracelib1.0/tests/close.test
@@ -1,0 +1,17 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test close_dt_socket "Test that closing the darwintrace socket is not possible" \
+    -setup [setup {}] \
+    -cleanup [expect] \
+    -body {
+        exec -ignorestderr -- ./close 2>@1
+    } \
+    -match glob \
+    -result "close(*): Bad file descriptor"
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/darwintrace.test
+++ b/src/darwintracelib1.0/tests/darwintrace.test
@@ -1,0 +1,171 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test darwintrace_hides_files "Test that a file on the blacklist isn't stat(2)able" \
+    -setup [setup [list deny $cwd]] \
+    -cleanup [expect [list "$cwd/stat"]] \
+    -body {exec -ignorestderr -- ./stat stat 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_hides_symlinks "Test that a symlink on the blacklist isn't stat(2)able, even if its target is" \
+    -setup {
+        file link -symbolic link .
+        [setup [list deny "$cwd/link" allow $cwd]]
+    } \
+    -cleanup {
+        file delete -force link
+        [expect [list "$cwd/link"]]
+    } \
+    -body {exec -ignorestderr -- ./lstat link 2>@1} \
+    -result "lstat: No such file or directory"
+
+test darwintrace_long_filenames "Test that a long filename does not trigger the stack canary" \
+    -setup [setup [list allow $cwd]] \
+    -cleanup [expect] \
+    -body {exec -ignorestderr -- ./stat [string repeat "ab/de/ghi/" 102] 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_works_across_fork "Test that darwintrace works across fork(2)" \
+    -setup [setup [list deny "$cwd/access.c" allow $cwd]] \
+    -cleanup [expect [list "$cwd/access.c"]] \
+    -body {exec -ignorestderr -- ./fork ./access.c 2>@1} \
+    -result [join [list "access(./access.c): No such file or directory" "access(./access.c): No such file or directory"] "\n"]
+
+test darwintrace_allow_root "Test that access to / is always possible" \
+    -setup [setup {}] \
+    -cleanup [expect] \
+    -body {exec -ignorestderr -- ./stat / 2>@1} \
+    -result ""
+
+test darwintrace_empty_path "Test that access to and empty path isn't hindered by darwintrace" \
+    -setup [setup {}] \
+    -cleanup [expect] \
+    -body {exec -ignorestderr -- ./stat "" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_up_beyond_root_absolute "Test that walking up beyond the root with absolute paths works" \
+    -setup [setup [list deny "/"]] \
+    -cleanup [expect [list "/bin/sh"]] \
+    -body {exec -ignorestderr -- ./stat "/bin/..//..//../bin/sh" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_up_beyond_root_relative "Test that walking up beyond the root with relative paths works" \
+    -setup [setup [list deny "/"]] \
+    -cleanup [expect [list "/bin/sh"]] \
+    -body {
+        set levels [llength [regexp -all -inline -- "/" $cwd]]
+        set path [file join [string repeat "../" [expr {$levels + 2}]] bin sh]
+        exec -ignorestderr -- ./stat "$path" 2>@1
+    } \
+    -result "stat: No such file or directory"
+
+test darwintrace_ignores_rsrc_forks "Test that resource forks are ignored" \
+    -setup [setup [list deny "/"]] \
+    -cleanup [expect [list "/bin/sh"]] \
+    -body {exec -ignorestderr -- ./stat "/bin/sh/..namedfork/rsrc" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_on_volfs "Test that /.vol/device/inode works" \
+    -setup [setup [list deny "/"]] \
+    -cleanup [expect [list "/bin/sh"]] \
+    -body {
+        file stat "/bin/sh" st
+        exec -ignorestderr -- ./stat "/.vol/${st(dev)}/${st(ino)}" 2>@1
+    } \
+    -result "stat: No such file or directory"
+
+test darwintrace_on_looping_symlinks "Test that self-symlinks are handled" \
+    -setup {
+        set levels [llength [regexp -all -inline -- "/" $cwd]]
+        set path [file join [string repeat "../" [expr {$levels + 2}]] $cwd symlink]
+        exec -ignorestderr -- ln -s $path symlink
+        [setup [list allow "/"]]
+    } \
+    -cleanup {
+        [expect]
+        file delete -force symlink
+    } \
+    -body {exec -ignorestderr -- ./stat "$cwd/symlink" 2>@1} \
+    -result "stat: Too many levels of symbolic links"
+
+test darwintrace_checks_symlink_path "Test that accessing a symlink fails, even if the target is in the sandbox" \
+    -setup {
+        [setup [list deny "$cwd/symlink" allow $cwd]]
+        file link -symbolic symlink stat
+    } \
+    -cleanup {
+        [expect [list "$cwd/symlink"]]
+        file delete -force symlink
+    } \
+    -body {exec -ignorestderr -- ./stat "$cwd/symlink" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_access_through_symlink_checks_target_permission "Test that file through a symlink checks whether the target is in the sandbox" \
+    -setup {
+        [setup [list deny "$cwd/stat" allow $cwd]]
+        # while we're here, let's also test absolute symlinks
+        file link -symbolic symlink "$cwd/stat"
+    } \
+    -cleanup {
+        [expect [list "$cwd/stat"]]
+        file delete -force symlink
+    } \
+    -body {exec -ignorestderr -- ./stat "$cwd/symlink" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_relative_symlink_at_top_level "Test that a relative symlink at the top level works as expected" \
+    -setup [setup [list allow /]] \
+    -cleanup [expect] \
+    -body {exec -ignorestderr -- ./stat "/tmp" 2>@1} \
+    -result ""
+
+test darwintrace_relative_symlinks "Test that resolution of relative symlinks works as expected" \
+    -setup {
+        set levels [llength [regexp -all -inline -- "/" $cwd]]
+        set path "[string repeat "../" [expr {$levels + 2}]]$cwd//./stat"
+
+        [setup [list allow "$cwd/symlink"]]
+
+        exec -ignorestderr -- ln -s $path symlink
+    } \
+    -cleanup {
+        file delete -force symlink
+        [expect [list "$cwd/stat"]]
+    } \
+    -body {exec -ignorestderr -- ./stat "$cwd/symlink" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_long_symlinks "Test that resolution of long symlinks does not trigger the stack canary" \
+    -setup {
+        [setup [list allow /]]
+        exec -- ln -s [string repeat "ab/de/ghi/" 102] longlink
+    } \
+    -cleanup {
+        [expect]
+        file delete -force longlink
+    } \
+    -body {exec -ignorestderr -- ./stat "$cwd/longlink" 2>@1} \
+    -result "stat: No such file or directory"
+
+test darwintrace_without_log_env_fails "Test that injecting the lib without setting DARWINTRACE_LOG fails" \
+    -body {
+        set ::env(DYLD_INSERT_LIBRARIES) $darwintrace_lib
+        exec -ignorestderr -- ./stat . 2>@1
+    } \
+    -returnCodes [list 1] \
+    -result "darwintrace: trace library loaded, but DARWINTRACE_LOG not set\nchild killed: SIGABRT"
+
+test darwintrace_with_incorrect_log_env_fails "Test that DARWINTRACE_LOG pointing to a non-socket fails" \
+    -body {
+        set ::env(DYLD_INSERT_LIBRARIES) $darwintrace_lib
+        set ::env(DARWINTRACE_LOG) "GARBAGE.RANDOM.DOES.NOT.EXIST"
+        exec -ignorestderr -- ./stat . 2>@1
+    } \
+    -returnCodes [list 1] \
+    -result "darwintrace: connect: No such file or directory\nchild killed: SIGABRT"
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/dup2.c
+++ b/src/darwintracelib1.0/tests/dup2.c
@@ -1,0 +1,52 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	(void) argc;
+	(void) argv;
+
+	__darwintrace_setup();
+
+	// dup2 non-dt socket
+	if (-1 == dup2(STDOUT_FILENO, 255)) {
+		fprintf(stderr, "dup2(STDOUT_FILENO, 255): %s\n", strerror(errno));
+	}
+
+	FILE *stream = __darwintrace_sock();
+	if (stream == NULL) {
+		fprintf(stderr, "__darwintrace_sock() returned NULL\n");
+		exit(EXIT_FAILURE);
+	}
+
+	int fd = fileno(stream);
+	if (-1 == dup2(STDOUT_FILENO, fd)) {
+		fprintf(stderr, "dup2(STDOUT_FILENO, %d): %s\n", fd, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	FILE *newstream = __darwintrace_sock();
+	if (newstream == NULL) {
+		fprintf(stderr, "__darwintrace_sock() returned NULL after dup2(2)\n");
+		exit(EXIT_FAILURE);
+	}
+	int newfd = fileno(newstream);
+
+	if (fd == newfd) {
+		fprintf(stderr, "__darwintrace_sock() fd did not change from %d, even though we dup(2)'d over it\n", fd);
+		exit(EXIT_FAILURE);
+	}
+
+	__darwintrace_initialized = false;
+	if (-1 == dup2(STDOUT_FILENO, newfd)) {
+		fprintf(stderr, "uninitialized dup2(STDOUT_FILENO, %d): %s\n", newfd, strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/dup2.test
+++ b/src/darwintracelib1.0/tests/dup2.test
@@ -1,0 +1,14 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test dup2_dt_socket "Test that dup(2) over the darwintrace socket moves the socket" \
+    -setup [setup {}] \
+    -cleanup [expect] \
+    -body {exec -ignorestderr -- ./dup2 2>@1} \
+    -result ""
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/env.c
+++ b/src/darwintracelib1.0/tests/env.c
@@ -1,0 +1,107 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1988, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef lint
+static const char copyright[] =
+"@(#) Copyright (c) 1988, 1993, 1994\n\
+	The Regents of the University of California.  All rights reserved.\n";
+#endif /* not lint */
+
+#if 0
+#ifndef lint
+static char sccsid[] = "@(#)env.c	8.3 (Berkeley) 4/2/94";
+#endif /* not lint */
+#endif
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+extern char **environ;
+
+static void usage(void);
+
+/*
+ * Exit codes.
+ */
+#define EXIT_CANCELED      125 /* Internal error prior to exec attempt. */
+#define EXIT_CANNOT_INVOKE 126 /* Program located, but not usable. */
+#define EXIT_ENOENT        127 /* Could not find program to exec. */
+
+int
+main(int argc, char **argv)
+{
+	char **ep, *p;
+	int ch;
+	int rtrn;
+
+	while ((ch = getopt(argc, argv, "u:")) != -1)
+		switch(ch) {
+		case 'u':
+			rtrn = unsetenv(optarg);
+			if (rtrn == -1)
+				err(EXIT_FAILURE, "unsetenv %s", optarg);
+			break;
+		case '?':
+		default:
+			usage();
+		}
+	for (argv += optind; *argv && (p = strchr(*argv, '=')); ++argv) {
+		*p = '\0';
+		rtrn = setenv(*argv, p + 1, 1);
+		*p = '=';
+		if (rtrn == -1)
+			err(EXIT_FAILURE, "setenv %s", *argv);
+	}
+	if (*argv) {
+		execvp(*argv, argv);
+		err(errno == ENOENT ? EXIT_ENOENT : EXIT_CANNOT_INVOKE,
+		    "%s", *argv);
+	}
+	for (ep = environ; *ep; ep++)
+		(void)printf("%s%c", *ep, '\n');
+	exit(0);
+}
+
+static void
+usage(void)
+{
+	(void)fprintf(stderr,
+	    "usage: env [-u name] [name=value ...] [utility [argument ...]]\n");
+	(void)fprintf(stderr, "%s\n", copyright);
+	exit(1);
+}

--- a/src/darwintracelib1.0/tests/execve.c
+++ b/src/darwintracelib1.0/tests/execve.c
@@ -1,0 +1,43 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[], char* envp[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: execve PROGRAM ARGS...\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	pid_t pid = fork();
+	int status = 0;
+	switch (pid) {
+		case -1:
+			perror("fork");
+			exit(EXIT_FAILURE);
+		case 0:
+			execve(argv[1], argv + 1, envp);
+			perror("execve");
+			exit(EXIT_SUCCESS);
+		default:
+			if (pid != waitpid(pid, &status, 0)) {
+				perror("waitpid");
+				exit(EXIT_FAILURE);
+			}
+			if (WIFEXITED(status)) {
+				exit(WEXITSTATUS(status));
+			} else if (WIFSIGNALED(status)) {
+				fprintf(stderr, "%s killed with signal %d\n", argv[1], WTERMSIG(status));
+				exit(EXIT_FAILURE);
+			}
+	}
+	fprintf(stderr, "%s: unexpected exit status %d\n", argv[1], status);
+	exit(EXIT_FAILURE);
+}

--- a/src/darwintracelib1.0/tests/fork.c
+++ b/src/darwintracelib1.0/tests/fork.c
@@ -1,0 +1,43 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: fork PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (access(argv[1], F_OK) == -1) {
+		fprintf(stderr, "access(%s): %s\n", argv[1], strerror(errno));
+	}
+
+	pid_t pid = fork();
+	int status = 0;
+	switch (pid) {
+		case -1:
+			perror("fork");
+			exit(EXIT_FAILURE);
+		case 0:
+			if (access(argv[1], F_OK) == -1) {
+				fprintf(stderr, "access(%s): %s\n", argv[1], strerror(errno));
+			}
+			exit(EXIT_SUCCESS);
+		default:
+			if (pid != waitpid(pid, &status, 0)) {
+				perror("waitpid");
+				exit(EXIT_FAILURE);
+			}
+			if (WIFEXITED(status)) {
+				exit(WEXITSTATUS(status));
+			} else if (WIFSIGNALED(status)) {
+				fprintf(stderr, "%s killed with signal %d\n", argv[1], WTERMSIG(status));
+				exit(EXIT_FAILURE);
+			}
+	}
+	fprintf(stderr, "%s: unexpected exit status %d\n", argv[1], status);
+	exit(EXIT_FAILURE);
+}

--- a/src/darwintracelib1.0/tests/lstat.c
+++ b/src/darwintracelib1.0/tests/lstat.c
@@ -1,0 +1,23 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: lstat PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	struct stat st;
+	if (-1 == lstat(argv[1], &st)) {
+		perror("lstat");
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/mkdir.c
+++ b/src/darwintracelib1.0/tests/mkdir.c
@@ -1,0 +1,27 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: mkdir PATH...\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	for (int idx = 1; idx < argc; ++idx) {
+		if (-1 == mkdir(argv[idx], 0777)) {
+			fprintf(stderr, "mkdir(%s): %s\n", argv[idx], strerror(errno));
+		}
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/mkdir.test
+++ b/src/darwintracelib1.0/tests/mkdir.test
@@ -1,0 +1,43 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test mkdir_allows_existing_dirs "Test that mkdir(2) succeeds outside sandbox, if the directory exists" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect [list "/usr" "/usr/bin" "/bin"]] \
+    -body {exec -ignorestderr -- ./mkdir /usr /usr/bin /bin 2>@1} \
+    -result ""
+
+test mkdir_denies_outside_sandbox "Test that mkdir(2) fails if attempted outside of the sandbox" \
+    -setup [setup [list deny /]] \
+    -cleanup {
+        file delete -force "$cwd/testdirectory"
+        [expect [list "$cwd/testdirectory"]]
+    } \
+    -body {exec -ignorestderr -- ./mkdir "$cwd/testdirectory" 2>@1} \
+    -result "mkdir($cwd/testdirectory): Permission denied"
+
+test mkdir_allowed_inside_sandbox "Test that mkdir(2) succeeds inside of the sandbox" \
+    -setup [setup [list allow "$cwd"]] \
+    -cleanup {
+        file delete -force "$cwd/testdirectory2"
+        [expect]
+    } \
+    -body {exec -ignorestderr -- ./mkdir "$cwd/testdirectory2" 2>@1} \
+    -result ""
+
+test mkdir_allowed_when_uninitialized "Test that mkdir(2) succeeds outside of the sandbox when darwintrace is uninitialized" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set output [exec -ignorestderr -- ./mkdir /usr 2>@1]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $output
+    } \
+    -result "mkdir(/usr): File exists"
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/open.c
+++ b/src/darwintracelib1.0/tests/open.c
@@ -1,0 +1,41 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 3) {
+		fprintf(stderr, "Usage: open {-create|-read} PATH...\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	int flags = 0;
+	mode_t mode = 0666;
+	if (strcmp(argv[1], "-create") == 0) {
+		flags |= O_RDWR | O_CREAT;
+	} else if (strcmp(argv[1], "-read") == 0) {
+		flags |= O_RDONLY;
+	} else {
+		fprintf(stderr, "open: unsupported mode '%s'. Choose one of '-create', '-read'.\n", argv[1]);
+		exit(EXIT_FAILURE);
+	}
+
+	for (int idx = 2; idx < argc; ++idx) {
+		int fd = open(argv[idx], flags, mode);
+		if (-1 == fd) {
+			fprintf(stderr, "open(%s): %s\n", argv[idx], strerror(errno));
+		} else {
+			close(fd);
+		}
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/open.test
+++ b/src/darwintracelib1.0/tests/open.test
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test open_succeeds_on_dirs "Test that open(2) succeeds on directories even outside the sandbox" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect {}] \
+    -body {exec -ignorestderr -- ./open -read /usr} \
+    -result ""
+
+test open_fails_outside_sandbox "Test that open(O_RDONLY) fails outside of the sandbox" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect [list "$cwd/open"]] \
+    -body {exec -ignorestderr -- ./open -read "$cwd/open" 2>@1} \
+    -result "open($cwd/open): No such file or directory"
+
+test open_write_fails_outside_sandbox "Test that open(O_RDWR|O_CREAT) fails outside of the sandbox" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect [list "$cwd/open"]] \
+    -body {exec -ignorestderr -- ./open -create "$cwd/open" 2>@1} \
+    -result "open($cwd/open): Permission denied"
+
+test open_succeeds_inside_sandbox "Test that open(O_RDONLY) succeeds inside of the sandbox" \
+    -setup [setup [list allow "$cwd"]] \
+    -cleanup [expect {}] \
+    -body {exec -ignorestderr -- ./open -read "$cwd/open" 2>@1} \
+    -result ""
+
+test open_write_succeeds_inside_sandbox "Test that open(O_RDWR|O_CREAT) succeeds inside of the sandbox" \
+    -setup [setup [list allow "$cwd"]] \
+    -cleanup {
+        file delete -force "$cwd/opentest"
+        [expect {}]
+    } \
+    -body {exec -ignorestderr -- ./open -create "$cwd/opentest" 2>@1} \
+    -result ""
+
+test open_succeeds_when_uninitialized "Test that open(2) succeeds outside of the sandbox when darwintrace is uninitialized" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set output [exec -ignorestderr -- ./open -read ./open 2>@1]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $output
+    } \
+    -result ""
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/posix_spawn.c
+++ b/src/darwintracelib1.0/tests/posix_spawn.c
@@ -1,0 +1,55 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <spawn.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[], char* envp[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: posix_spawn PROGRAM ARGS...\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	bool use_spawn_setexec = false;
+	if (getenv("DARWINTRACE_SPAWN_SETEXEC") != NULL) {
+		use_spawn_setexec = true;
+	}
+
+	pid_t pid;
+	posix_spawnattr_t attr;
+	if (0 != (errno = posix_spawnattr_init(&attr))) {
+		perror("posix_spawnattr_init");
+		exit(EXIT_FAILURE);
+	}
+	if (0 != (errno = posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETEXEC))) {
+		perror("posix_spawnattr_setflags");
+		exit(EXIT_FAILURE);
+	}
+
+	if (0 != (errno = posix_spawn(&pid, argv[1], NULL, use_spawn_setexec ? &attr : NULL, argv + 1, envp))) {
+		perror("posix_spawn");
+		exit(EXIT_SUCCESS);
+	} else {
+		int status;
+		if (pid != waitpid(pid, &status, 0)) {
+			perror("waitpid");
+			exit(EXIT_FAILURE);
+		}
+		if (WIFEXITED(status)) {
+			exit(WEXITSTATUS(status));
+		} else if (WIFSIGNALED(status)) {
+			fprintf(stderr, "%s killed with signal %d\n", argv[1], WTERMSIG(status));
+			exit(EXIT_FAILURE);
+		}
+		fprintf(stderr, "%s: unexpected exit status %d\n", argv[1], status);
+		exit(EXIT_FAILURE);
+	}
+}

--- a/src/darwintracelib1.0/tests/proc.test
+++ b/src/darwintracelib1.0/tests/proc.test
@@ -235,13 +235,19 @@ test spawn_sip_suid_binary "Test that posix_spawn(2) works on a SIP-protected SU
     -cleanup [expect {}] \
     -body {
         set status 0
-        if {[catch {exec -ignorestderr -- ./posix_spawn /usr/bin/crontab -l} results options]} {
-            puts $::errorInfo
-            set details [dict get $options -errorcode]
-            if {[lindex $details 0] eq "CHILDSTATUS"} {
-                set status [lindex $details 2]
+        if {[catch {exec -ignorestderr -- ./posix_spawn /usr/bin/crontab -l 2>@1} results options]} {
+            if {[string match "crontab: no crontab for *" $results]} {
+                # The current user has no crontab; that will cause crontab -l
+                # to fail, but we don't care; hide the error.
+                set status 0
             } else {
-                return -options $options -level 0 $results
+                puts $::errorInfo
+                set details [dict get $options -errorcode]
+                if {[lindex $details 0] eq "CHILDSTATUS"} {
+                    set status [lindex $details 2]
+                } else {
+                    return -options $options -level 0 $results
+                }
             }
         }
         return $status

--- a/src/darwintracelib1.0/tests/proc.test
+++ b/src/darwintracelib1.0/tests/proc.test
@@ -1,0 +1,251 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+package require Pextlib 1.0
+
+source "testlib.tcl"
+
+test execve_selfpreserving_env "Test that you cannot get out of the sandbox by unsetting environment variables" \
+    -setup [setup [list allow $cwd]] \
+    -cleanup [expect] \
+    -body {
+        set lines [split [exec -ignorestderr -- ./env DYLD_INSERT_LIBRARIES=foo DARWINTRACE_LOG=bar ./env] "\n"]
+        set result {}
+        foreach line $lines {
+            if {[string match "DYLD_INSERT_LIBRARIES=*" $line] || [string match "DARWINTRACE_LOG=*" $line]} {
+                lappend result $line
+            }
+        }
+        return [lsort $result]
+    } \
+    -match glob \
+    -result [list "DARWINTRACE_LOG=/tmp/macports-test-*" "DYLD_INSERT_LIBRARIES=$darwintrace_lib"]
+
+test execve_preserves_environment "Test that execve(2) will restore DYLD_INSERT_LIBRARIES and DARWINTRACE_LOG when deleted" \
+    -setup [setup [list allow $cwd]] \
+    -cleanup [expect] \
+    -body {
+        set lines [split [exec -ignorestderr -- ./env -u DYLD_INSERT_LIBRARIES -u DARWINTRACE_LOG ./env] "\n"]
+        set result {}
+        foreach line $lines {
+            if {[string match "DYLD_INSERT_LIBRARIES=*" $line] || [string match "DARWINTRACE_LOG=*" $line]} {
+                lappend result $line
+            }
+        }
+        return [lsort $result]
+    } \
+    -match glob \
+    -result [list "DARWINTRACE_LOG=/tmp/macports-test-*" "DYLD_INSERT_LIBRARIES=$darwintrace_lib"]
+
+test execve_outside_sandbox "Test that you cannot run tools outside of the sandbox" \
+    -setup [setup {}] \
+    -cleanup [expect "$cwd/stat"] \
+    -body {exec -ignorestderr -- ./execve ./stat ./stat.c 2>@1} \
+    -result "execve: No such file or directory"
+
+test spawn_outside_sandbox "Test that you cannot run tools outside of the sandbox with posix_spawn(2)" \
+    -setup [setup {}] \
+    -cleanup [expect "$cwd/stat"] \
+    -body {
+        set lines [list]
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./stat ./stat.c 2>@1]
+
+        set ::env(DARWINTRACE_SPAWN_SETEXEC) 1
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./stat ./stat.c 2>@1]
+        unset ::env(DARWINTRACE_SPAWN_SETEXEC)
+
+        return $lines
+    } \
+    -result [lrepeat 2 "posix_spawn: No such file or directory"]
+
+test execve_uninitialized "Test that execve(2) outside the sandbox succeeds if darwintrace is uninitialized" \
+    -setup [setup {}] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set output [exec -ignorestderr -- ./execve ./stat ./stat.c 2>@1]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $output
+    } \
+    -result ""
+
+test spawn_uninitialized "Test that posix_spawn(2) outside the sandbox succeeds if darwintrace is uninitialized" \
+    -setup [setup {}] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set lines [list]
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./stat ./stat.c 2>@1]
+
+        set ::env(DARWINTRACE_SPAWN_SETEXEC) 1
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./stat ./stat.c 2>@1]
+        unset ::env(DARWINTRACE_SPAWN_SETEXEC)
+
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $lines
+    } \
+    -result [lrepeat 2 ""]
+
+test execve_inside_sandbox "Test that execve(2) inside the sandbox succeeds" \
+    -setup [setup [list deny "$cwd/stat.c" allow $cwd]] \
+    -cleanup [expect "$cwd/stat.c"] \
+    -body {exec -ignorestderr -- ./execve ./stat ./stat.c 2>@1} \
+    -result "stat: No such file or directory"
+
+test spawn_inside_sandbox "Test that posix_spawn(2) inside the sandbox succeeds" \
+    -setup [setup [list deny "$cwd/stat.c" allow $cwd]] \
+    -cleanup [expect "$cwd/stat.c"] \
+    -body {
+        set lines [list]
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./stat ./stat.c 2>@1]
+
+        set ::env(DARWINTRACE_SPAWN_SETEXEC) 1
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./stat ./stat.c 2>@1]
+        unset ::env(DARWINTRACE_SPAWN_SETEXEC)
+
+        return $lines
+    } \
+    -result [lrepeat 2 "stat: No such file or directory"]
+
+test execve_interpreter_outside_sandbox "Test that execve(2) on a script with an interpreter outside of the sandbox fails" \
+    -setup {
+        set fd [open "execve_script" w 0700]
+        puts $fd "#!  \t  ${cwd}/stat stat.c"
+        close $fd
+        [setup [list deny "$cwd/stat" allow $cwd]]
+    } \
+    -cleanup {
+        file delete -force execve_script
+        [expect [list "$cwd/stat"]]
+    } \
+    -body {exec -ignorestderr -- ./execve ./execve_script 2>@1} \
+    -result "execve: No such file or directory"
+
+test spawn_interpreter_outside_sandbox "Test that posix_spawn(2) on a script with an interpreter outside of the sandbox fails" \
+    -setup {
+        set fd [open "execve_script" w 0700]
+        puts $fd "#!  \t  ${cwd}/stat stat.c"
+        close $fd
+        [setup [list deny "$cwd/stat" allow $cwd]]
+    } \
+    -cleanup {
+        file delete -force execve_script
+        [expect [list "$cwd/stat"]]
+    } \
+    -body {
+        set lines [list]
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./execve_script 2>@1]
+
+        set ::env(DARWINTRACE_SPAWN_SETEXEC) 1
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./execve_script 2>@1]
+        unset ::env(DARWINTRACE_SPAWN_SETEXEC)
+
+        return $lines
+    } \
+    -result [lrepeat 2 "posix_spawn: No such file or directory"]
+
+test execve_non_interpreter "Test that execve(2) on a script with broken shebang does not produce violations" \
+    -setup {
+        set fd [open "execve_script" w 0700]
+        puts $fd "#"
+        close $fd
+        [setup [list allow /]]
+    } \
+    -cleanup {
+        file delete -force execve_script
+        [expect {}]
+    } \
+    -body {exec -ignorestderr -- ./execve ./execve_script 2>@1} \
+    -result "execve: Exec format error"
+
+test spawn_non_interpreter "Test that posix_spawn(2) on a script with broken shebang does not produce violations" \
+    -setup {
+        set fd [open "execve_script" w 0700]
+        puts $fd "#"
+        close $fd
+        [setup [list allow /]]
+    } \
+    -cleanup {
+        file delete -force execve_script
+        [expect {}]
+    } \
+    -body {
+        set lines [list]
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./execve_script 2>@1]
+
+        set ::env(DARWINTRACE_SPAWN_SETEXEC) 1
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./execve_script 2>@1]
+        unset ::env(DARWINTRACE_SPAWN_SETEXEC)
+
+        return $lines
+    } \
+    -result [lrepeat 2 "posix_spawn: Exec format error"]
+
+test execve_non_existing_inside_sandbox "Test that execve(2) on a non-existing file inside the sandbox does not produce violations" \
+    -setup [setup [list allow /]] \
+    -cleanup [expect {}] \
+    -body {exec -ignorestderr -- ./execve ./execve_non_existing_binary 2>@1} \
+    -result "execve: No such file or directory"
+
+test spawn_non_existing_inside_sandbox "Test that posix_spawn(2) on a non-existing file inside the sandbox does not produce violations" \
+    -setup [setup [list allow /]] \
+    -cleanup [expect {}] \
+    -body {
+        set lines [list]
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./execve_non_existing_binary 2>@1]
+
+        set ::env(DARWINTRACE_SPAWN_SETEXEC) 1
+        lappend lines [exec -ignorestderr -- ./posix_spawn ./execve_non_existing_binary 2>@1]
+        unset ::env(DARWINTRACE_SPAWN_SETEXEC)
+
+        return $lines
+    } \
+    -result [lrepeat 2 "posix_spawn: No such file or directory"]
+
+test spawn_sip_binary "Test that posix_spawn(2) works on a SIP-protected binary (which will make a copy)" \
+    -setup {
+        file delete -force [file join $::env(DARWINTRACE_SIP_WORKAROUND_PATH) [getuid] usr/bin/env]
+        [setup [list allow /]]
+    } \
+    -cleanup [expect {}] \
+    -body {
+        set lines [split [exec -ignorestderr -- ./posix_spawn /usr/bin/env] "\n"]
+        set result {}
+        foreach line $lines {
+            if {[string match "DYLD_INSERT_LIBRARIES=*" $line] || [string match "DARWINTRACE_LOG=*" $line]} {
+                lappend result $line
+            }
+        }
+        return [concat [lsort $result] [file exists [file join $::env(DARWINTRACE_SIP_WORKAROUND_PATH) [getuid] usr/bin/env]]]
+    } \
+    -match glob \
+    -result [list "DARWINTRACE_LOG=/tmp/macports-test-*" "DYLD_INSERT_LIBRARIES=$darwintrace_lib" 1]
+
+test spawn_sip_script "Test that posix_spawn(2) works on a SIP-protected shell script (which will copy the interpreter)" \
+    -setup [setup [list allow /]] \
+    -cleanup [expect {}] \
+    -body {exec -ignorestderr -- ./posix_spawn /usr/bin/umask} \
+    -match regexp \
+    -result "0\[0-7]{3}"
+
+test spawn_sip_suid_binary "Test that posix_spawn(2) works on a SIP-protected SUID binary (which will not be copied)" \
+    -setup [setup [list allow /]] \
+    -cleanup [expect {}] \
+    -body {
+        set status 0
+        if {[catch {exec -ignorestderr -- ./posix_spawn /usr/bin/crontab -l} results options]} {
+            puts $::errorInfo
+            set details [dict get $options -errorcode]
+            if {[lindex $details 0] eq "CHILDSTATUS"} {
+                set status [lindex $details 2]
+            } else {
+                return -options $options -level 0 $results
+            }
+        }
+        return $status
+    } \
+    -result 0
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/proc.test
+++ b/src/darwintracelib1.0/tests/proc.test
@@ -7,6 +7,8 @@ package require Pextlib 1.0
 
 source "testlib.tcl"
 
+testConstraint notarm64 [expr {[exec -ignorestderr -- /usr/bin/arch] ne "arm64"}]
+
 test execve_selfpreserving_env "Test that you cannot get out of the sandbox by unsetting environment variables" \
     -setup [setup [list allow $cwd]] \
     -cleanup [expect] \
@@ -204,7 +206,12 @@ test spawn_non_existing_inside_sandbox "Test that posix_spawn(2) on a non-existi
     } \
     -result [lrepeat 2 "posix_spawn: No such file or directory"]
 
+# This test is currently broken on arm64, because Apple compiles its SIP-protected binaries with
+# pointer authenticaation using the arm64e architecture, but marks it as a preview and only allows
+# Apple-signed binaries, or arbitrary binaries on systems that are booted with
+# boot-args=-arm64e_preview_abi (which cannot be enabled without disabling SIP).
 test spawn_sip_binary "Test that posix_spawn(2) works on a SIP-protected binary (which will make a copy)" \
+    -constraints {notarm64} \
     -setup {
         file delete -force [file join $::env(DARWINTRACE_SIP_WORKAROUND_PATH) [getuid] usr/bin/env]
         [setup [list allow /]]
@@ -223,7 +230,12 @@ test spawn_sip_binary "Test that posix_spawn(2) works on a SIP-protected binary 
     -match glob \
     -result [list "DARWINTRACE_LOG=/tmp/macports-test-*" "DYLD_INSERT_LIBRARIES=$darwintrace_lib" 1]
 
+# This test is currently broken on arm64, because Apple compiles its SIP-protected binaries with
+# pointer authenticaation using the arm64e architecture, but marks it as a preview and only allows
+# Apple-signed binaries, or arbitrary binaries on systems that are booted with
+# boot-args=-arm64e_preview_abi (which cannot be enabled without disabling SIP).
 test spawn_sip_script "Test that posix_spawn(2) works on a SIP-protected shell script (which will copy the interpreter)" \
+    -constraints {notarm64} \
     -setup [setup [list allow /]] \
     -cleanup [expect {}] \
     -body {exec -ignorestderr -- ./posix_spawn /usr/bin/umask} \

--- a/src/darwintracelib1.0/tests/readdir.c
+++ b/src/darwintracelib1.0/tests/readdir.c
@@ -1,0 +1,35 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: readdir PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	DIR* dir = opendir(argv[1]);
+	if (dir == NULL) {
+		perror("opendir");
+		exit(EXIT_FAILURE);
+	}
+
+	struct dirent *d;
+	while (errno = 0, (d = readdir(dir)) != NULL) {
+		printf("%s\n", d->d_name);
+	}
+	if (errno != 0) {
+		perror("readdir");
+		exit(EXIT_FAILURE);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/readdir.test
+++ b/src/darwintracelib1.0/tests/readdir.test
@@ -1,0 +1,62 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test darwintrace_hides_files_in_readdir "Test that a file on the blacklist does not show up in readdir(3)" \
+    -setup [setup [list deny "$cwd/stat.c" allow $cwd]] \
+    -cleanup [expect {}] \
+    -body {
+        set lines [split [exec -ignorestderr -- ./readdir . 2>@1] "\n"]
+        return [lsearch -all -inline $lines stat.c]
+    } \
+    -result [list]
+
+test readdir_allowed_inside_sandbox "Test that files inside the sandbox show up in readdir(3)" \
+    -setup [setup [list allow "$cwd/stat.c"]] \
+    -cleanup [expect {}] \
+    -body {
+        set lines [split [exec -ignorestderr -- ./readdir . 2>@1] "\n"]
+        return [lsearch -all -inline $lines stat.c]
+    } \
+    -result [list stat.c]
+
+test readdir_allowed_when_uninitialized "Test that files outside the sandbox show up in readdir() when darwintrace is uninitialized" \
+    -setup [setup [list deny "$cwd/stat.c" allow $cwd]] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set lines [split [exec -ignorestderr -- ./readdir . 2>@1] "\n"]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return [lsearch -all -inline $lines stat.c]
+    } \
+    -result [list stat.c]
+
+test darwintrace_readdir_at_maxpathlen "Test that readdir(3) with a directory at MAXPATHLEN doesn't trigger the stack canary" \
+    -setup {
+        global dirname filename
+        set dirname [string repeat "ab/de/ghi/" 90]
+        set filename [string repeat "a" 200]
+
+        file mkdir $dirname
+
+        set saved [pwd]
+        cd $dirname
+        exec -ignorestderr -- touch $filename >/dev/null
+        cd $saved
+
+        [setup [list allow $cwd]]
+    } \
+    -cleanup {
+        exec -ignorestderr -- rm -rf ab
+        [expect]
+    } \
+    -body {
+        set lines [split [exec -ignorestderr -- ./readdir $dirname 2>@1] "\n"]
+        return [lsearch -inline -all $lines "a*"]
+    } \
+    -result [string repeat a 200]
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/readlink.c
+++ b/src/darwintracelib1.0/tests/readlink.c
@@ -1,0 +1,31 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc != 2) {
+		fprintf(stderr, "Usage: readlink PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	char buf[MAXPATHLEN];
+	ssize_t len = readlink(argv[1], buf, sizeof(buf) - 1);
+	if (-1 == len) {
+		fprintf(stderr, "readlink(%s): %s\n", argv[1], strerror(errno));
+	} else {
+		buf[len] = '\0';
+		printf("%s\n", buf);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/readlink.test
+++ b/src/darwintracelib1.0/tests/readlink.test
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test readlink_denies_outside_sandbox "Test that readlink(2) fails outside of the sandbox" \
+    -setup {
+        file link -symbolic link .
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force link
+        [expect [list "$cwd/link"]]
+    } \
+    -body {exec -ignorestderr -- ./readlink link 2>@1} \
+    -result "readlink(link): No such file or directory"
+
+test readlink_succeeds_inside_sandbox "Test that readlink(2) succeeds inside of the sandbox" \
+    -setup {
+        file link -symbolic link readlink.c
+        # note the link target is outside of the sandbox ...
+        [setup [list deny "$cwd/readlink.c" allow "$cwd"]]
+    } \
+    -cleanup {
+        file delete -force link
+        # ... but this does not produce a violation
+        [expect {}]
+    } \
+    -body {exec -ignorestderr -- ./readlink link 2>@1} \
+    -result "readlink.c"
+
+test readlink_succeeds_on_missing_file "Test that readlink(2) does not care whether the target exists" \
+    -setup {
+        # Tcl's file link -symbolic will fail on links targets that don't exist
+        exec -ignorestderr -- ln -s this_file_does_not_exist link
+        [setup [list allow /]]
+    } \
+    -cleanup {
+        file delete -force link
+        [expect {}]
+    } \
+    -body {
+        exec -ignorestderr -- ./readlink link 2>@1
+    } \
+    -result "this_file_does_not_exist"
+
+test readlink_succeeds_when_uninitialized "Test that readlink(2) succeeds outside of the sandbox when darwintrace is uninitialized" \
+    -setup {
+        file link -symbolic link .
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force link
+        [expect {}]
+    } \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set output [exec -ignorestderr -- ./readlink link 2>@1]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $output
+    } \
+    -result "."
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/rename.c
+++ b/src/darwintracelib1.0/tests/rename.c
@@ -1,0 +1,25 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc != 3) {
+		fprintf(stderr, "Usage: rename SRC TGT\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	if (-1 == rename(argv[1], argv[2])) {
+		fprintf(stderr, "rename(%s, %s): %s\n", argv[1], argv[2], strerror(errno));
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/rename.test
+++ b/src/darwintracelib1.0/tests/rename.test
@@ -1,0 +1,64 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test rename_fails_source_outside_sandbox "Test that rename(2) fails if the source is outside of the sandbox" \
+    -setup {
+        exec -ignorestderr -- touch rename_src_file
+        [setup [list deny "$cwd/rename_src_file" allow $cwd]]
+    } \
+    -cleanup {
+        file delete -force rename_src_file rename_tgt_file
+        [expect [list "$cwd/rename_src_file"]]
+    } \
+    -body {exec -ignorestderr -- ./rename rename_src_file rename_tgt_file 2>@1} \
+    -result "rename(rename_src_file, rename_tgt_file): No such file or directory"
+
+test rename_fails_target_outside_sandbox "Test that rename(2) fails if the target is outside of the sandbox" \
+    -setup {
+        exec -ignorestderr -- touch rename_src_file
+        [setup [list deny "$cwd/rename_tgt_file" allow $cwd]]
+    } \
+    -cleanup {
+        file delete -force rename_src_file rename_tgt_file
+        [expect [list "$cwd/rename_tgt_file"]]
+    } \
+    -body {exec -ignorestderr -- ./rename rename_src_file rename_tgt_file 2>@1} \
+    -result "rename(rename_src_file, rename_tgt_file): Permission denied"
+
+test rename_succeeds_inside_sandbox "Test that rename(2) succeeds if source and target are inside of the sandbox" \
+    -setup {
+        exec -ignorestderr -- touch rename_src_file
+        [setup [list allow $cwd]]
+    } \
+    -cleanup {
+        file delete -force rename_src_file rename_tgt_file
+        [expect {}]
+    } \
+    -body {
+        exec -ignorestderr -- ./rename rename_src_file rename_tgt_file 2>@1
+        return [file exists rename_tgt_file]
+    } \
+    -result 1
+
+test rename_succeeds_when_uninitialized "Test that rename(2) succeeds with source and target outside of the sandbox when darwintrace is uninitialized" \
+    -setup {
+        exec -ignorestderr -- touch rename_src_file
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force rename_src_file rename_tgt_file
+        [expect {}]
+    } \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        exec -ignorestderr -- ./rename rename_src_file rename_tgt_file 2>@1
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return [file exists rename_tgt_file]
+    } \
+    -result 1
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/rmdir.c
+++ b/src/darwintracelib1.0/tests/rmdir.c
@@ -1,0 +1,22 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: rmdir PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	if (-1 == rmdir(argv[1])) {
+		perror("rmdir");
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/rmdir.test
+++ b/src/darwintracelib1.0/tests/rmdir.test
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test rmdir_outside_sandbox "Test that rmdir(2) does not work outside of the sandbox" \
+    -setup {
+        file mkdir rmdirme
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force rmdirme
+        [expect [list "$cwd/rmdirme"]]
+    } \
+    -body {exec -ignorestderr -- ./rmdir rmdirme 2>@1} \
+    -result "rmdir: No such file or directory"
+
+test rmdir_inside_sandbox "Test that rmdir(2) works inside the sandbox" \
+    -setup {
+        file mkdir rmdirme
+        [setup [list allow /]]
+    } \
+    -cleanup {
+        file delete -force rmdirme
+        [expect {}]
+    } \
+    -body {
+        exec -ignorestderr -- ./rmdir rmdirme 2>@1
+        return [file isdirectory rmdirme]
+    } \
+    -result 0
+
+test rmdir_uninitialized "Test that rmdir(2) works outside the sandbox if darwintrace is uninitialized" \
+    -setup {
+        file mkdir rmdirme
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force rmdirme
+        [expect {}]
+    } \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        exec -ignorestderr -- ./rmdir rmdirme 2>@1
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return [file isdirectory rmdirme]
+    } \
+    -result 0
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/stat.c
+++ b/src/darwintracelib1.0/tests/stat.c
@@ -1,0 +1,23 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: stat PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	struct stat st;
+	if (-1 == stat(argv[1], &st)) {
+		perror("stat");
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/stat.test
+++ b/src/darwintracelib1.0/tests/stat.test
@@ -1,0 +1,66 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test stat_denies_dirs "Test that stat(2)/lstat(2) deny access to directories" \
+    -setup [setup [list deny /]] \
+    -cleanup [expect {}] \
+    -body {
+        join [list \
+            [exec -ignorestderr -- ./stat /usr 2>@1] \
+            [exec -ignorestderr -- ./lstat /usr 2>@1] \
+        ] "\n"
+    } \
+    -result "\n"
+
+test stat_denies_outside_sandbox "Test that stat(2)/lstat(2) hide files outside of the sandbox" \
+    -setup [setup {}] \
+    -cleanup [expect [list "$cwd/stat"]] \
+    -body {
+        join [list \
+            [exec -ignorestderr -- ./stat ./stat 2>@1] \
+            [exec -ignorestderr -- ./lstat ./stat 2>@1] \
+        ] "\n"
+    } \
+    -result [join [list "stat: No such file or directory" "lstat: No such file or directory"] "\n"]
+
+test stat_allowed_inside_sandbox "Test that stat(2)/lstat(2) do not hide files inside the sandbox" \
+    -setup [setup [list allow "$cwd/stat"]] \
+    -cleanup [expect] \
+    -body {
+        join [list \
+            [exec -ignorestderr -- ./stat ./stat 2>@1] \
+            [exec -ignorestderr -- ./lstat ./stat 2>@1] \
+        ] "\n"
+    } \
+    -result "\n"
+
+test stat_allow_all_wildcard "Test the allow-all wildcard shortcut" \
+    -setup [setup [list allow "/"]] \
+    -cleanup [expect] \
+    -body {
+        join [list \
+            [exec -ignorestderr -- ./stat ./stat 2>@1] \
+            [exec -ignorestderr -- ./lstat ./stat 2>@1] \
+        ] "\n"
+    } \
+    -result "\n"
+
+test stat_uninitialized "Test that stat(2)/lstat(2) do not hide files outside of the sandbox if darwintrace is uninitialized" \
+    -setup [setup {}] \
+    -cleanup [expect {}] \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set result [join [list \
+            [exec -ignorestderr -- ./stat ./stat 2>@1] \
+            [exec -ignorestderr -- ./lstat ./stat 2>@1] \
+        ] "\n"]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $result
+    } \
+    -result "\n"
+
+cleanupTests

--- a/src/darwintracelib1.0/tests/testlib.tcl
+++ b/src/darwintracelib1.0/tests/testlib.tcl
@@ -1,0 +1,189 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require struct::set
+
+package require Pextlib 1.0
+package require Thread
+
+set cwd [file normalize [file dirname [info script]]]
+set darwintrace_lib [file join $cwd .. darwintrace.dylib]
+
+proc appendEntry {sandbox path action} {
+    upvar 2 $sandbox sndbxlst
+
+    set mapping {}
+    # Escape backslashes with backslashes
+    lappend mapping "\\" "\\\\"
+    # Escape colons with \:
+    lappend mapping ":" "\\:"
+    # Escape equal signs with \=
+    lappend mapping "=" "\\="
+
+    # file normalize will leave symlinks as the very last
+    # path component intact. This will, for instance, prevent /tmp from
+    # being resolved to /private/tmp.
+    # Use realpath to avoid this behavior.
+    set normalizedPath [file normalize $path]
+    # realpath only works on files that exist
+    if {![catch {file type $normalizedPath}]} {
+        set normalizedPath [realpath $normalizedPath]
+    }
+    lappend sndbxlst "[string map $mapping $path]=$action"
+    if {$normalizedPath ne $path} {
+        lappend sndbxlst "[string map $mapping $normalizedPath]=$action"
+    }
+}
+
+##
+# Append a trace sandbox entry suitable for allowing access to
+# a directory to a given sandbox list.
+#
+# @param sandbox The name of the sandbox list variable
+# @param path The path that should be permitted
+proc allow {sandbox path} {
+    appendEntry $sandbox $path "+"
+}
+
+##
+# Append a trace sandbox entry suitable for denying access to a directory
+# (and stopping processing of the sandbox) to a given sandbox list.
+#
+# @param sandbox The name of the sandbox list variable
+# @param path The path that should be denied
+proc deny {sandbox path} {
+    appendEntry $sandbox $path "-"
+}
+
+##
+# Append a trace sandbox entry suitable for deferring the access decision
+# back to MacPorts to query for dependencies to a given sandbox list.
+#
+# @param sandbox The name of the sandbox list variable
+# @param path The path that should be handed back to MacPorts for further
+#             processing.
+proc ask {sandbox path} {
+    appendEntry $sandbox $path "?"
+}
+
+proc setup {rules} {
+    global sandbox
+
+    set sandbox [list]
+    foreach {rule path} $rules {
+        switch $rule {
+            allow {
+                allow sandbox $path
+            }
+            deny {
+                deny sandbox $path
+            }
+            ask {
+                ask sandbox $path
+            }
+        }
+    }
+
+    return tracelib_setup
+}
+
+proc tracelib_setup {} {
+    global \
+        cwd \
+        darwintrace_lib \
+        env \
+        fifo \
+        sandbox \
+        thread \
+        tracelib_result
+
+    set fifo_mktemp_template "/tmp/macports-test-XXXXXX"
+    set fifo [mktemp $fifo_mktemp_template]
+
+    set thread [thread::create -joinable {source threadsetup.tcl}]
+    thread::send $thread [list setup $fifo]
+
+    tracelib setsandbox [join $sandbox :]
+    tracelib enablefence
+
+    thread::send -async $thread [list run] tracelib_result
+
+    set ::env(DYLD_INSERT_LIBRARIES) $darwintrace_lib
+    set ::env(DARWINTRACE_LOG) $fifo
+}
+
+proc expect {{violations {}} {unknowns {}}} {
+    global expectations
+    array set expectations {}
+    set expectations(violations) $violations
+    set expectations(unknowns) $unknowns
+
+    return tracelib_cleanup
+}
+
+proc tracelib_cleanup {} {
+    global \
+        env \
+        expectations \
+        fifo \
+        sandbox \
+        thread \
+        tracelib_result
+
+    tracelib closesocket
+    tracelib clean
+    file delete -force $fifo
+
+    vwait tracelib_result
+
+    thread::send $thread [list set warnings] warnings
+    thread::send $thread [list set violations] violations
+    thread::send $thread [list set unknowns] unknowns
+
+    struct::set add violations_set $violations
+    struct::set add unknowns_set $unknowns
+    struct::set add expected_violations_set $expectations(violations)
+    struct::set add expected_unknowns_set $expectations(unknowns)
+
+    set failed no
+    lassign [struct::set intersect3 $violations_set $expected_violations_set] _ additional_violations unexpected_violations
+    foreach violation $additional_violations {
+        puts "Unexpected violation '$violation'"
+        set failed yes
+    }
+    foreach violation $unexpected_violations {
+        puts "Expected violation '$violation' did not occur"
+        set failed yes
+    }
+
+    lassign [struct::set intersect3 $unknowns_set $expected_unknowns_set] _ additional_unknowns unexpected_unknowns
+    foreach unknown_ $additional_unknowns {
+        puts "Unexpected unknown '$unknown_'"
+        set failed yes
+    }
+    foreach unknown_ $unexpected_unknowns {
+        puts "Expected unknown '$unknown_' did not occur"
+        set failed yes
+    }
+
+    if {$failed} {
+        foreach {name contents} [list "WARNINGS" $warnings "VIOLATIONS" $violations "UNKNOWNS" $unknowns] {
+            if {[llength $contents] != 0} {
+                puts "$name"
+                foreach item $contents {
+                    puts "  $item"
+                }
+            }
+        }
+        puts "SANDBOX"
+        foreach sandbox_entry $sandbox {
+            puts "  $sandbox_entry"
+        }
+    }
+
+    thread::send -async $thread [list cleanup]
+    thread::join $thread
+
+    array unset env DYLD_INSERT_LIBRARIES
+    array unset env DARWINTRACE_LOG
+}
+

--- a/src/darwintracelib1.0/tests/threadsetup.tcl
+++ b/src/darwintracelib1.0/tests/threadsetup.tcl
@@ -1,0 +1,36 @@
+proc ui_warn {msg} {
+	global warnings
+	lappend warnings $msg
+}
+
+proc slave_add_sandbox_violation {path} {
+	global violations
+	lappend violations $path
+}
+
+proc slave_add_sandbox_unknown {path} {
+	global unknowns
+	lappend unknowns $path
+}
+
+proc setup {fifo} {
+    package require Pextlib 1.0
+    global warnings violations unknowns
+
+    set warnings [list]
+    set violations [list]
+    set unknowns [list]
+
+    tracelib setname $fifo
+    tracelib opensocket
+}
+
+proc run {} {
+	tracelib run
+}
+
+proc cleanup {} {
+	thread::unwind
+}
+
+thread::wait

--- a/src/darwintracelib1.0/tests/unlink.c
+++ b/src/darwintracelib1.0/tests/unlink.c
@@ -1,0 +1,22 @@
+#define DARWINTRACE_USE_PRIVATE_API
+#include "../darwintrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+	if (argc < 2) {
+		fprintf(stderr, "Usage: unlink PATH\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (getenv("DARWINTRACE_UNINITIALIZE") != NULL) {
+		__darwintrace_initialized = false;
+	}
+
+	if (-1 == unlink(argv[1])) {
+		perror("unlink");
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/src/darwintracelib1.0/tests/unlink.test
+++ b/src/darwintracelib1.0/tests/unlink.test
@@ -1,0 +1,49 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+
+source "testlib.tcl"
+
+test unlink_outside_sandbox "Test that unlink(2) does not work outside of the sandbox" \
+    -setup {
+        exec -- touch unlinkme
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force unlinkme
+        [expect [list "$cwd/unlinkme"]]
+    } \
+    -body {exec -ignorestderr -- ./unlink unlinkme 2>@1} \
+    -result "unlink: No such file or directory"
+
+test unlink_inside_sandbox "Test that unlink(2) works inside the sandbox" \
+    -setup {
+        exec -- touch unlinkme
+        [setup [list allow /]]
+    } \
+    -cleanup {
+        file delete -force unlinkme
+        [expect {}]
+    } \
+    -body {exec -ignorestderr -- ./unlink unlinkme 2>@1} \
+    -result ""
+
+test unlink_uninitialized "Test that unlink(2) works outside the sandbox if darwintrace is uninitialized" \
+    -setup {
+        exec -- touch unlinkme
+        [setup [list deny /]]
+    } \
+    -cleanup {
+        file delete -force unlinkme
+        [expect {}]
+    } \
+    -body {
+        set ::env(DARWINTRACE_UNINITIALIZE) 1
+        set output [exec -ignorestderr -- ./unlink unlinkme 2>@1]
+        unset ::env(DARWINTRACE_UNINITIALIZE)
+        return $output
+    } \
+    -result ""
+
+cleanupTests

--- a/src/pextlib1.0/sip_copy_proc.c
+++ b/src/pextlib1.0/sip_copy_proc.c
@@ -230,7 +230,7 @@ static copy_needed_return_t copy_needed(const char *path, char *const argv[],
             free_argv(new_argv);
             return copy_not_needed;
         }
-        if ((st->st_flags & (S_ISUID | S_ISGID)) > 0) {
+        if ((st->st_mode & (S_ISUID | S_ISGID)) > 0) {
             // the binary is SUID/SGID, which would get lost when copying;
             // DYLD_ variables are stripped for SUID/SGID binaries anyway
             free_argv(new_argv);

--- a/src/pextlib1.0/sip_copy_proc.c
+++ b/src/pextlib1.0/sip_copy_proc.c
@@ -381,8 +381,8 @@ static char *lazy_copy(const char *path, struct stat *in_st) {
 
     // check whether copying is needed; it isn't if the file exists and the
     // modification times match
-    struct stat out_st;
-    if (   -1 != stat(target_path, &out_st)
+    struct stat out_st = {0};
+    if (-1 != stat(target_path, &out_st)
         && in_st->st_mtimespec.tv_sec == out_st.st_mtimespec.tv_sec
         && in_st->st_mtimespec.tv_nsec == out_st.st_mtimespec.tv_nsec) {
         // copying not needed


### PR DESCRIPTION
This set of changes fixes a number of issues with trace mode:

- Better support for long paths, fixing a number of places where buffer overflows occurred.
- Removal of `DYLD_FORCE_FLAT_NAMESPACE=1` which is no longer required
- Do not attempt to inject `DYLD` environment variables into setuid binaries (which would be stripped anyway)
- Do not copy setuid binaries into the sip-workaround directory. The setuid bit would be stripped when copying anyway.
- Add automated tests for darwintrace so that developers can see the coverage and when know earlier when it starts breaking
- Improve trace mode performance by caching SQLite lookups on the trace mode server side
- Re-sign binaries with an ad-hoc code signature when copying them. This fixes trace mode on x86_64 Ventura.
- A few fixes to make sure the tests work as expected.