### PR TITLE
snapshot: UX improvements

### DIFF
--- a/src/macports1.0/snapshot.tcl
+++ b/src/macports1.0/snapshot.tcl
@@ -42,8 +42,8 @@ namespace eval snapshot {
         ui_msg "  port snapshot --delete <snapshot-id>"
     }
 
-	proc main {opts} {
-		# Function to create a snapshot of the current state of ports.
+    proc main {opts} {
+        # Function to create a snapshot of the current state of ports.
         #
         # Args:
         #           opts - The options passed in.
@@ -110,7 +110,10 @@ namespace eval snapshot {
                 return 0
             }
             "diff" {
-                set snapshot [registry::snapshot get_by_id [dict get $opts ports_snapshot_diff]]
+                if {[catch {set snapshot [registry::snapshot get_by_id [dict get $opts ports_snapshot_diff]]} result]} {
+                    ui_error "Failed to obtain snapshot with ID [dict get $opts ports_snapshot_diff]: $result"
+                    return 1
+                }
                 array set diff [diff $snapshot]
                 set show_all [dict exists $opts ports_snapshot_all]
                 set note ""

--- a/src/macports1.0/snapshot.tcl
+++ b/src/macports1.0/snapshot.tcl
@@ -141,6 +141,7 @@ namespace eval snapshot {
                         }
                     }
                 }
+
                 if {[llength $diff(removed)] > 0} {
                     append note "The following ports are in the snapshot but not installed:\n"
                     foreach removed_port [lsort -ascii -index 0 $diff(removed)] {
@@ -167,6 +168,10 @@ namespace eval snapshot {
                             append note "   $field changed from '$old' to '$new'\n"
                         }
                     }
+                }
+
+                if {[llength $diff(added)] == 0 && [llength $diff(removed)] == 0 && [llength $diff(changed)] == 0} {
+                    append note "The current state and the specified snapshot match.\n"
                 }
 
                 ui_msg [string trimright $note "\n"]


### PR DESCRIPTION
- snapshot: Report match in --diff if there are no changes  
  The user experience of `sudo port snapshot --diff $id --all` just printing nothing is not great. Improve this by explicitly printing a success message if there are no changes.
- snapshot: Handle errors with unknown snapshot IDs