### PR TITLE
record applied patchfiles in the statefile

### DIFF
--- a/src/port1.0/portpatch.tcl
+++ b/src/port1.0/portpatch.tcl
@@ -68,7 +68,7 @@ proc portpatch::build_getpatchtype {args} {
 }
 
 proc portpatch::patch_main {args} {
-    global UI_PREFIX
+    global UI_PREFIX target_state_fd
 
     # First make sure that patchfiles exists and isn't stubbed out.
     if {![exists patchfiles] || [option patchfiles] eq ""} {
@@ -96,18 +96,24 @@ proc portpatch::patch_main {args} {
     catch {set xzcat "[findBinary xz $portutil::autoconf::xz_path] -dc"}
 
     foreach patch $patchlist {
-        ui_info "$UI_PREFIX [format [msgcat::mc "Applying %s"] [file tail $patch]]"
-        switch -- [file extension $patch] {
-            .Z -
-            .gz {command_exec patch "$gzcat \"$patch\" | (" ")"}
-            .bz2 {command_exec patch "$bzcat \"$patch\" | (" ")"}
-            .xz {
-                if {[info exists xzcat]} {
-                    command_exec patch "$xzcat \"$patch\" | (" ")"
-                } else {
-                    return -code error [msgcat::mc "xz binary not found; port needs to add 'depends_patch bin:xz:xz'"]
-                }}
-            default {command_exec patch "" "< '$patch'"}
+        set pfile [file tail $patch]
+        if {![check_statefile patch $pfile $target_state_fd]} {
+            ui_info "$UI_PREFIX [format [msgcat::mc "Applying %s"] [file tail $patch]]"
+            switch -- [file extension $patch] {
+                .Z -
+                .gz {command_exec patch "$gzcat \"$patch\" | (" ")"}
+                .bz2 {command_exec patch "$bzcat \"$patch\" | (" ")"}
+                .xz {
+                    if {[info exists xzcat]} {
+                        command_exec patch "$xzcat \"$patch\" | (" ")"
+                    } else {
+                        return -code error [msgcat::mc "xz binary not found; port needs to add 'depends_patch bin:xz:xz'"]
+                    }}
+                default {command_exec patch "" "< '$patch'"}
+            }
+            write_statefile patch $pfile $target_state_fd
+        } else {
+            ui_info "$UI_PREFIX [format [msgcat::mc "Skipping already applied %s"] $pfile]"
         }
     }
     return 0

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1878,7 +1878,11 @@ proc get_statefile_value {class fd result} {
 
 # check_statefile
 # Check completed/selected state of target/variant $name
-proc check_statefile {class name fd} {
+proc check_statefile {class name {fd {}}} {
+    global target_state_fd
+    if {$fd eq {} && [info exists target_state_fd]} {
+        set fd $target_state_fd
+    }
     seek $fd 0
     while {[gets $fd line] >= 0} {
         if {$line eq "$class: $name"} {
@@ -1890,7 +1894,11 @@ proc check_statefile {class name fd} {
 
 # write_statefile
 # Set target $name completed in the state file
-proc write_statefile {class name fd} {
+proc write_statefile {class name {fd {}}} {
+    global target_state_fd
+    if {$fd eq {} && [info exists target_state_fd]} {
+        set fd $target_state_fd
+    }
     if {[check_statefile $class $name $fd]} {
         return 0
     }


### PR DESCRIPTION
Adds a "patch: <patchfile>" line to the statefile and verify this record before applying each subsequent patch. This is a very useful mechanism during port maintenance when some patches have to be rebased; it allows repeated application of `port patch` (or "higher") where only the failing patch has to be reverted and already applied patches are skipped automatically.
    
    Also adds default fd argument to check_statefile and write_statefile in
    portutil.tcl , so that they can be called externally without having to
    reopen the statefile. In that case they will check/write to the current
    statefile descriptor `$target_state_fd`. This will allow to call them
    safely from the patch_main override procedure in the muniversal-1.1 PG.

Notes:
1. Currently the name of the applied patch is taken from the resolved path to the patchfile and so cannot reliably include any form of hierarchical organisation used in the `filespath` directory. Aliasing is thus possible but has never happened to me in the several years that I have been using this mod.
Should the record list the entries as specified in the port's `patchfiles` rather than in `patch_main`'s `patch_list`?

2. A similar modification will have to be made to the `patch_main` override in the `muniversal-1.1` PG. Hence the changes proposed for `check_statefile` and `write_statefile`.

Closes: https://trac.macports.org/ticket/46927