### PR TITLE
base: add new config 'indexjobs', controlling portindex threads

### DIFF
--- a/doc/macports.conf.5
+++ b/doc/macports.conf.5
@@ -301,6 +301,21 @@ T}
 .sp 1
 .RE
 .PP
+indexjobs
+.RS 4
+Number of threads to use when indexing ports\&. 0 is a special value meaning "the number of CPU cores\&."
+.TS
+tab(:);
+lt lt.
+T{
+\fBDefault:\fR
+T}:T{
+0
+T}
+.TE
+.sp 1
+.RE
+.PP
 portautoclean
 .RS 4
 Automatic cleaning of the build directory of a given port after it has been installed\&.

--- a/doc/macports.conf.5.txt
+++ b/doc/macports.conf.5.txt
@@ -113,6 +113,11 @@ buildmakejobs::
     physical memory plus one, whichever is less."
     *Default:*;; 0
 
+indexjobs::
+    Number of threads to use when indexing ports. 0 is a special value meaning
+    "the number of CPU cores."
+    *Default:*;; 0
+
 portautoclean::
     Automatic cleaning of the build directory of a given port after it has been
     installed.

--- a/doc/macports.conf.in
+++ b/doc/macports.conf.in
@@ -127,6 +127,11 @@ variants_conf       	@MPCONFIGDIR_EXPANDED@/variants.conf
 # - gigabytes of physical memory + 1
 #buildmakejobs       	0
 
+# Number of threads to use when indexing ports. If set
+# to 0, the number of threads will be the number of
+# automatically-detected CPU cores
+#indexjobs       	0
+
 # umask value to use when a port installs its files.
 #destroot_umask      	022
 

--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -211,7 +211,7 @@ proc init_threads {} {
         append worker_init_script \
             [list set oldmtime $oldmtime] \n
     }
-    set maxjobs [macports::get_parallel_jobs no]
+    set maxjobs [macports::get_index_jobs]
     set poolid [tpool::create -minworkers 1 -maxworkers $maxjobs -initcmd $worker_init_script]
     set pending_jobs [dict create]
     set nextjobnum 0


### PR DESCRIPTION
Notes:
- The name for the new config option is arbitrary, and can be changed to whatever folks prefer.
- No new tests are included yet, but I'd be happy to add those if there's interest.

Eases:
- [Ticket 69781 - portindex: multi-threading appears bottlenecked for 10.13, 10.12, and perhaps earlier](https://trac.macports.org/ticket/69781)

Fixes:
- [Ticket 71711 - portindex: allow thread count override via new macports.conf property](https://trac.macports.org/ticket/71711)