### PR TITLE
portutil: fix link in the warning message for macOS <10.9

### DIFF
--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -3420,7 +3420,7 @@ proc _check_xcode_version {} {
                     ui_warn "You can install them as part of the Xcode Command Line Tools package by running `xcode-select --install'."
                 } else {
                     ui_warn "You can install them as part of the Xcode Command Line Tools package from Xcode's Preferences in the Downloads section."
-                    ui_warn "See https://guide.macports.org/chunked/installing.xcode.html#installing.xcode.lion.43 for more information."
+                    ui_warn "See https://guide.macports.org/#installing.xcode.lion.43 for more information."
                 }
             }
 


### PR DESCRIPTION
<img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/bd09220b-c8ce-41aa-8bf6-d74594f235ee" />
