### PR TITLE
Escape special regex characters in depspecs

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3186,12 +3186,13 @@ proc _libtest {depspec {return_match 0}} {
     if {$i < 0} {set i [string length $depline]}
     set depname [string range $depline 0 $i-1]
     set depversion [string range $depline $i end]
-    regsub {\.} $depversion {\.} depversion
     if {${os.platform} eq "darwin"} {
-        set depregex \^${depname}${depversion}\\.dylib\$
+        set depregex ${depname}${depversion}.dylib
     } else {
-        set depregex \^${depname}\\.so${depversion}\$
+        set depregex ${depname}.so${depversion}
     }
+
+    set depregex \^[quotemeta $depregex]\$
 
     return [_mportsearchpath $depregex $search_path 0 $return_match]
 }
@@ -3204,7 +3205,7 @@ proc _bintest {depspec {return_match 0}} {
 
     set search_path [split $env(PATH) :]
 
-    set depregex \^$depregex\$
+    set depregex \^[quotemeta $depregex]\$
 
     return [_mportsearchpath $depregex $search_path 1 $return_match]
 }
@@ -3225,7 +3226,7 @@ proc _pathtest {depspec {return_match 0}} {
         set search_path "${prefix}/${search_path}"
     }
 
-    set depregex \^$depregex\$
+    set depregex \^[quotemeta $depregex]\$
 
     return [_mportsearchpath $depregex $search_path 0 $return_match]
 }


### PR DESCRIPTION
It seems like a bug, rather than an intended feature, that "foo" in depspecs like `bin:foo:bar`, `lib:foo.1:bar`, and `path:a/b/foo:bar` was interpreted as a regular expression rather than as a simple string. The MacPorts Guide has always documented these to be simple strings, not regexes.

This fixes handling of depspecs that contain special regex characters -- at present that's `path:lib/pkgconfig/gtk+-2.0.pc:gtk2` and `path:lib/pkgconfig/gtk+-3.0.pc:gtk3` -- so that gtk2-devel and gtk3-devel, respectively, can satisfy them.

Closes: https://trac.macports.org/ticket/69585