### PR TITLE
src: Add strl{cat,cpy},getline compat includes

### DIFF
--- a/src/darwintracelib1.0/darwintrace.c
+++ b/src/darwintracelib1.0/darwintrace.c
@@ -36,6 +36,7 @@
 #define DARWINTRACE_USE_PRIVATE_API 1
 #include "darwintrace.h"
 #include "sandbox_actions.h"
+#include "strlcpy.h"
 
 #ifdef HAVE_STDATOMIC_H
 #include <stdatomic.h>

--- a/src/darwintracelib1.0/readdir.c
+++ b/src/darwintracelib1.0/readdir.c
@@ -34,6 +34,7 @@
  */
 
 #include "darwintrace.h"
+#include "strlcat.h"
 
 #include <errno.h>
 #include <fcntl.h>

--- a/src/machista1.0/Makefile.in
+++ b/src/machista1.0/Makefile.in
@@ -7,6 +7,11 @@ OBJS= 		libmachista.o hashmap.o machista_wrap.o
 SHLIB_NAME= machista${SHLIB_SUFFIX}
 INSTALLDIR=	${TCL_PACKAGE_PATH}/machista1.0
 
+CPPFLAGS+= -I$(srcdir)/../compat
+ifneq ($(HAVE_STRLCAT),yes)
+OBJS+= ../compat/strlcat.o
+endif
+
 SWIG         = @SWIG@
 SWIG_FLAGS   = -tcl8 -pkgversion 1.0 -namespace
 SWIG_LDFLAGS = -ltcl

--- a/src/machista1.0/libmachista.c
+++ b/src/machista1.0/libmachista.c
@@ -61,6 +61,7 @@
 
 #include "libmachista.h"
 #include "hashmap.h"
+#include "strlcpy.h"
 
 #ifdef __MACH__
 /* Tiger compatibility */

--- a/src/pextlib1.0/sip_copy_proc.c
+++ b/src/pextlib1.0/sip_copy_proc.c
@@ -52,6 +52,8 @@
 #include <copyfile.h>
 #endif
 
+#include "getline.h"
+
 #include "sip_copy_proc.h"
 
 #ifndef DARWINTRACE_SIP_WORKAROUND_PATH

--- a/src/pextlib1.0/tracelib.c
+++ b/src/pextlib1.0/tracelib.c
@@ -71,24 +71,9 @@
 #include "Pextlib.h"
 
 #include "strlcat.h"
+#include "strlcpy.h"
 
 #ifdef HAVE_TRACEMODE_SUPPORT
-#ifndef HAVE_STRLCPY
-/* Define strlcpy if it's not available. */
-size_t strlcpy(char *dst, const char *src, size_t size);
-size_t strlcpy(char *dst, const char *src, size_t size) {
-    size_t result = strlen(src);
-    if (size > 0) {
-        size_t copylen = size - 1;
-        if (copylen > result) {
-            copylen = result;
-        }
-        memcpy(dst, src, copylen);
-        dst[copylen] = 0;
-    }
-    return result;
-}
-#endif
 
 #ifdef HAVE_PEERPID_LIST
 static bool peerpid_list_enqueue(int sock, pid_t pid);


### PR DESCRIPTION
pextlib1.0/tracelib.c additionally had its own implementation, which is now no longer required since we have a centrally provided compatibility implementation.

machista1.0 did not yet use the compat implementation and thus probably did not work on operating systems that do not have strlcpy.