### PR TITLE
cp: NULL-terminate new_argv and use simpler execv instead of execve

### DIFF
--- a/src/programs/cp/cp.c
+++ b/src/programs/cp/cp.c
@@ -5,8 +5,6 @@
 #include <unistd.h>
 #include <sys/errno.h>
 
-extern char **environ;
-
 int main(int argc, char *argv[])
 {
     const char *cp_path = "/bin/cp";
@@ -18,7 +16,7 @@ int main(int argc, char *argv[])
         for (int i = 1; i < argc; i++) {
             new_argv[i+1] = argv[i];
         }
-        execve(cp_path, new_argv, environ);
+        execv(cp_path, new_argv);
     }
     /* something failed */
     perror("cp");

--- a/src/programs/cp/cp.c
+++ b/src/programs/cp/cp.c
@@ -9,11 +9,11 @@ int main(int argc, char *argv[])
 {
     const char *cp_path = "/bin/cp";
     const char *clone_arg = "-c";
-    const char **new_argv = malloc(sizeof(char *) * (argc+1));
+    const char **new_argv = malloc(sizeof(char *) * (argc+2));
     if (new_argv) {
         new_argv[0] = cp_path;
         new_argv[1] = clone_arg;
-        for (int i = 1; i < argc; i++) {
+        for (int i = 1; i <= argc; i++) {
             new_argv[i+1] = argv[i];
         }
         execv(cp_path, new_argv);


### PR DESCRIPTION
This is intended to fix https://trac.macports.org/ticket/70897 but I could not reproduce the problem so I don't know if this fixes it.