### PR TITLE
Restore non-error if 'outdated' expands to nothing

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -4704,6 +4704,11 @@ proc macports::upgrade_multi {portnames argdict options} {
     #    registry::entry close $i
     #}
 
+    if {[llength $portnames] == 0} {
+        ui_info "Nothing to upgrade."
+        return 0
+    }
+
     # stop upgrade from being called via mportexec as well
     set orig_nodeps yes
     if {![info exists global_options(ports_nodeps)]} {


### PR DESCRIPTION
'sudo port upgrade outdated' specifically printed "Nothing to upgrade" due to a special case in port/port.tcl. A recent change using macports::upgrade_multi broke this, and now causes an error because $status is never set (the loop never runs).

Fix this by handling the empty portnames case explicitly and restore the previous message.