### PR TITLE
macports.tcl: Fix regression in 5b6a134d6

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -2445,7 +2445,7 @@ proc mportexec {mport target} {
         registry::exclusive_lock
         # see if we actually need to build this port
         if {$target ni {activate install} ||
-            ![$workername eval [list registry_exists \$subport \$version \$revision \$portvariants]]} {
+            ![$workername eval {registry_exists $subport $version $revision $portvariants}]} {
 
             # upgrade dependencies that are already installed
             if {![macports::global_option_isset ports_nodeps]} {


### PR DESCRIPTION
5b6a134d66000ca1549ea218850307ef9ae37943 caused dependencies to be installed that were not actually required when -s was used. For example, with iperf (and thus its runtime dependencies) and cmake (its only build-time dependency) installed, running sudo port -st install --unrequested iperf would start to install gperf and cmake-bootstrap, even though they were not required.

It seems this happened because MacPorts did not longer correctly detect that the build dependency was actually installed and proceeded to install and upgrade all its dependencies.

Thanks to halabund and Schamschula for the report.