### PR TITLE
Do not lint platforms for default on subports

### DIFF
--- a/src/port1.0/portlint.tcl
+++ b/src/port1.0/portlint.tcl
@@ -260,7 +260,7 @@ proc portlint::lint_platforms {platforms} {
     set errors [list]
     set warnings [list]
 
-    global lint_platforms
+    global lint_platforms subport name
 
     foreach platform $platforms {
         set platname [lindex $platform 0]
@@ -269,7 +269,7 @@ proc portlint::lint_platforms {platforms} {
         }
     }
 
-    if {$platforms eq "darwin"} {
+    if {$platforms eq "darwin" && [string equal -nocase $name $subport]} {
         lappend warnings "Unnecessary platforms line as darwin is the default"
     }
 

--- a/src/port1.0/tests/portlint.test
+++ b/src/port1.0/tests/portlint.test
@@ -649,6 +649,8 @@ test test_lint_platforms_succeeds_with_darwin_freebsd {
     Verify that platforms is accepted with darwin freebsd
 } -body {
     set platforms "darwin freebsd"
+    set name "test"
+    set subport "test"
     set results [portlint::lint_platforms $platforms]
     set err_results [lindex $results 0]
     set warn_results [lindex $results 1]
@@ -666,6 +668,8 @@ test test_lint_platforms_succeeds_with_freebsd {
     Verify that platforms is accepted with freebsd
 } -body {
     set platforms "freebsd"
+    set name "test"
+    set subport "test"
     set results [portlint::lint_platforms $platforms]
     set err_results [lindex $results 0]
     set warn_results [lindex $results 1]
@@ -683,6 +687,8 @@ test test_lint_platforms_fails_with_msdos {
     Verify that platforms fails with msdos as this is unknown
 } -body {
     set platforms "msdos"
+    set name "test"
+    set subport "test"
     set results [portlint::lint_platforms $platforms]
     set err_results [lindex $results 0]
     set warn_results [lindex $results 1]
@@ -700,6 +706,8 @@ test test_lint_platforms_fails_with_darwin {
     Verify that platforms fails with darwin as this is the default
 } -body {
     set platforms "darwin"
+    set name "test"
+    set subport "test"
     set results [portlint::lint_platforms $platforms]
     set err_results [lindex $results 0]
     set warn_results [lindex $results 1]
@@ -712,5 +720,24 @@ test test_lint_platforms_fails_with_darwin {
     }
     return "lint_platforms_darwin_fails passed"
 } -result "lint_platforms_darwin_fails passed"
+
+test test_lint_platforms_succeeds_with_subports {
+    Verify that platforms succeeds with subports
+} -body {
+    set platforms "darwin"
+    set name "test"
+    set subport "subport"
+    set results [portlint::lint_platforms $platforms]
+    set err_results [lindex $results 0]
+    set warn_results [lindex $results 1]
+
+    if {[llength $warn_results] > 0} {
+        return "FAIL: unexpected error results"
+    }
+    if {[llength $err_results] > 0} {
+        return "FAIL: unexpected error results"
+    }
+    return "test_lint_platforms_succeeds_with_subports passed"
+} -result "test_lint_platforms_succeeds_with_subports passed"
 
 cleanupTests


### PR DESCRIPTION
The check that platforms isn't equal to darwin is not performed on a subport as there is a specific logic for subports.

Closes: https://trac.macports.org/ticket/70997