### PR TITLE
programs/cp: Fix pointer cast warning

### DIFF
--- a/src/programs/cp/cp.c
+++ b/src/programs/cp/cp.c
@@ -2,15 +2,16 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#include <string.h>
 #include <sys/errno.h>
+#include <unistd.h>
 
 int main(int argc, char *argv[])
 {
-    const char *cp_path = "/bin/cp";
-    const char *clone_arg = "-c";
-    const char **new_argv = malloc(sizeof(char *) * (argc+2));
-    if (new_argv) {
+    char *cp_path = strdup("/bin/cp");
+    char *clone_arg = strdup("-c");
+    char **new_argv = malloc(sizeof(char *) * (argc+2));
+    if (cp_path && clone_arg && new_argv) {
         new_argv[0] = cp_path;
         new_argv[1] = clone_arg;
         for (int i = 1; i <= argc; i++) {


### PR DESCRIPTION
`execve()` expects the args to be in writable memory, so copy them using `strdup(3)`.