### PR TITLE
Fix standard_configure.sh for out-of-source builds

### DIFF
--- a/standard_configure.sh
+++ b/standard_configure.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+script_dir=$(dirname "$0")
+
 # This is how we run configure when building binary packages (more or less,
 # minus architecture selection). If you don't want a custom build, this
 # is probably how you should run it too.
-env PATH=/usr/bin:/bin:/usr/sbin:/sbin CFLAGS="-pipe -Os" ./configure --enable-readline "$@"
+env PATH=/usr/bin:/bin:/usr/sbin:/sbin CFLAGS="-pipe -Os" "$script_dir"/configure --enable-readline "$@"
 
 # If you want to use a different prefix, add this to the above:
 # --prefix=/some/path --with-applications-dir=/some/path/Applications


### PR DESCRIPTION
See: https://trac.macports.org/ticket/28001