### PR TITLE
Remove "Creating launchd control script" message

### DIFF
--- a/src/port1.0/portstartupitem.tcl
+++ b/src/port1.0/portstartupitem.tcl
@@ -520,9 +520,9 @@ proc portstartupitem::startupitem_create {} {
     foreach_startupitem {
         if {${si_type} ne "none" && ([tbool si_create] || $si_custom_file ne "")} {
             if {[tbool si_create]} {
-                ui_notice "$UI_PREFIX [msgcat::mc "Creating ${si_type} control script '$si_name'"]"
+                ui_debug "Creating ${si_type} control script '$si_name'"
             } else {
-                ui_notice "$UI_PREFIX [msgcat::mc "Installing ${si_type} control script '$si_name'"]"
+                ui_debug "Installing ${si_type} control script '$si_name'"
             }
 
             switch -- ${si_type} {


### PR DESCRIPTION
This message or one of its prior wordings has been present ever since the startup item code was originally added in 3ffdaf3 in 2005.

I presume the purpose of this message was to inform the user that a startup item existed for this port. It no longer accomplishes that purpose because it only appears during the destroot phase which most users will not see because they install pre-built archives instead of building from source. Meanwhile a better message in the form of notes that display at the end of installation, regardless of whether it was from source or via pre-built archive, was added in 6faf3f8 in 2018.

Originally, the startup item was created at the end of the destroot phase, so users would first see the "Staging into destroot" message, followed by a delay as staging occurred, followed by the "Creating launchd control script" message, followed almost immediately by the install phase messages. In 6f7ed40 in 2020 it was changed so that startup items would be created at the beginning of the destroot phase. This made the output more confusing: now, "Staging into destroot" was followed immediately by "Creating launchd control script", which would then remain until staging had completed, giving the erroneous impression that staging completed instantly while creating the control script took a long time.

Nothing else in the destroot phase gets the special privilege of printing an extra line to the terminal; there's no reason why creating the launchd control script should do so.

Thus, remove the "Creating launchd control script" message entirely.