### PR TITLE
CI: Remove macos-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12, macos-13, macos-14, ubuntu-latest]
+        os: [macos-12, macos-13, macos-14, ubuntu-latest]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The macos-11 runner is slated for removal by the end of the month with brownouts scheduled to occur in the weeks leading up to that.