### PR TITLE
pextlib: Replace `mkstemp` with Tcl 8.6 `file tempfile`

### DIFF
--- a/doc/INTERNALS
+++ b/doc/INTERNALS
@@ -53,4 +53,4 @@ supplies all these procedures, all of which are generated at run-time using
 the "options" procedure in portutil.tcl.
 
     The "pextlib" TCL library provides a variety of otherwise unavailable TCL
-procedures, such as an interface to flock(2) and mkstemp(3).
+procedures, such as an interface to flock(2).

--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -2686,11 +2686,6 @@ Create a temporary file using a
 .Ar template .
 See
 .Xr mktemp 3 .
-.It Ic mkstemp Ar template
-Create a temporary file securely using a
-.Ar template .
-See
-.Xr mkstemp 3 .
 .It Ic mkdtemp Ar template
 Create a temporary directory using a
 .Ar template .

--- a/src/pextlib1.0/Pextlib.c
+++ b/src/pextlib1.0/Pextlib.c
@@ -1076,7 +1076,6 @@ int Pextlib_Init(Tcl_Interp *interp)
 	Tcl_CreateObjCommand(interp, "adv-flock", AdvFlockCmd, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "readdir", ReaddirCmd, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "strsed", StrsedCmd, NULL, NULL);
-	Tcl_CreateObjCommand(interp, "mkstemp", MkstempCmd, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "mktemp", MktempCmd, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "mkdtemp", MkdtempCmd, NULL, NULL);
 	Tcl_CreateObjCommand(interp, "existsuser", ExistsuserCmd, NULL, NULL);

--- a/src/pextlib1.0/mktemp.c
+++ b/src/pextlib1.0/mktemp.c
@@ -101,32 +101,3 @@ int MktempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Ob
 	free(template);
 	return TCL_OK;
 }
-
-int MkstempCmd(ClientData clientData UNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
-{
-	Tcl_Channel channel;
-	char *template, *channelname;
-	int fd;
-
-	if (objc != 2) {
-		Tcl_WrongNumArgs(interp, 1, objv, "template");
-		return TCL_ERROR;
-	}
-
-	template = strdup(Tcl_GetString(objv[1]));
-	if (template == NULL)
-		return TCL_ERROR;
-
-	if ((fd = mkstemp(template)) < 0) {
-		Tcl_AppendResult(interp, "mkstemp failed: ", strerror(errno), NULL);
-		free(template);
-		return TCL_ERROR;
-	}
-
-	channel = Tcl_MakeFileChannel((ClientData)(intptr_t)fd, TCL_READABLE|TCL_WRITABLE);
-	Tcl_RegisterChannel(interp, channel);
-	channelname = (char *)Tcl_GetChannelName(channel);
-	Tcl_AppendResult(interp, channelname, " ", template, NULL);
-	free(template);
-	return TCL_OK;
-}

--- a/src/pextlib1.0/mktemp.h
+++ b/src/pextlib1.0/mktemp.h
@@ -31,4 +31,3 @@
 
 int MkdtempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
 int MktempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);
-int MkstempCmd(ClientData, Tcl_Interp *, int, Tcl_Obj *const objv[]);

--- a/src/port1.0/portbump.tcl
+++ b/src/port1.0/portbump.tcl
@@ -190,17 +190,11 @@ proc portbump::bump_main {args} {
         # root -> owner id
         exec_as_uid $owneruid {
             # Create temporary Portfile.bump.XXXXXX
-            if {[catch {set tmpfile [mkstemp "${portpath}/Portfile.bump.XXXXXX"]} error]} {
+            if {[catch {set tmpfd [file tempfile tmpfile "${portpath}/Portfile.bump.XXXXXX"]} error]} {
                 ui_debug $::errorInfo
-                ui_error "mkstemp: $error"
-                return -code error "mkstemp failed"
+                ui_error "file tempfile: $error"
+                return -code error "file tempfile failed"
             }
-
-            # Extract the Tcl Channel number
-            set tmpfd [lindex $tmpfile 0]
-
-            # Set tmpfile to only the file name
-            set tmpfile [join [lrange $tmpfile 1 end]]
 
             # Get Portfile attributes
             set attributes [file attributes $portfile]

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1087,15 +1087,10 @@ proc reinplace {args}  {
         # absolute path, otherwise it is $dir/$file
         set file [file join $dir $file]
 
-        if {[catch {set tmpfile [mkstemp "${tempdir}/[file tail $file].sed.XXXXXXXX"]} error]} {
+        if {[catch {set tmpfd [file tempfile tmpfile "${tempdir}/[file tail $file].sed.XXXXXXXX"]} error]} {
             ui_debug $::errorInfo
             ui_error "reinplace: $error"
             return -code error "reinplace failed"
-        } else {
-            # Extract the Tcl Channel number
-            set tmpfd [lindex $tmpfile 0]
-            # Set tmpfile to only the file name
-            set tmpfile [join [lrange $tmpfile 1 end]]
         }
 
         set cmdline {}


### PR DESCRIPTION
Possible alternative to #308. The two uses of `mkstemp` updated by this PR are the only ones I am aware of.