### PR TITLE
Migrate `CONST` usage to `const`

### DIFF
--- a/src/machista1.0/machista_wrap.c
+++ b/src/machista1.0/machista_wrap.c
@@ -828,8 +828,8 @@ typedef struct swig_const_info {
     swig_type_info **ptype;
 } swig_const_info;
 
-typedef int   (*swig_wrapper)(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST []);
-typedef int   (*swig_wrapper_func)(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST []);
+typedef int   (*swig_wrapper)(ClientData, Tcl_Interp *, int, Tcl_Obj *const []);
+typedef int   (*swig_wrapper_func)(ClientData, Tcl_Interp *, int, Tcl_Obj *const []);
 typedef char *(*swig_variable_func)(ClientData, Tcl_Interp *, char *, char *, int);
 typedef void  (*swig_delete_func)(ClientData);
 
@@ -868,7 +868,7 @@ typedef struct swig_instance {
 /* Structure for command table */
 typedef struct {
   const char *name;
-  int       (*wrapper)(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST []);
+  int       (*wrapper)(ClientData, Tcl_Interp *, int, Tcl_Obj *const []);
   ClientData  clientdata;
 } swig_command_info;
 
@@ -1213,7 +1213,7 @@ SWIG_Tcl_ObjectDelete(ClientData clientData) {
 
 /* Function to invoke object methods given an instance */
 SWIGRUNTIME int
-SWIG_Tcl_MethodCommand(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST _objv[]) {
+SWIG_Tcl_MethodCommand(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const _objv[]) {
   char *method,   *attrname;
   swig_instance   *inst = (swig_instance *) clientData;
   swig_method     *meth;
@@ -1418,7 +1418,7 @@ SWIG_Tcl_NewInstanceObj(Tcl_Interp *interp, void *thisvalue, swig_type_info *typ
 
 /* Function to create objects */
 SWIGRUNTIME int
-SWIG_Tcl_ObjectConstructor(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+SWIG_Tcl_ObjectConstructor(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   Tcl_Obj          *newObj = 0;
   void             *thisvalue = 0;
   swig_instance   *newinst = 0;
@@ -1498,7 +1498,7 @@ SWIG_Tcl_ObjectConstructor(ClientData clientData, Tcl_Interp *interp, int objc, 
  *   Get arguments 
  * -----------------------------------------------------------------------------*/
 SWIGRUNTIME int
-SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[], const char *fmt, ...) {
+SWIG_Tcl_GetArgs(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[], const char *fmt, ...) {
   int        argno = 0, opt = 0;
   long       tempi;
   double     tempd;
@@ -1854,7 +1854,7 @@ static swig_class *swig_macho_handle_bases[] = {0};
 static const char * swig_macho_handle_base_names[] = {0};
 static swig_class _wrap_class_macho_handle = { "macho_handle", &SWIGTYPE_p_macho_handle,0,0, swig_macho_handle_methods, swig_macho_handle_attributes, swig_macho_handle_bases,swig_macho_handle_base_names, &swig_module };
 SWIGINTERN int
-_wrap_macho_loadcmd_mlt_install_name_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_loadcmd_mlt_install_name_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_loadcmd *arg1 = (struct macho_loadcmd *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -1875,7 +1875,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_loadcmd_mlt_type_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_loadcmd_mlt_type_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_loadcmd *arg1 = (struct macho_loadcmd *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -1896,7 +1896,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_loadcmd_mlt_comp_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_loadcmd_mlt_comp_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_loadcmd *arg1 = (struct macho_loadcmd *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -1917,7 +1917,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_loadcmd_mlt_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_loadcmd_mlt_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_loadcmd *arg1 = (struct macho_loadcmd *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -1938,7 +1938,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_loadcmd_next_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_loadcmd_next_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_loadcmd *arg1 = (struct macho_loadcmd *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -1973,7 +1973,7 @@ static swig_class *swig_macho_loadcmd_bases[] = {0};
 static const char * swig_macho_loadcmd_base_names[] = {0};
 static swig_class _wrap_class_macho_loadcmd = { "macho_loadcmd", &SWIGTYPE_p_macho_loadcmd,0,0, swig_macho_loadcmd_methods, swig_macho_loadcmd_attributes, swig_macho_loadcmd_bases,swig_macho_loadcmd_base_names, &swig_module };
 SWIGINTERN int
-_wrap_macho_arch_mat_install_name_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_mat_install_name_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -1994,7 +1994,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_arch_mat_rpath_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_mat_rpath_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2015,7 +2015,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_arch_mat_arch_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_mat_arch_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2036,7 +2036,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_arch_mat_comp_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_mat_comp_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2057,7 +2057,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_arch_mat_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_mat_version_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2078,7 +2078,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_arch_mat_loadcmds_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_mat_loadcmds_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2099,7 +2099,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_macho_arch_next_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_arch_next_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_arch *arg1 = (struct macho_arch *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2136,7 +2136,7 @@ static swig_class *swig_macho_arch_bases[] = {0};
 static const char * swig_macho_arch_base_names[] = {0};
 static swig_class _wrap_class_macho_arch = { "macho_arch", &SWIGTYPE_p_macho_arch,0,0, swig_macho_arch_methods, swig_macho_arch_attributes, swig_macho_arch_bases,swig_macho_arch_base_names, &swig_module };
 SWIGINTERN int
-_wrap_macho_mt_archs_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_macho_mt_archs_get(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho *arg1 = (struct macho *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2167,7 +2167,7 @@ static swig_class *swig_macho_bases[] = {0};
 static const char * swig_macho_base_names[] = {0};
 static swig_class _wrap_class_macho = { "macho", &SWIGTYPE_p_macho,0,0, swig_macho_methods, swig_macho_attributes, swig_macho_bases,swig_macho_base_names, &swig_module };
 SWIGINTERN int
-_wrap_create_handle(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_create_handle(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_handle *result = 0 ;
   
   if (SWIG_GetArgs(interp, objc, objv,":machista::create_handle ") == TCL_ERROR) SWIG_fail;
@@ -2180,7 +2180,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_destroy_handle(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_destroy_handle(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_handle *arg1 = (struct macho_handle *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -2200,7 +2200,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_parse_file(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_parse_file(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   struct macho_handle *arg1 = (struct macho_handle *) 0 ;
   char *arg2 = (char *) 0 ;
   struct macho **arg3 = (struct macho **) 0 ;
@@ -2240,7 +2240,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_strerror(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_strerror(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   int arg1 ;
   int val1 ;
   int ecode1 = 0 ;
@@ -2261,7 +2261,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_get_arch_name(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_get_arch_name(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   cpu_type_t arg1 ;
   int val1 ;
   int ecode1 = 0 ;
@@ -2282,7 +2282,7 @@ fail:
 
 
 SWIGINTERN int
-_wrap_format_dylib_version(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+_wrap_format_dylib_version(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
   uint32_t arg1 ;
   unsigned int val1 ;
   int ecode1 = 0 ;

--- a/src/macports1.0/get_systemconfiguration_proxies.c
+++ b/src/macports1.0/get_systemconfiguration_proxies.c
@@ -55,9 +55,9 @@ char *cfStringToCStringASCII( CFStringRef cfString );
  * Synopsis: array set someArray get_systemconfiguration_proxies
  */
 #ifdef HAVE_FRAMEWORK_SYSTEMCONFIGURATION
-int GetSystemConfigurationProxiesCmd( ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED )
+int GetSystemConfigurationProxiesCmd( ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *const objv[] UNUSED )
 #else
-int GetSystemConfigurationProxiesCmd( ClientData clientData UNUSED, Tcl_Interp *interp UNUSED, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED )
+int GetSystemConfigurationProxiesCmd( ClientData clientData UNUSED, Tcl_Interp *interp UNUSED, int objc UNUSED, Tcl_Obj *const objv[] UNUSED )
 #endif
 {
     int cmdResult = TCL_OK;

--- a/src/macports1.0/get_systemconfiguration_proxies.h
+++ b/src/macports1.0/get_systemconfiguration_proxies.h
@@ -34,7 +34,7 @@
 
 #include <tcl.h> 
 
-int GetSystemConfigurationProxiesCmd( ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[] ); 
+int GetSystemConfigurationProxiesCmd( ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[] ); 
 
 #endif   /* _GETSYSTEMCONFIGURATIONPROXIES_H */
 

--- a/src/macports1.0/sysctl.c
+++ b/src/macports1.0/sysctl.c
@@ -51,7 +51,7 @@
 /*
  * Read-only wrapper for sysctlbyname(3). Only works for values of type CTLTYPE_INT and CTLTYPE_QUAD.
  */
-int SysctlCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int SysctlCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 #if defined HAVE_SYSCTLBYNAME && !defined __linux__
     const char error_message[] = "sysctl failed: ";

--- a/src/macports1.0/sysctl.h
+++ b/src/macports1.0/sysctl.h
@@ -30,4 +30,4 @@
  */
 
 /* Read-only wrapper for sysctlbyname(3) */
-int SysctlCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int SysctlCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/Pextlib.c
+++ b/src/pextlib1.0/Pextlib.c
@@ -187,7 +187,7 @@ void ui_debug(Tcl_Interp *interp, const char *format, ...) {
     va_end(va);
 }
 
-int StrsedCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int StrsedCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     char *pattern, *string, *res;
     int range[2];
@@ -211,7 +211,7 @@ int StrsedCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
     return TCL_OK;
 }
 
-int ExistsuserCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int ExistsuserCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Tcl_Obj *tcl_result;
     struct passwd *pwent;
@@ -239,7 +239,7 @@ int ExistsuserCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tc
     return TCL_OK;
 }
 
-int ExistsgroupCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int ExistsgroupCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Tcl_Obj *tcl_result;
     struct group *grent;
@@ -270,7 +270,7 @@ int ExistsgroupCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, T
 /* Find the first unused UID > 500
    UIDs > 500 are visible on the macOS login screen,
    but UIDs < 500 are reserved by Apple */
-int NextuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED)
+int NextuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *const objv[] UNUSED)
 {
     Tcl_Obj *tcl_result;
     int cur;
@@ -287,7 +287,7 @@ int NextuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED
 }
 
 /* Just as with NextuidCmd, return the first unused gid > 500 */
-int NextgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED)
+int NextgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *const objv[] UNUSED)
 {
     Tcl_Obj *tcl_result;
     int cur;
@@ -303,7 +303,7 @@ int NextgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED
     return TCL_OK;
 }
 
-int UmaskCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int UmaskCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Tcl_Obj *tcl_result;
     char *tcl_mask, *p;
@@ -354,7 +354,7 @@ int UmaskCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj
  * Create a symbolic link at target pointing to value
  * See symlink(2) for possible errors
  */
-int CreateSymlinkCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int CreateSymlinkCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     char *value, *target;
 
@@ -381,7 +381,7 @@ int CreateSymlinkCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc,
  * Syntax is:
  * unsetenv name (* for all)
  */
-int UnsetEnvCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int UnsetEnvCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     char *name;
 
@@ -449,9 +449,9 @@ int UnsetEnvCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_
  *
  * Synopsis: lchown filename user ?group?
  */
-int lchownCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int lchownCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
-    CONST char *path;
+    const char *path;
     long user;
     long group = -1;
 
@@ -462,7 +462,7 @@ int lchownCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 
     path = Tcl_GetString(objv[1]);
     if (Tcl_GetLongFromObj(NULL, objv[2], &user) != TCL_OK) {
-        CONST char *userString = Tcl_GetString(objv[2]);
+        const char *userString = Tcl_GetString(objv[2]);
         struct passwd *pwent = getpwnam(userString);
         if (pwent == NULL) {
             Tcl_SetResult(interp, "Unknown user given", TCL_STATIC);
@@ -472,7 +472,7 @@ int lchownCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
     }
     if (objc == 4) {
         if (Tcl_GetLongFromObj(NULL, objv[3], &group) != TCL_OK) {
-           CONST char *groupString = Tcl_GetString(objv[3]);
+           const char *groupString = Tcl_GetString(objv[3]);
            struct group *grent = getgrnam(groupString);
            if (grent == NULL) {
                Tcl_SetResult(interp, "Unknown group given", TCL_STATIC);
@@ -498,7 +498,7 @@ int lchownCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
  *
  * Synopsis: fileIsBinary filename
  */
-static int fileIsBinaryCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+static int fileIsBinaryCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     const char *path;
     FILE *file;
     uint32_t magic;
@@ -590,7 +590,7 @@ static int fileIsBinaryCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int
 
 /* Check if the configured DNS server(s) incorrectly return a result for
    a nonexistent hostname. Returns true if broken, false if OK. */
-int CheckBrokenDNSCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED)
+int CheckBrokenDNSCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *const objv[] UNUSED)
 {
     static int already_checked = 0;
     Tcl_Obj *tcl_result;
@@ -623,7 +623,7 @@ int CheckBrokenDNSCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc
 
 	raises the limit of open files to the maximum
 */
-int SetMaxOpenFilesCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *CONST objv[] UNUSED)
+int SetMaxOpenFilesCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc UNUSED, Tcl_Obj *const objv[] UNUSED)
 {
 	struct rlimit rl;
 
@@ -1037,7 +1037,7 @@ int fs_case_sensitive_fallback(Tcl_Interp *interp, const char *path, mount_cs_ca
  * Returns 1 if the FS is case-sensitive, 0 otherwise.
  * Errors out if the case-sensitivity could not be determined.
  */
-int FSCaseSensitiveCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+int FSCaseSensitiveCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     Tcl_Obj *tcl_result;
     int ret = -1;
 

--- a/src/pextlib1.0/adv-flock.c
+++ b/src/pextlib1.0/adv-flock.c
@@ -60,7 +60,7 @@ static void alarmHandler(int sig UNUSED) {
 }
 
 int
-AdvFlockCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+AdvFlockCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     static const char errorstr[] = "use one of \"-shared\", \"-exclusive\", or \"-unlock\", and optionally \"-noblock\"";
     int operation = 0, fd, i, ret, sigret = TCL_OK;
     int errnoval = 0;

--- a/src/pextlib1.0/adv-flock.h
+++ b/src/pextlib1.0/adv-flock.h
@@ -29,4 +29,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int AdvFlockCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int AdvFlockCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/curl.c
+++ b/src/pextlib1.0/curl.c
@@ -87,10 +87,10 @@ static CURL* theHandle = NULL;
  * ------------------------------------------------------------------------- */
 int SetResultFromCurlErrorCode(Tcl_Interp* interp, CURLcode inErrorCode);
 int SetResultFromCurlMErrorCode(Tcl_Interp* interp, CURLMcode inErrorCode);
-int CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int CurlIsNewerCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int CurlPostCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+int CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int CurlIsNewerCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int CurlPostCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 
 typedef struct {
 	Tcl_Interp *interp;
@@ -163,7 +163,7 @@ SetResultFromCurlMErrorCode(Tcl_Interp *interp, CURLMcode inErrorCode)
  * @param objv			parameters
  */
 int
-CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 	bool handleAdded = false;
@@ -756,7 +756,7 @@ CurlFetchCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-CurlIsNewerCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+CurlIsNewerCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 	FILE* theFile = NULL;
@@ -992,7 +992,7 @@ CurlIsNewerCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 	FILE* theFile = NULL;
@@ -1200,7 +1200,7 @@ CurlGetSizeCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-CurlPostCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+CurlPostCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 	FILE* theFile = NULL;
@@ -1448,7 +1448,7 @@ CurlCmd(
 		ClientData clientData UNUSED,
 		Tcl_Interp* interp,
 		int objc,
-		Tcl_Obj* CONST objv[])
+		Tcl_Obj* const objv[])
 {
 	typedef enum {
 		kCurlFetch,

--- a/src/pextlib1.0/curl.h
+++ b/src/pextlib1.0/curl.h
@@ -52,7 +52,7 @@
  *	Determine the file size of some resource. Try to not fetch the resource
  *  if possible. The size returned is the number of bytes.
  */
-int CurlCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+int CurlCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 
 #endif
 		/* _CURL_H */

--- a/src/pextlib1.0/filemap.c
+++ b/src/pextlib1.0/filemap.c
@@ -161,17 +161,17 @@ void UpdateStringOfFilemap(Tcl_Obj* inObjPtr);
 int SetFilemapFromAny(Tcl_Interp* inInterp, Tcl_Obj* inObjPtr);
 int SetResultFromErrorCode(Tcl_Interp* interp, int inErrorCode);
 SFilemapObject* GetObjectFromVarName(Tcl_Interp* interp, Tcl_Obj* inVarName);
-int FilemapCloseCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapCreateCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapExistsCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapGetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapIsReadOnlyCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapListCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapOpenCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapRevertCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapSaveCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapSetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
-int FilemapUnsetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+int FilemapCloseCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapCreateCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapExistsCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapGetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapIsReadOnlyCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapListCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapOpenCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapRevertCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapSaveCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapSetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
+int FilemapUnsetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 
 /* ------------------------------------------------------------------------- **
  * ObjType definition
@@ -1315,7 +1315,7 @@ GetObjectFromVarName(Tcl_Interp* interp, Tcl_Obj* inVarName)
  * @param objv			parameters
  */
 int
-FilemapCloseCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapCloseCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1368,7 +1368,7 @@ FilemapCloseCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapCreateCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapCreateCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	Tcl_Obj* theObject;
 	SFilemapObject* theFilemapObject;
@@ -1414,7 +1414,7 @@ FilemapCreateCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapExistsCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapExistsCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1456,7 +1456,7 @@ FilemapExistsCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapGetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapGetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1498,7 +1498,7 @@ FilemapGetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapIsReadOnlyCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapIsReadOnlyCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1535,7 +1535,7 @@ FilemapIsReadOnlyCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapListCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapListCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1577,7 +1577,7 @@ FilemapListCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapOpenCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapOpenCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theErr = 0;
 	char isReadOnly = 0;
@@ -1715,7 +1715,7 @@ FilemapOpenCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapRevertCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapRevertCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1768,7 +1768,7 @@ FilemapRevertCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapSaveCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapSaveCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1826,7 +1826,7 @@ FilemapSaveCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapSetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapSetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1880,7 +1880,7 @@ FilemapSetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
  * @param objv			parameters
  */
 int
-FilemapUnsetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
+FilemapUnsetCmd(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[])
 {
 	int theResult = TCL_OK;
 
@@ -1937,7 +1937,7 @@ FilemapCmd(
 		ClientData clientData UNUSED,
 		Tcl_Interp* interp,
 		int objc, 
-		Tcl_Obj* CONST objv[])
+		Tcl_Obj* const objv[])
 {
     typedef enum {
     	kFilemapClose,

--- a/src/pextlib1.0/filemap.h
+++ b/src/pextlib1.0/filemap.h
@@ -85,7 +85,7 @@
  * filemap unset filemapVarName path
  *	remove a key,value pair from the database.
  */
-int FilemapCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+int FilemapCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 
 #endif
 		/* _FILEMAP_H */

--- a/src/pextlib1.0/fs-traverse.c
+++ b/src/pextlib1.0/fs-traverse.c
@@ -54,7 +54,7 @@
 
 #include "fs-traverse.h"
 
-static int do_traverse(Tcl_Interp *interp, int flags, char * CONST *targets, Tcl_Obj *varname, Tcl_Obj *body);
+static int do_traverse(Tcl_Interp *interp, int flags, char * const *targets, Tcl_Obj *varname, Tcl_Obj *body);
 
 #define F_DEPTH 0x1
 #define F_IGNORE_ERRORS 0x2
@@ -62,14 +62,14 @@ static int do_traverse(Tcl_Interp *interp, int flags, char * CONST *targets, Tcl
 
 /* fs-traverse ?-depth? ?-ignoreErrors? ?-tails? ?--? varname target-list body */
 int
-FsTraverseCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+FsTraverseCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Tcl_Obj *varname;
     Tcl_Obj *body;
     int flags = 0;
     int rval = TCL_OK;
     Tcl_Obj *listPtr;
-    Tcl_Obj *CONST *objv_orig = objv;
+    Tcl_Obj *const *objv_orig = objv;
     int lobjc;
     Tcl_Obj **lobjv;
 
@@ -164,7 +164,7 @@ do_compare(const FTSENT **a, const FTSENT **b)
 }
 
 static int
-do_traverse(Tcl_Interp *interp, int flags, char * CONST *targets, Tcl_Obj *varname, Tcl_Obj *body)
+do_traverse(Tcl_Interp *interp, int flags, char * const *targets, Tcl_Obj *varname, Tcl_Obj *body)
 {
     int rval = TCL_OK;
     FTS *root_fts;

--- a/src/pextlib1.0/fs-traverse.h
+++ b/src/pextlib1.0/fs-traverse.h
@@ -29,4 +29,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int FsTraverseCmd(ClientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int FsTraverseCmd(ClientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/md5cmd.c
+++ b/src/pextlib1.0/md5cmd.c
@@ -72,7 +72,7 @@ CHECKSUMFile(MD5_, MD5_CTX)
 #error CommonCrypto, libmd or libcrypto required
 #endif
 
-int MD5Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int MD5Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *file, *action;
 	char buf[33];

--- a/src/pextlib1.0/md5cmd.h
+++ b/src/pextlib1.0/md5cmd.h
@@ -29,4 +29,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int MD5Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int MD5Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/mktemp.c
+++ b/src/pextlib1.0/mktemp.c
@@ -50,7 +50,7 @@
 
 #include "mktemp.h"
 
-int MkdtempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int MkdtempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *template, *sp;
 	Tcl_Obj *tcl_result;
@@ -76,7 +76,7 @@ int MkdtempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
 	return TCL_OK;
 }
 
-int MktempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int MktempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *template, *sp;
 	Tcl_Obj *tcl_result;
@@ -102,7 +102,7 @@ int MktempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 	return TCL_OK;
 }
 
-int MkstempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int MkstempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Tcl_Channel channel;
 	char *template, *channelname;

--- a/src/pextlib1.0/mktemp.h
+++ b/src/pextlib1.0/mktemp.h
@@ -29,6 +29,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int MkdtempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
-int MktempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
-int MkstempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int MkdtempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
+int MktempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
+int MkstempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/pipe.c
+++ b/src/pextlib1.0/pipe.c
@@ -50,7 +50,7 @@
  * Return a list with the file descriptors of the pipe. The first item is the
  * readable fd.
  */
-int PipeCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int PipeCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Tcl_Obj* result;
 	int fildes[2];

--- a/src/pextlib1.0/pipe.h
+++ b/src/pextlib1.0/pipe.h
@@ -29,4 +29,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int PipeCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int PipeCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/readdir.c
+++ b/src/pextlib1.0/readdir.c
@@ -46,7 +46,7 @@
  *
  * Synopsis: readdir directory
  */
-int ReaddirCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int ReaddirCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	DIR *dirp;
 	struct dirent *mp;

--- a/src/pextlib1.0/readdir.h
+++ b/src/pextlib1.0/readdir.h
@@ -29,4 +29,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int ReaddirCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int ReaddirCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/readline.c
+++ b/src/pextlib1.0/readline.c
@@ -158,7 +158,7 @@ attempted_completion_function(const char* word, int start, int end)
 		read -attempted_completion proc line ?prompt?
 		completion_matches text function
 */
-int ReadlineCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int ReadlineCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char* action;
 	Tcl_Obj *tcl_result;
@@ -276,7 +276,7 @@ int ReadlineCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_
 		stifle max
 		unstifle
 */
-int RLHistoryCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int RLHistoryCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char* action = NULL;
 #ifdef HAVE_LIBREADLINE

--- a/src/pextlib1.0/readline.h
+++ b/src/pextlib1.0/readline.h
@@ -3,5 +3,5 @@
  *
  */
 
-int ReadlineCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
-int RLHistoryCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int ReadlineCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
+int RLHistoryCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/realpath.c
+++ b/src/pextlib1.0/realpath.c
@@ -53,7 +53,7 @@
  * @param objc			number of parameters
  * @param objv			parameters
  */
-int RealpathCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int RealpathCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     const char error_message[] = "realpath failed: ";
     Tcl_Obj *tcl_result;

--- a/src/pextlib1.0/realpath.h
+++ b/src/pextlib1.0/realpath.h
@@ -43,6 +43,6 @@
  *  Fixes a problem with Tcl installations affected by not defining HAVE_REALPATH (this is
  *  the case with the Tcl in Mac OS X prior to 10.6)
  */
-int RealpathCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+int RealpathCmd(ClientData clientData, Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 
 #endif /* _REALPATH_H */

--- a/src/pextlib1.0/rmd160cmd.c
+++ b/src/pextlib1.0/rmd160cmd.c
@@ -75,7 +75,7 @@ CHECKSUMFile(RMD160, RMD160_CTX)
 CHECKSUMData(RMD160, RMD160_CTX)
 #endif
 
-int RMD160Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int RMD160Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *file, *instr, *action;
 	int inlen;

--- a/src/pextlib1.0/rmd160cmd.h
+++ b/src/pextlib1.0/rmd160cmd.h
@@ -37,7 +37,7 @@
 /**
  * A native command for rmd160 checksums.
  */
-int RMD160Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int RMD160Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
 
 #endif
 	/* _RMD160CMD_H */

--- a/src/pextlib1.0/sha1cmd.c
+++ b/src/pextlib1.0/sha1cmd.c
@@ -73,7 +73,7 @@ CHECKSUMFile(SHA1_, SHA_CTX)
 #error CommonCrypto, libmd or libcrypto required
 #endif
 
-int SHA1Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int SHA1Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *file, *action;
 	char buf[2*SHA_DIGEST_LENGTH + 1];

--- a/src/pextlib1.0/sha1cmd.h
+++ b/src/pextlib1.0/sha1cmd.h
@@ -30,4 +30,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int SHA1Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int SHA1Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/sha256cmd.c
+++ b/src/pextlib1.0/sha256cmd.c
@@ -86,7 +86,7 @@ CHECKSUMEnd(SHA256_, SHA256_CTX, SHA256_DIGEST_LENGTH)
 CHECKSUMFile(SHA256_, SHA256_CTX)
 #endif
 
-int SHA256Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int SHA256Cmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *file, *action;
 	char buf[2*SHA256_DIGEST_LENGTH + 1];

--- a/src/pextlib1.0/sha256cmd.h
+++ b/src/pextlib1.0/sha256cmd.h
@@ -37,7 +37,7 @@
 /**
  * A native command for sha256 checksums.
  */
-int SHA256Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int SHA256Cmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
 
 #endif
 	/* _SHA256CMD_H */

--- a/src/pextlib1.0/system.c
+++ b/src/pextlib1.0/system.c
@@ -284,7 +284,7 @@ static void handle_sigint(int s) {
 }
 
 /* usage: system ?-callback proc? ?-notty? ?-nodup? ?-nice value? ?-W path? command */
-int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int SystemCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     char *args[7];
     char *cmdstring;

--- a/src/pextlib1.0/system.h
+++ b/src/pextlib1.0/system.h
@@ -29,4 +29,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int SystemCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *CONST objv[]);
+int SystemCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/tracelib.c
+++ b/src/pextlib1.0/tracelib.c
@@ -334,7 +334,7 @@ static int error2tcl(const char *msg, int err, Tcl_Interp *interp) {
  * \param[in] objv the parameters
  * \return a Tcl return code
  */
-static int TracelibSetNameCmd(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+static int TracelibSetNameCmd(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     if (objc != 3) {
         Tcl_WrongNumArgs(interp, 2, objv, "number of arguments should be exactly 3");
         return TCL_ERROR;
@@ -363,7 +363,7 @@ static int TracelibSetNameCmd(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[
  * \param[in] objv the parameters
  * \return a Tcl return code
  */
-static int TracelibSetSandboxCmd(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+static int TracelibSetSandboxCmd(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     char *src, *dst;
     enum { NORMAL, ACTION, ESCAPE } state = NORMAL;
 
@@ -1038,7 +1038,7 @@ static int TracelibCloseSocketCmd(Tcl_Interp *interp UNUSED) {
     return TCL_OK;
 }
 
-static int TracelibSetDeps(Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+static int TracelibSetDeps(Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     Tcl_Obj **objects;
     int length;
     if (objc != 3) {
@@ -1095,7 +1095,7 @@ static int TracelibEnableFence(Tcl_Interp *interp UNUSED) {
 }
 #endif /* defined(HAVE_TRACEMODE_SUPPORT) */
 
-int TracelibCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+int TracelibCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     int result = TCL_OK;
 
     /* There is no args for commands now. */

--- a/src/pextlib1.0/tracelib.h
+++ b/src/pextlib1.0/tracelib.h
@@ -58,7 +58,7 @@
  *      tracelib enablefence
  *          - enable dep/sandbox checking
  */
-int TracelibCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int TracelibCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 #endif
 /* _PEXTLIB_TRACELIB_H */

--- a/src/pextlib1.0/tty.c
+++ b/src/pextlib1.0/tty.c
@@ -46,7 +46,7 @@
 #include "tty.h"
 
 int
-IsattyCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+IsattyCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Tcl_Obj *tcl_result;
     Tcl_Channel chan;
@@ -80,7 +80,7 @@ IsattyCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *C
 }
 
 int
-TermGetSizeCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+TermGetSizeCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     Tcl_Obj *tcl_result;
     Tcl_Channel chan;

--- a/src/pextlib1.0/tty.h
+++ b/src/pextlib1.0/tty.h
@@ -38,13 +38,13 @@
 /**
  * A wrapper for isatty(3)
  */
-int IsattyCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int IsattyCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 /**
  * Determines current size of tty
  *
  * @returns list with 2 elements, rows and columns
  */
-int TermGetSizeCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int TermGetSizeCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 #endif /* _PEXTLIB_TTY_H */

--- a/src/pextlib1.0/uid.c
+++ b/src/pextlib1.0/uid.c
@@ -31,7 +31,7 @@
 	
 	synopsis: getuid
 */
-int getuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int getuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	/* Check the arg count */
 	if (objc != 1) {
@@ -48,7 +48,7 @@ int getuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 	
 	synopsis: geteuid
 */
-int geteuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int geteuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	/* Check the arg count */
 	if (objc != 1) {
@@ -63,7 +63,7 @@ int geteuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
 /*
     getgid
 */
-int getgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int getgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     if (objc != 1) {
         Tcl_WrongNumArgs(interp, 1, objv, NULL);
@@ -77,7 +77,7 @@ int getgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 /*
     getegid
 */
-int getegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int getegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     if (objc != 1) {
         Tcl_WrongNumArgs(interp, 1, objv, NULL);
@@ -93,7 +93,7 @@ int getegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
 	
 	synopsis: setuid uid
 */
-int setuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int setuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	long uid = 0;
 	
@@ -123,7 +123,7 @@ int setuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 	
 	synopsis: seteuid uid
 */
-int seteuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int seteuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	long uid = 0;
 
@@ -151,7 +151,7 @@ int seteuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
 /*
     setgid
 */
-int setgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int setgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     long gid;
     
@@ -177,7 +177,7 @@ int setgidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 /*
     setegid
 */
-int setegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int setegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     long gid;
     
@@ -206,7 +206,7 @@ int setegidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
  * getpwuid <uid> [<field>]
  *
 */
-int getpwuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
+int getpwuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]) {
     uid_t uid;
     const char *field = NULL;
     struct passwd *pw;
@@ -310,7 +310,7 @@ int getpwuidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_
 	
 	synopsis: name_to_uid name
 */
-int name_to_uidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int name_to_uidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	struct passwd *pwent;
 	char* name = NULL;
@@ -342,7 +342,7 @@ int name_to_uidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, T
 	
 	synopsis: uid_to_name uid
 */
-int uid_to_nameCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int uid_to_nameCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	long uid = 0;
 	struct passwd *pwent;
@@ -371,7 +371,7 @@ int uid_to_nameCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, T
 	synopsis: uname_to_gid name
 	this function takes a *user* name
 */
-int uname_to_gidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int uname_to_gidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	struct passwd *pwent;
 	char* name = NULL;
@@ -404,7 +404,7 @@ int uname_to_gidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, 
 	synopsis: name_to_gid name
     this function takes a *group* name
 */
-int name_to_gidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int name_to_gidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     struct group *grent;
     char *name;
@@ -431,7 +431,7 @@ int name_to_gidCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, T
 /*
     gid_to_name
 */
-int gid_to_nameCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int gid_to_nameCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
     long gid;
     struct group *grent;

--- a/src/pextlib1.0/uid.h
+++ b/src/pextlib1.0/uid.h
@@ -34,20 +34,20 @@
 
 #include <tcl.h>
 
-int getuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int geteuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int getgidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int getegidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int setuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int seteuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int setgidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int setegidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int getpwuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int name_to_uidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int uid_to_nameCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int uname_to_gidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int name_to_gidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
-int gid_to_nameCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int getuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int geteuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int getgidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int getegidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int setuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int seteuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int setgidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int setegidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int getpwuidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int name_to_uidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int uid_to_nameCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int uname_to_gidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int name_to_gidCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
+int gid_to_nameCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);
 
 
 #endif

--- a/src/pextlib1.0/vercomp.c
+++ b/src/pextlib1.0/vercomp.c
@@ -174,7 +174,7 @@ static int vercmp_op(const char *versionA, const char *operator, const char *ver
     return -1;
 }
 
-int VercompCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+int VercompCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Tcl_Obj *tcl_result;
 	const char *versionA, *versionB, *operator;

--- a/src/pextlib1.0/vercomp.h
+++ b/src/pextlib1.0/vercomp.h
@@ -31,4 +31,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int VercompCmd(ClientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int VercompCmd(ClientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);

--- a/src/pextlib1.0/xinstall.c
+++ b/src/pextlib1.0/xinstall.c
@@ -143,7 +143,7 @@ static int	trymmap(int);
 static void	usage(Tcl_Interp *interp);
 
 int
-InstallCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+InstallCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	struct stat from_sb, to_sb;
 	mode_t *set;

--- a/src/pextlib1.0/xinstall.h
+++ b/src/pextlib1.0/xinstall.h
@@ -27,4 +27,4 @@
  * SUCH DAMAGE.
  */
 
-int InstallCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
+int InstallCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[]);

--- a/src/registry2.0/entry.c
+++ b/src/registry2.0/entry.c
@@ -95,7 +95,7 @@ static int list_obj_to_entry(Tcl_Interp* interp, reg_entry*** entries,
  * required. That's OK because there's only one place this function is called,
  * and it's called with all of them there.
  */
-static int entry_create(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_create(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 7) {
         Tcl_WrongNumArgs(interp, 2, objv, "name version revision variants "
@@ -129,7 +129,7 @@ static int entry_create(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  * Deletes an entry from the registry (then closes it). If this is done within a
  * transaction and the transaction is rolled back, the entry will remain valid.
  */
-static int entry_delete(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_delete(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 3) {
         Tcl_WrongNumArgs(interp, 1, objv, "delete entry");
@@ -187,7 +187,7 @@ static int entry_delete(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  *
  * Opens an entry matching the given parameters.
  */
-static int entry_open(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_open(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 7) {
         Tcl_WrongNumArgs(interp, 1, objv, "open portname version revision "
@@ -221,7 +221,7 @@ static int entry_open(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  *
  * Closes an entry. It will remain in the registry until next time.
  */
-static int entry_close(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_close(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     if (objc != 3) {
         Tcl_WrongNumArgs(interp, 1, objv, "close entry");
         return TCL_ERROR;
@@ -260,7 +260,7 @@ static strategy_type strategies[] = {
  * Can be given an option of -exact, -glob, -regexp or -null to specify the
  * matching strategy; defaults to exact.
  */
-static int entry_search(Tcl_Interp* interp, int objc, Tcl_Obj* CONST *objv) {
+static int entry_search(Tcl_Interp* interp, int objc, Tcl_Obj* const *objv) {
     reg_registry *reg = registry_for(interp, reg_attached);
     if (!reg) {
         return TCL_ERROR;
@@ -355,7 +355,7 @@ cleanup_error:
  * simply checks if the given string is a valid entry object in the current
  * interp. No query to the database will be made.
  */
-static int entry_exists(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_exists(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     reg_error error;
     if (objc != 3) {
         Tcl_WrongNumArgs(interp, 2, objv, "name");
@@ -389,7 +389,7 @@ static int entry_exists(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  *
  * TODO: add more arguments (epoch, revision, variants), maybe
  */
-static int entry_imaged(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_imaged(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc == 5 || objc > 6) {
         Tcl_WrongNumArgs(interp, 2, objv, "?name ?version ?revision variants???");
@@ -432,7 +432,7 @@ static int entry_imaged(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  * installed ports in 'direct' mode. That is, any port which is capable of
  * satisfying a dependency.
  */
-static int entry_installed(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]){
+static int entry_installed(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]){
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc > 3) {
         Tcl_WrongNumArgs(interp, 2, objv, "?name?");
@@ -470,7 +470,7 @@ static int entry_installed(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]){
  *
  * Returns the port that owns the given filename (empty string if none).
  */
-static int entry_owner(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int entry_owner(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     int cs = 1;
 
@@ -508,7 +508,7 @@ static int entry_owner(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
 
 typedef struct {
     char* name;
-    int (*function)(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+    int (*function)(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 } entry_cmd_type;
 
 static entry_cmd_type entry_cmds[] = {
@@ -533,7 +533,7 @@ static entry_cmd_type entry_cmds[] = {
  * represents ports too, but not those in the registry.
  */
 int entry_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int cmd_index;
     if (objc < 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd ?arg ...?");

--- a/src/registry2.0/entry.h
+++ b/src/registry2.0/entry.h
@@ -36,6 +36,6 @@
 void delete_entry(ClientData clientData);
 
 int entry_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]);
+        Tcl_Obj* const objv[]);
 
 #endif /* _ENTRY_H */

--- a/src/registry2.0/entryobj.c
+++ b/src/registry2.0/entryobj.c
@@ -62,7 +62,7 @@ const char* entry_props[] = {
 
 /* ${entry} prop ?value? */
 static int entry_obj_prop(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int index;
     if (objc > 3) {
         Tcl_WrongNumArgs(interp, 2, objv, "?value?");
@@ -122,7 +122,7 @@ static filemap_op filemap_cmds[] = {
 };
 
 static int entry_obj_filemap(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     int op;
     if (objc != 3) {
@@ -157,7 +157,7 @@ static int entry_obj_filemap(Tcl_Interp* interp, reg_entry* entry, int objc,
 }
 
 static int entry_obj_files(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "files");
@@ -191,7 +191,7 @@ static int entry_obj_files(Tcl_Interp* interp, reg_entry* entry, int objc,
 }
 
 static int entry_obj_imagefiles(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "imagefiles");
@@ -225,7 +225,7 @@ static int entry_obj_imagefiles(Tcl_Interp* interp, reg_entry* entry, int objc,
 }
 
 static int entry_obj_activate(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc > 4) {
         Tcl_WrongNumArgs(interp, 1, objv, "activate file-list ?as-file-list?");
@@ -277,7 +277,7 @@ static int entry_obj_activate(Tcl_Interp* interp, reg_entry* entry, int objc,
 }
 
 static int entry_obj_dependencies(Tcl_Interp* interp, reg_entry* entry,
-        int objc, Tcl_Obj* CONST objv[]) {
+        int objc, Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "dependencies");
@@ -307,7 +307,7 @@ static int entry_obj_dependencies(Tcl_Interp* interp, reg_entry* entry,
 }
 
 static int entry_obj_dependents(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "dependents");
@@ -337,7 +337,7 @@ static int entry_obj_dependents(Tcl_Interp* interp, reg_entry* entry, int objc,
 }
 
 static int entry_obj_depends(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 3) {
         Tcl_WrongNumArgs(interp, 1, objv, "depends portname");
@@ -355,7 +355,7 @@ static int entry_obj_depends(Tcl_Interp* interp, reg_entry* entry, int objc,
 }
 
 static int entry_obj_add_portgroup(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 6) {
         Tcl_WrongNumArgs(interp, 1, objv, "addgroup name version sha256 size");
@@ -378,7 +378,7 @@ static int entry_obj_add_portgroup(Tcl_Interp* interp, reg_entry* entry, int obj
 }
 
 static int entry_obj_get_portgroups(Tcl_Interp* interp, reg_entry* entry, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     reg_registry* reg = registry_for(interp, reg_attached);
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "groups_used");
@@ -410,7 +410,7 @@ static int entry_obj_get_portgroups(Tcl_Interp* interp, reg_entry* entry, int ob
 typedef struct {
     char* name;
     int (*function)(Tcl_Interp* interp, reg_entry* entry, int objc,
-            Tcl_Obj* CONST objv[]);
+            Tcl_Obj* const objv[]);
 } entry_obj_cmd_type;
 
 static entry_obj_cmd_type entry_cmds[] = {
@@ -459,7 +459,7 @@ static entry_obj_cmd_type entry_cmds[] = {
  * chance to touch it.
  */
 int entry_obj_cmd(ClientData clientData, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int cmd_index;
     if (objc < 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd ?arg ...?");

--- a/src/registry2.0/entryobj.h
+++ b/src/registry2.0/entryobj.h
@@ -42,6 +42,6 @@ typedef struct {
 extern const char* entry_props[];
 
 int entry_obj_cmd(ClientData clientData, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]);
+        Tcl_Obj* const objv[]);
 
 #endif /* _ENTRY_OBJ_CMD_H */

--- a/src/registry2.0/file.c
+++ b/src/registry2.0/file.c
@@ -78,7 +78,7 @@ void delete_file(ClientData clientData) {
  *
  * Opens a file matching the given parameters.
  */
-static int file_open(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int file_open(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
 	reg_registry* reg = registry_for(interp, reg_attached);
 	if (objc != 4) {
 		Tcl_WrongNumArgs(interp, 1, objv, "open portid path");
@@ -107,7 +107,7 @@ static int file_open(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  *
  * Closes a file. It will remain in the registry.
  */
-static int file_close(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int file_close(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
 	if (objc != 3) {
 		Tcl_WrongNumArgs(interp, 1, objv, "close file");
 		return TCL_ERROR;
@@ -146,7 +146,7 @@ static strategy_type strategies[] = {
  * For each key, can be given an option of -exact, -glob, -regexp or -null to
  * specify the matching strategy; defaults to exact.
  */
-static int file_search(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int file_search(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     int i, j;
     reg_registry* reg = registry_for(interp, reg_attached);
     if (reg == NULL) {
@@ -271,7 +271,7 @@ static int file_search(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
 
 typedef struct {
     char* name;
-    int (*function)(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+    int (*function)(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 } file_cmd_type;
 
 static file_cmd_type file_cmds[] = {
@@ -288,7 +288,7 @@ static file_cmd_type file_cmds[] = {
  * Commands manipulating file entries in the registry. This can be called `registry::file`
  */
 int file_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int cmd_index;
     if (objc < 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd ?arg ...?");

--- a/src/registry2.0/file.h
+++ b/src/registry2.0/file.h
@@ -37,7 +37,7 @@
 void delete_file(ClientData clientData);
 
 int file_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]);
+        Tcl_Obj* const objv[]);
 
 #endif /* _FILE_H */
 

--- a/src/registry2.0/fileobj.c
+++ b/src/registry2.0/fileobj.c
@@ -50,7 +50,7 @@ const char* file_props[] = {
 
 /* ${file} prop ?value? */
 static int file_obj_prop(Tcl_Interp* interp, reg_file* file, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int index;
     if (objc > 3) {
         Tcl_WrongNumArgs(interp, 2, objv, "?value?");
@@ -99,7 +99,7 @@ static int file_obj_prop(Tcl_Interp* interp, reg_file* file, int objc,
 typedef struct {
     char* name;
     int (*function)(Tcl_Interp* interp, reg_file* file, int objc,
-            Tcl_Obj* CONST objv[]);
+            Tcl_Obj* const objv[]);
 } file_obj_cmd_type;
 
 static file_obj_cmd_type file_cmds[] = {
@@ -120,7 +120,7 @@ static file_obj_cmd_type file_cmds[] = {
  * chance to touch it.
  */
 int file_obj_cmd(ClientData clientData, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int cmd_index;
     if (objc < 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd ?arg ...?");

--- a/src/registry2.0/fileobj.h
+++ b/src/registry2.0/fileobj.h
@@ -38,6 +38,6 @@
 extern const char* file_props[];
 
 int file_obj_cmd(ClientData clientData, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]);
+        Tcl_Obj* const objv[]);
 
 #endif /* _FILE_OBJ_CMD_H */

--- a/src/registry2.0/portgroup.c
+++ b/src/registry2.0/portgroup.c
@@ -73,7 +73,7 @@ void delete_portgroup(ClientData clientData) {
  *
  * Opens a portgroup matching the given parameters.
  */
-static int portgroup_open(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int portgroup_open(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
 	reg_registry* reg = registry_for(interp, reg_attached);
 	if (objc != 7) {
 		Tcl_WrongNumArgs(interp, 1, objv, "open id name version size sha256");
@@ -106,7 +106,7 @@ static int portgroup_open(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
  *
  * Closes a portgroup. It will remain in the registry.
  */
-static int portgroup_close(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int portgroup_close(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
 	if (objc != 3) {
 		Tcl_WrongNumArgs(interp, 1, objv, "close portgroup");
 		return TCL_ERROR;
@@ -145,7 +145,7 @@ static strategy_type strategies[] = {
  * For each key, can be given an option of -exact, -glob, -regexp or -null to
  * specify the matching strategy; defaults to exact.
  */
-static int portgroup_search(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]) {
+static int portgroup_search(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]) {
     int i, j;
     reg_registry* reg = registry_for(interp, reg_attached);
     if (reg == NULL) {
@@ -270,7 +270,7 @@ static int portgroup_search(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[])
 
 typedef struct {
     char* name;
-    int (*function)(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[]);
+    int (*function)(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[]);
 } portgroup_cmd_type;
 
 static portgroup_cmd_type portgroup_cmds[] = {
@@ -287,7 +287,7 @@ static portgroup_cmd_type portgroup_cmds[] = {
  * Commands manipulating portgroup entries in the registry. This can be called `registry::portgroup`
  */
 int portgroup_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int cmd_index;
     if (objc < 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd ?arg ...?");

--- a/src/registry2.0/portgroup.h
+++ b/src/registry2.0/portgroup.h
@@ -36,6 +36,6 @@
 void delete_portgroup(ClientData clientData);
 
 int portgroup_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]);
+        Tcl_Obj* const objv[]);
 
 #endif /* _PORTGROUP_H */

--- a/src/registry2.0/portgroupobj.c
+++ b/src/registry2.0/portgroupobj.c
@@ -48,7 +48,7 @@ const char* portgroup_props[] = {
 
 /* ${portgroup} prop ?value? */
 static int portgroup_obj_prop(Tcl_Interp* interp, reg_portgroup* portgroup, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int index;
     if (objc > 3) {
         Tcl_WrongNumArgs(interp, 2, objv, "?value?");
@@ -97,7 +97,7 @@ static int portgroup_obj_prop(Tcl_Interp* interp, reg_portgroup* portgroup, int 
 typedef struct {
     char* name;
     int (*function)(Tcl_Interp* interp, reg_portgroup* portgroup, int objc,
-            Tcl_Obj* CONST objv[]);
+            Tcl_Obj* const objv[]);
 } portgroup_obj_cmd_type;
 
 static portgroup_obj_cmd_type portgroup_cmds[] = {
@@ -118,7 +118,7 @@ static portgroup_obj_cmd_type portgroup_cmds[] = {
  * chance to touch it.
  */
 int portgroup_obj_cmd(ClientData clientData, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     int cmd_index;
     if (objc < 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd ?arg ...?");

--- a/src/registry2.0/portgroupobj.h
+++ b/src/registry2.0/portgroupobj.h
@@ -37,6 +37,6 @@
 extern const char* portgroup_props[];
 
 int portgroup_obj_cmd(ClientData clientData, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]);
+        Tcl_Obj* const objv[]);
 
 #endif /* _PORTGROUP_OBJ_CMD_H */

--- a/src/registry2.0/registry.c
+++ b/src/registry2.0/registry.c
@@ -200,7 +200,7 @@ reg_registry* registry_for(Tcl_Interp* interp, int status) {
 }
 
 static int registry_open(ClientData clientData UNUSED, Tcl_Interp* interp,
-        int objc, Tcl_Obj* CONST objv[]) {
+        int objc, Tcl_Obj* const objv[]) {
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "db-file");
         return TCL_ERROR;
@@ -224,7 +224,7 @@ static int registry_open(ClientData clientData UNUSED, Tcl_Interp* interp,
 }
 
 static int registry_close(ClientData clientData UNUSED, Tcl_Interp* interp,
-        int objc, Tcl_Obj* CONST objv[]) {
+        int objc, Tcl_Obj* const objv[]) {
     if (objc != 1) {
         Tcl_WrongNumArgs(interp, 1, objv, NULL);
         return TCL_ERROR;
@@ -252,7 +252,7 @@ static int registry_close(ClientData clientData UNUSED, Tcl_Interp* interp,
 }
 
 static int registry_read(ClientData clientData UNUSED, Tcl_Interp* interp,
-        int objc, Tcl_Obj* CONST objv[]) {
+        int objc, Tcl_Obj* const objv[]) {
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "command");
         return TCL_ERROR;
@@ -288,7 +288,7 @@ static int registry_read(ClientData clientData UNUSED, Tcl_Interp* interp,
 }
 
 static int registry_write(ClientData clientData UNUSED, Tcl_Interp* interp,
-        int objc, Tcl_Obj* CONST objv[]) {
+        int objc, Tcl_Obj* const objv[]) {
     if (objc != 2) {
         Tcl_WrongNumArgs(interp, 1, objv, "command");
         return TCL_ERROR;
@@ -343,7 +343,7 @@ static int registry_write(ClientData clientData UNUSED, Tcl_Interp* interp,
  * Commands manipulating metadata in the registry. This can be called `registry::metadata`
  */
 int metadata_cmd(ClientData clientData UNUSED, Tcl_Interp* interp, int objc,
-        Tcl_Obj* CONST objv[]) {
+        Tcl_Obj* const objv[]) {
     if (objc < 3) {
         Tcl_WrongNumArgs(interp, 1, objv, "cmd key ?value?");
         return TCL_ERROR;

--- a/src/registry2.0/util.c
+++ b/src/registry2.0/util.c
@@ -99,7 +99,7 @@ char* unique_name(Tcl_Interp* interp, char* prefix, unsigned int* lower_bound) {
  * use for this yet, so it's not a priority, but it should be there for
  * completeness.
  */
-int parse_flags(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[], int* start,
+int parse_flags(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[], int* start,
         option_spec options[], int* flags) {
     int i;
     int index;

--- a/src/registry2.0/util.h
+++ b/src/registry2.0/util.h
@@ -49,7 +49,7 @@ typedef struct {
 
 char* unique_name(Tcl_Interp* interp, char* prefix, unsigned int* lower_bound);
 
-int parse_flags(Tcl_Interp* interp, int objc, Tcl_Obj* CONST objv[], int* start,
+int parse_flags(Tcl_Interp* interp, int objc, Tcl_Obj* const objv[], int* start,
         option_spec options[], int* flags);
 
 void* get_object(Tcl_Interp* interp, char* name, char* type,


### PR DESCRIPTION
Currently, `CONST` (from tcl.h) is to be deprecated in Tcl 8.7, and removed in Tcl 9.0.