### PR TITLE
portpatch: pass --forward to avoid silent reverse patch

### DIFF
--- a/src/port1.0/portpatch.tcl
+++ b/src/port1.0/portpatch.tcl
@@ -50,7 +50,7 @@ options patch.asroot
 default patch.asroot no
 default patch.dir {${worksrcpath}}
 default patch.cmd {[portpatch::build_getpatchtype]}
-default patch.pre_args -p0
+default patch.pre_args "--forward -p0"
 
 proc portpatch::build_getpatchtype {args} {
     if {![exists patch.type]} {


### PR DESCRIPTION
On macOS ~~15~~ 13, if a patch is already applied, /usr/bin/patch asks the user if it is reversed.  If running interactively, the build will wait for user input (hang); if no stdin, it assumes reverse.  --forward prevents the "Reversed?" prompt and triggers failure (*.rej file and non-zero exit)

Root cause of macports/macports-ports#23318

I do not have any older macOS systems to test whether the '--forward' flag is available (or works).  Here is a script that demonstrates the behavior:

```
  rm -f targetA targetB targetC
  yes | head -n 20 | cat -n > file0
  sed -e '5s/y/n/' < file0 > file1
  diff -u file0 file1 > patch01
  cp file1 targetA
  patch --forward targetA < patch01 ; echo A $?
  sed -e '15s/y/n/' < file1 > file2
  diff -u file0 file2 > patch02
  cp file1 targetB
  patch --forward targetB < patch02 ; echo B $?
  cp file0 targetC
  patch --forward targetC < patch02 ; echo C $?
  diff targetC file2 ; echo diff $?
```

The --forward option should not generate any warnings.  Expected output (with noise removed):

```
A 1
B 1
C 0
diff 0
```
