### PR TITLE
Remove warning for "platforms darwin"

### DIFF
--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -269,10 +269,6 @@ proc portlint::lint_platforms {platforms} {
         }
     }
 
-    if {$platforms eq "darwin"} {
-        lappend warnings "Unnecessary platforms line as darwin is the default"
-    }
-
     return [list $errors $warnings]
 }
 


### PR DESCRIPTION
* Warning is not necessary and creates unnecessary work.
* Closes: https://trac.macports.org/ticket/70997