### PR TITLE
port1.0: Allow accessing clonebin in trace mode

### DIFF
--- a/src/port1.0/port_autoconf.tcl.in
+++ b/src/port1.0/port_autoconf.tcl.in
@@ -79,4 +79,5 @@ namespace eval portutil::autoconf {
 	variable prefix "@prefix_expanded@"
 	variable tcl_package_path "@TCL_PACKAGE_PATH@"
 	variable trace_sipworkaround_path "@DARWINTRACE_SIP_WORKAROUND_PATH@"
+	variable clonebin_path "@CLONEBIN_PATH@"
 }

--- a/src/port1.0/porttrace.tcl
+++ b/src/port1.0/porttrace.tcl
@@ -266,6 +266,8 @@ namespace eval porttrace {
 
         # Grant access to the directory we use to mirror binaries under SIP
         allow trace_sandbox ${portutil::autoconf::trace_sipworkaround_path}
+        # Grant access to MacPorts' clonebin utilities
+        allow trace_sandbox ${portutil::autoconf::clonebin_path}
         # Defer back to MacPorts for dependency checks inside $prefix. This must be at the end,
         # or it'll be used instead of more specific rules.
         ask trace_sandbox $prefix


### PR DESCRIPTION
Access would previously be allowed, too, because these files are not installed by a MacPorts port. They did generate a warning, though, which is not necessary. Adding an explicit whitelist entry silences them.