### PR TITLE
pextlib1.0: Sort includes, add stdio.h for getline(3) on Linux

### DIFF
--- a/src/pextlib1.0/system.c
+++ b/src/pextlib1.0/system.c
@@ -36,8 +36,8 @@
 #endif
 
 #ifndef __APPLE__
-/* required for fdopen(3)/seteuid(2), among others */
-#define _XOPEN_SOURCE 600
+/* required for fdopen(3)/seteuid(2)/getline(3), among others */
+#define _XOPEN_SOURCE 700
 #endif
 
 #include <tcl.h>
@@ -46,18 +46,19 @@
 #include <paths.h>
 #endif
 
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/resource.h>
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
-#include <limits.h>
-#include <errno.h>
-#include <signal.h>
 
 #include "system.h"
 #include "Pextlib.h"


### PR DESCRIPTION
Linux requires stdio.h for getline(3), and fails without it. We ship a getline.h compat implementation, but that doesn't get included unless HAVE_GETLINE isn't defined, which isn't the case on Linux.