### PR TITLE
port: add 'prefix' action to display the configured prefix

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -64,6 +64,7 @@ MAN1=	\
 		port-patch.1 \
 		port-pkg.1 \
 		port-platform.1 \
+		port-prefix.1 \
 		port-provides.1 \
 		port-quit.1 \
 		port-rdependents.1 \

--- a/doc/port-prefix.1
+++ b/doc/port-prefix.1
@@ -1,0 +1,48 @@
+'\" t
+.TH "PORT\-PREFIX" "1" "2\&.12\&.99" "MacPorts 2\&.12\&.99" "MacPorts Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+port-prefix \- Print the prefix for which MacPorts was configured
+.SH "SYNOPSIS"
+.sp
+.nf
+\fBport\fR \fBprefix\fR
+.fi
+.SH "DESCRIPTION"
+.sp
+This command prints the installation prefix of your MacPorts installation, i\&.e\&., the directory under which MacPorts and all ports are installed\&. The prefix is set at configure time and defaults to \fI/opt/local\fR\&.
+.SH "GLOBAL OPTIONS"
+.sp
+Please see the section \fBGLOBAL OPTIONS\fR in the \fBport\fR(1) man page for a description of global port options\&.
+.SH "SEE ALSO"
+.sp
+\fBport\fR(1)
+.SH "AUTHORS"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+(C) 2026 The MacPorts Project
+.fi
+.if n \{\
+.RE
+.\}

--- a/doc/port-prefix.1.txt
+++ b/doc/port-prefix.1.txt
@@ -1,0 +1,28 @@
+// vim: set et sw=4 ts=8 ft=asciidoc tw=80:
+port-prefix(1)
+==============
+
+NAME
+----
+port-prefix - Print the prefix for which MacPorts was configured
+
+SYNOPSIS
+--------
+[cmdsynopsis]
+*port* *prefix*
+
+DESCRIPTION
+-----------
+This command prints the installation prefix of your MacPorts installation, i.e.,
+the directory under which MacPorts and all ports are installed. The prefix is
+set at configure time and defaults to '/opt/local'.
+
+include::global-flags.txt[]
+
+SEE ALSO
+--------
+man:port[1]
+
+AUTHORS
+-------
+ (C) 2026 The MacPorts Project

--- a/doc/port.1
+++ b/doc/port.1
@@ -1077,6 +1077,11 @@ version
 Display the release number of the installed MacPorts infrastructure\&.
 .RE
 .PP
+prefix
+.RS 4
+Display the prefix for which MacPorts was configured\&.
+.RE
+.PP
 selfupdate
 .RS 4
 Updates the MacPorts system, ports tree(s) and base tools if needed, from the MacPorts rsync server, installing the newest infrastructure available\&.

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -539,6 +539,9 @@ mirror::
 version::
     Display the release number of the installed MacPorts infrastructure.
 
+prefix::
+    Display the prefix for which MacPorts was configured.
+
 selfupdate::
     Updates the MacPorts system, ports tree(s) and base tools if needed, from
     the MacPorts rsync server, installing the newest infrastructure available.

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -2680,6 +2680,13 @@ proc action_platform { action portlist opts } {
 }
 
 
+proc action_prefix { action portlist opts } {
+    global macports::prefix
+    puts ${prefix}
+    return 0
+}
+
+
 proc action_dependents { action portlist opts } {
     if {[require_portlist portlist]} {
         return 1
@@ -4152,6 +4159,7 @@ set action_array [dict create \
     \
     version     [list action_version        [ACTION_ARGS_NONE]] \
     platform    [list action_platform       [ACTION_ARGS_NONE]] \
+    prefix      [list action_prefix         [ACTION_ARGS_NONE]] \
     \
     uninstall   [list action_uninstall      [ACTION_ARGS_PORTS]] \
     \

--- a/src/port1.0/tests/portmain.test
+++ b/src/port1.0/tests/portmain.test
@@ -35,6 +35,10 @@ set portpath .
 set portbuildpath ./build
 set macports::portdbpath .
 
+set test_tclsh [file normalize [file join $macports::autoconf::top_srcdir tests test-tclsh]]
+set port_script [file normalize [file join $pwd .. .. port port.tcl]]
+testConstraint portClientAvailable [expr {[file executable $test_tclsh] && [file readable $port_script]}]
+
 
 test get_default_subport {
     Get default subport unit test.
@@ -58,6 +62,14 @@ test get_subbuildpath {
     }
     return "Get subbuild path successful."
 } -result "Get subbuild path successful."
+
+test action_prefix {
+    `port prefix` prints the configured prefix and nothing else.
+} -constraints {
+    portClientAvailable
+} -body {
+    exec -ignorestderr $test_tclsh $port_script prefix
+} -result $pwd/tmpdir
 
 
 cleanupTests


### PR DESCRIPTION
Adds a new `port prefix` command that prints the installation prefix MacPorts was configured with. Follows the same pattern as `port version` and `port platform`. Quiet mode (-q) suppresses the "Prefix: " label.

Also adds a dedicated port-prefix(1) man page and registers it in the doc build system.

Closes: https://trac.macports.org/ticket/72961