### PR TITLE
Migration: snapshot installed files and use to resolve path-based deps

### DIFF
--- a/src/cregistry/snapshot.h
+++ b/src/cregistry/snapshot.h
@@ -67,6 +67,9 @@ reg_snapshot* reg_snapshot_create(reg_registry* reg, char* note,
 // helper method for storing ports for this snapshot
 int snapshot_store_ports(reg_registry* reg, reg_snapshot* snapshot,
         reg_error* errPtr);
+// helper method for storing files for this snapshot
+int snapshot_store_files(reg_registry* reg, reg_snapshot* snapshot,
+        reg_error* errPtr);
 
 // snapshot properties retrieval methods
 int reg_snapshot_propget(reg_snapshot* snapshot, char* key, char** value,


### PR DESCRIPTION
Adding the lists of installed files to registry snapshots allows us to resolve path-based depspecs in the same way that a normal upgrade does. While this increases the size of the snapshots considerably, I think it's worth it for the correctness.

Lightly tested and confirmed to behave correctly with curl installed with its `path:share/curl/curl-ca-bundle.crt:curl-ca-bundle` dep satisfied by certsync.