### PR TITLE
pextlib: return 2-element list from mkstemp

### DIFF
--- a/src/pextlib1.0/mktemp.c
+++ b/src/pextlib1.0/mktemp.c
@@ -43,6 +43,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -105,7 +106,9 @@ int MktempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 int MkstempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	Tcl_Channel channel;
-	char *template, *channelname;
+	char *template;
+	const char *channelname;
+	Tcl_Obj *tcl_result, *robjv[2];
 	int fd;
 
 	if (objc != 2) {
@@ -125,8 +128,11 @@ int MkstempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_O
 
 	channel = Tcl_MakeFileChannel((ClientData)(intptr_t)fd, TCL_READABLE|TCL_WRITABLE);
 	Tcl_RegisterChannel(interp, channel);
-	channelname = (char *)Tcl_GetChannelName(channel);
-	Tcl_AppendResult(interp, channelname, " ", template, NULL);
+	channelname = Tcl_GetChannelName(channel);
+	robjv[0] = Tcl_NewStringObj(channelname, -1);
+	robjv[1] = Tcl_NewStringObj(template, -1);
+	tcl_result = Tcl_NewListObj(2, robjv);
+	Tcl_SetObjResult(interp, tcl_result);
 	free(template);
 	return TCL_OK;
 }

--- a/src/port1.0/portbump.tcl
+++ b/src/port1.0/portbump.tcl
@@ -190,17 +190,11 @@ proc portbump::bump_main {args} {
         # root -> owner id
         exec_as_uid $owneruid {
             # Create temporary Portfile.bump.XXXXXX
-            if {[catch {set tmpfile [mkstemp "${portpath}/Portfile.bump.XXXXXX"]} error]} {
+            if {[catch {lassign [mkstemp "${portpath}/Portfile.bump.XXXXXX"] tmpfd tmpfile} error]} {
                 ui_debug $::errorInfo
                 ui_error "mkstemp: $error"
                 return -code error "mkstemp failed"
             }
-
-            # Extract the Tcl Channel number
-            set tmpfd [lindex $tmpfile 0]
-
-            # Set tmpfile to only the file name
-            set tmpfile [join [lrange $tmpfile 1 end]]
 
             # Get Portfile attributes
             set attributes [file attributes $portfile]

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1087,15 +1087,10 @@ proc reinplace {args}  {
         # absolute path, otherwise it is $dir/$file
         set file [file join $dir $file]
 
-        if {[catch {set tmpfile [mkstemp "${tempdir}/[file tail $file].sed.XXXXXXXX"]} error]} {
+        if {[catch {lassign [mkstemp "${tempdir}/[file tail $file].sed.XXXXXXXX"] tmpfd tmpfile} error]} {
             ui_debug $::errorInfo
             ui_error "reinplace: $error"
             return -code error "reinplace failed"
-        } else {
-            # Extract the Tcl Channel number
-            set tmpfd [lindex $tmpfile 0]
-            # Set tmpfile to only the file name
-            set tmpfile [join [lrange $tmpfile 1 end]]
         }
 
         set cmdline {}


### PR DESCRIPTION
…which when combined with the Tcl 8.5 `lassign` command should be simpler to use. The two uses updated by this PR are the only ones I am aware of.

Hopefully this makes `mkstemp` a slightly more attractive replacement for `mktemp` which relies on the `mktemp()` C function, which is deprecated since macOS 13 due to possible TOCTOU errors.