### PR TITLE
port, portindex: add portgroups as a searchable field and selector

### DIFF
--- a/doc/port-info.1
+++ b/doc/port-info.1
@@ -26,17 +26,19 @@ port-info \- Return information about the given ports\&.
 .nf
 \fBport\fR [\fB\-q\fR] [\fB\-D\fR \fIportdir\fR] \fBinfo\fR
      [\-\-categories|\-\-category] [\-\-conflicts] [\-\-depends] [\-\-depends_fetch]
-     [\-\-depends_extract] [\-\-depends_build] [\-\-depends_lib] [\-\-depends_run]
+     [\-\-depends_extract] [\-\-depends_patch] [\-\-depends_build] [\-\-depends_lib]
+     [\-\-depends_run] [\-\-depends_test]
      [\-\-description] [\-\-epoch] [\-\-fullname] [\-\-heading] [\-\-homepage] [\-\-index]
      [\-\-license] [\-\-line] [\-\-long_description] [\-\-maintainer|\-\-maintainers]
-     [\-\-name] [\-\-patchfiles] [\-\-platform|\-\-platforms] [\-\-portdir] [\-\-pretty]
+     [\-\-name] [\-\-patchfiles] [\-\-platform|\-\-platforms] [\-\-portdir]
+     [\-\-portgroup|\-\-portgroups] [\-\-pretty]
      [\-\-replaced_by] [\-\-revision] [\-\-subports] [\-\-variant|\-\-variants]
      [\-\-version]
      [[\fIportname\fR | \fIpseudo\-portname\fR | \fIport\-expressions\fR | \fIport\-url\fR]]
 .fi
 .SH "DESCRIPTION"
 .sp
-\fBport info\fR prints information about the given ports\&. Specifying at least one of the options limits the output to the corresponding field\&. If no fields are specified, a useful default set consisting of name, epoch, version, revision, categories, replaced_by, variants, description, homepage, dependencies, platforms, license, and maintainers is shown\&.
+\fBport info\fR prints information about the given ports\&. Specifying at least one of the options limits the output to the corresponding field\&. If no fields are specified, a useful default set consisting of name, epoch, version, revision, categories, replaced_by, variants, description, homepage, dependencies, portgroups, platforms, license, and maintainers is shown\&.
 .SH "OPTIONS"
 .sp
 The following options do not select fields for the output but change how the information is obtained or formatted:
@@ -69,7 +71,7 @@ List the categories of a port\&.
 List other ports that cannot be active at the same time as the given port\&.
 .RE
 .PP
-\fB\-\-depends\fR, \fB\-\-depends_fetch\fR, \fB\-\-depends_extract\fR, \fB\-\-depends_build\fR, \fB\-\-depends_lib\fR, \fB\-\-depends_run\fR
+\fB\-\-depends\fR, \fB\-\-depends_fetch\fR, \fB\-\-depends_extract\fR, \fB\-\-depends_patch\fR, \fB\-\-depends_build\fR, \fB\-\-depends_lib\fR, \fB\-\-depends_run\fR, \fB\-\-depends_test\fR
 .RS 4
 List the specified dependencies of a port\&.
 \fB\-\-depends\fR
@@ -135,6 +137,11 @@ List the platforms supported by a port\&. This field exists for historical reaso
 \fB\-\-portdir\fR
 .RS 4
 Print the path to a port\(cqs directory relative to the port tree root\&.
+.RE
+.PP
+\fB\-\-portgroup\fR, \fB\-\-portgroups\fR
+.RS 4
+List the PortGroups used by a port, including their versions\&.
 .RE
 .PP
 \fB\-\-replaced_by\fR

--- a/doc/port-info.1.txt
+++ b/doc/port-info.1.txt
@@ -11,10 +11,12 @@ SYNOPSIS
 [cmdsynopsis]
 *port* [*-q*] [*-D* 'portdir'] *info*
      [--categories|--category] [--conflicts] [--depends] [--depends_fetch]
-     [--depends_extract] [--depends_build] [--depends_lib] [--depends_run]
+     [--depends_extract] [--depends_patch] [--depends_build] [--depends_lib]
+     [--depends_run] [--depends_test]
      [--description] [--epoch] [--fullname] [--heading] [--homepage] [--index]
      [--license] [--line] [--long_description] [--maintainer|--maintainers]
-     [--name] [--patchfiles] [--platform|--platforms] [--portdir] [--pretty]
+     [--name] [--patchfiles] [--platform|--platforms] [--portdir]
+     [--portgroup|--portgroups] [--pretty]
      [--replaced_by] [--revision] [--subports] [--variant|--variants]
      [--version]
      [['portname' | 'pseudo-portname' | 'port-expressions' | 'port-url']]
@@ -25,7 +27,7 @@ DESCRIPTION
 the options limits the output to the corresponding field. If no fields are
 specified, a useful default set consisting of name, epoch, version, revision,
 categories, replaced_by, variants, description, homepage, dependencies,
-platforms, license, and maintainers is shown.
+portgroups, platforms, license, and maintainers is shown.
 
 OPTIONS
 -------
@@ -52,7 +54,7 @@ The rest of the options affect which fields will be given in the output:
 *--conflicts*::
     List other ports that cannot be active at the same time as the given port.
 
-*--depends*, *--depends_fetch*, *--depends_extract*, *--depends_build*, *--depends_lib*, *--depends_run*::
+*--depends*, *--depends_fetch*, *--depends_extract*, *--depends_patch*, *--depends_build*, *--depends_lib*, *--depends_run*, *--depends_test*::
     List the specified dependencies of a port. *--depends* is a shorthand option
     for all other *--depends_** options.
 
@@ -92,6 +94,9 @@ The rest of the options affect which fields will be given in the output:
 
 *--portdir*::
     Print the path to a port's directory relative to the port tree root.
+
+*--portgroup*, *--portgroups*::
+    List the PortGroups used by a port, including their versions.
 
 *--replaced_by*::
     List the name of the port that replaces a port, if any.

--- a/doc/port-search.1
+++ b/doc/port-search.1
@@ -134,6 +134,33 @@ in the name, but not the description\&.
 Test the search string against the path of the directory that contains the port\&.
 .RE
 .PP
+\fB\-\-portgroup\fR, \fB\-\-portgroups\fR
+.RS 4
+Search for ports that use a given PortGroup\&. The pattern has the optional form
+\fINAME@VERSION\fR, where either half may be omitted\&. For example,
+\fBport search \-\-portgroup python\fR
+prints all ports using any version of the python PortGroup, while
+\fBport search \-\-portgroup python@1\&.0\fR
+restricts the match to ports using version 1\&.0 of that PortGroup\&. The form
+\fB\-\-portgroup @1\&.0\fR
+matches any PortGroup whose version is 1\&.0\&.
+.sp
+The pattern on each side of the
+\fI@\fR
+is interpreted according to the selected matching style (\fB\-\-glob\fR
+by default, or
+\fB\-\-exact\fR,
+\fB\-\-regex\fR)\&. Unlike other fields, matching is performed against each portgroup entry individually rather than against the serialized list, so
+\fB\-\-exact \-\-portgroup python\fR
+works as expected\&.
+.sp
+There is also a pseudo\-portname selector
+\fBportgroup:python\fR
+available for use with
+\fBport-echo\fR(1)
+and other commands\&.
+.RE
+.PP
 \fB\-\-variant\fR, \fB\-\-variants\fR
 .RS 4
 Search for variant names\&.

--- a/doc/port-search.1.txt
+++ b/doc/port-search.1.txt
@@ -98,6 +98,23 @@ Field selection
     Test the search string against the path of the directory that contains the
     port.
 
+*--portgroup*, *--portgroups*::
+    Search for ports that use a given PortGroup. The pattern has the optional
+    form 'NAME@VERSION', where either half may be omitted. For example, *port
+    search --portgroup python* prints all ports using any version of the
+    python PortGroup, while *port search --portgroup pass:[python@1.0]*
+    restricts the match to ports using version 1.0 of that PortGroup. The
+    form *--portgroup @1.0* matches any PortGroup whose version is 1.0.
++
+The pattern on each side of the '@' is interpreted according to the selected
+matching style (*--glob* by default, or *--exact*, *--regex*). Unlike other
+fields, matching is performed against each portgroup entry individually rather
+than against the serialized list, so *--exact --portgroup python* works as
+expected.
++
+There is also a pseudo-portname selector *portgroup:python* available for use
+with man:port-echo[1] and other commands.
+
 *--variant*, *--variants*::
     Search for variant names.
 

--- a/doc/port.1
+++ b/doc/port.1
@@ -314,6 +314,95 @@ or
 .sp -1
 .IP \(bu 2.3
 .\}
+\fIdepends_lib\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends_build\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends_run\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends_fetch\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends_extract\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends_patch\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends_test\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIdepends\fR
+(shorthand for all depends_* selectors)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 \fIlicense\fR
 .RE
 .sp
@@ -325,7 +414,44 @@ or
 .sp -1
 .IP \(bu 2.3
 .\}
+\fIreplaced_by\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 \fIportdir\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIportgroup\fR
+or
+\fIportgroups\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIsubport\fR
+or
+\fIsubports\fR
 .RE
 .sp
 Other pseudo\-portname selectors match ports which have a particular relationship to another port\&. These will match ports that are direct or recursive dependencies or dependents of the given portname:
@@ -383,6 +509,17 @@ Other pseudo\-portname selectors match ports which have a particular relationshi
 .IP \(bu 2.3
 .\}
 \fIrdependentof\fR
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fIsubportof\fR
 .RE
 .sp
 Search strings that will expand to a set of matching ports can be constructed based on the "\fIpseudo\-portname selector\fR":regex combination used\&. \fIportnames\fR containing valid UNIX glob patterns will also expand to the set of matching ports\&. Any action passed to port will be invoked on each of them\&.

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -73,8 +73,19 @@ matches the given regular expression. Usage is: selector:regex
     - 'description'
     - 'long_description'
     - 'homepage'
+    - 'depends_lib'
+    - 'depends_build'
+    - 'depends_run'
+    - 'depends_fetch'
+    - 'depends_extract'
+    - 'depends_patch'
+    - 'depends_test'
+    - 'depends' (shorthand for all depends_* selectors)
     - 'license'
+    - 'replaced_by'
     - 'portdir'
+    - 'portgroup' or 'portgroups'
+    - 'subport' or 'subports'
 
 Other pseudo-portname selectors match ports which have a particular
 relationship to another port. These will match ports that are direct or
@@ -86,6 +97,7 @@ recursive dependencies or dependents of the given portname:
     - 'rdepends'
     - 'dependentof'
     - 'rdependentof'
+    - 'subportof'
 
 Search strings that will expand to a set of matching ports can be constructed
 based on the "'pseudo-portname selector'":regex combination used. 'portnames'

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -4108,6 +4108,82 @@ proc mportsync {{options {}}} {
 }
 
 ##
+# Compare a single string against a pattern using the given matchstyle.
+# An empty \a pattern is treated as "match anything" and returns 1.
+#
+# @param pattern The pattern to match against. Empty string matches anything.
+# @param str The string to test.
+# @param matchstyle One of \c exact, \c glob, or \c regexp.
+# @param case_sensitive boolean; "yes"/1 for case-sensitive, "no"/0 otherwise.
+# @return 1 on match, 0 otherwise.
+proc macports::_test_pattern {pattern str matchstyle case_sensitive} {
+    if {$pattern eq ""} {
+        return 1
+    }
+    switch -- $matchstyle {
+        exact {
+            if {$case_sensitive} {
+                return [string equal $pattern $str]
+            }
+            return [string equal -nocase $pattern $str]
+        }
+        glob {
+            if {$case_sensitive} {
+                return [string match $pattern $str]
+            }
+            return [string match -nocase $pattern $str]
+        }
+        regexp {
+            if {$case_sensitive} {
+                return [regexp -- $pattern $str]
+            }
+            return [regexp -nocase -- $pattern $str]
+        }
+    }
+    return -code error "_test_pattern: Unsupported matching style: ${matchstyle}."
+}
+
+##
+# Test whether any portgroup entry in \a entries matches \a pattern.
+#
+# Portgroup entries in the PortIndex are stored as {name version} lists. The
+# caller's \a pattern may be split on a \c @ delimiter into an optional name
+# portion and an optional version portion (either half may be empty). A
+# portgroup entry matches when its name matches the name-pattern AND its
+# version matches the version-pattern (the AND is under a single matchstyle;
+# empty halves match unconditionally). The split is on the last \c @ so that
+# patterns like \c foo@1.0 match a name of \c foo and version of \c 1.0.
+#
+# This per-entry matching is what makes \c "port search --portgroup python"
+# find all ports that use the python PortGroup of any version, while
+# \c "--portgroup python@1.0" filters to that specific version.
+#
+# @param pattern The user-supplied pattern, optionally containing an \c @
+#                separator.
+# @param entries The \c portgroups value from a PortIndex entry, a list of
+#                \c {name version} pairs.
+# @param matchstyle One of \c exact, \c glob, or \c regexp.
+# @param case_sensitive boolean.
+# @return 1 if any entry matches, 0 otherwise.
+proc macports::_test_portgroups_match {pattern entries matchstyle case_sensitive} {
+    set at_idx [string last @ $pattern]
+    if {$at_idx >= 0} {
+        set name_pat [string range $pattern 0 $at_idx-1]
+        set version_pat [string range $pattern $at_idx+1 end]
+    } else {
+        set name_pat $pattern
+        set version_pat ""
+    }
+    foreach pg $entries {
+        if {[_test_pattern $name_pat [lindex $pg 0] $matchstyle $case_sensitive]
+                && [_test_pattern $version_pat [lindex $pg 1] $matchstyle $case_sensitive]} {
+            return 1
+        }
+    }
+    return 0
+}
+
+##
 # Searches all configured port sources for a given pattern in a given field
 # using a given matching style and optional case-sensitivity.
 #
@@ -4139,6 +4215,8 @@ proc mportsync {{options {}}} {
 #                \li \c revision
 #                \li \c replaced_by
 #                \li \c installs_libs
+#                \li \c portgroups (matched per-entry; \a pattern may be of
+#                    the form \c NAME@VERSION where either half may be empty)
 # @return a list where each even index (starting with 0) contains the name of
 #         a matching port. Each entry at an odd index is followed by its
 #         corresponding line from the portindex, which can be passed to
@@ -4173,31 +4251,40 @@ proc mportsearch {pattern {case_sensitive yes} {matchstyle regexp} {field name}}
                         set target [dict get $portinfo $field]
                     }
 
-                    switch -- $matchstyle {
-                        exact {
-                            if {$case_sensitive} {
-                                set compres [string compare $pattern $target]
-                            } else {
-                                set compres [string compare -nocase $pattern $target]
+                    if {$field eq "portgroups"} {
+                        # Match per-entry so users can write --portgroup NAME
+                        # to find all ports using any version of that
+                        # PortGroup, or --portgroup NAME@VERSION to filter
+                        # further.
+                        set matchres [macports::_test_portgroups_match \
+                            $pattern $target $matchstyle $case_sensitive]
+                    } else {
+                        switch -- $matchstyle {
+                            exact {
+                                if {$case_sensitive} {
+                                    set compres [string compare $pattern $target]
+                                } else {
+                                    set compres [string compare -nocase $pattern $target]
+                                }
+                                set matchres [expr {0 == $compres}]
                             }
-                            set matchres [expr {0 == $compres}]
-                        }
-                        glob {
-                            if {$case_sensitive} {
-                                set matchres [string match $pattern $target]
-                            } else {
-                                set matchres [string match -nocase $pattern $target]
+                            glob {
+                                if {$case_sensitive} {
+                                    set matchres [string match $pattern $target]
+                                } else {
+                                    set matchres [string match -nocase $pattern $target]
+                                }
                             }
-                        }
-                        regexp {
-                            if {$case_sensitive} {
-                                set matchres [regexp -- $pattern $target]
-                            } else {
-                                set matchres [regexp -nocase -- $pattern $target]
+                            regexp {
+                                if {$case_sensitive} {
+                                    set matchres [regexp -- $pattern $target]
+                                } else {
+                                    set matchres [regexp -nocase -- $pattern $target]
+                                }
                             }
-                        }
-                        default {
-                            return -code error "mportsearch: Unsupported matching style: ${matchstyle}."
+                            default {
+                                return -code error "mportsearch: Unsupported matching style: ${matchstyle}."
+                            }
                         }
                     }
 
@@ -7461,6 +7548,17 @@ proc macports::shellescape {arg} {
 # @return A list of associative arrays in serialized list format
 proc macports::unobscure_maintainers {list} {
     return [macports_util::unobscure_maintainers $list]
+}
+
+# Strip the filepath from live-parsed portgroup entries, keeping only
+# {name version}. The portgroups field from a live Portfile parse has
+# entries of the form {name version groupFile}; only name and version
+# are meaningful for PortIndex storage and user-facing display.
+#
+# @param entries A list of portgroup entries in {name version ?groupFile?} form
+# @return A list of portgroup entries in {name version} form
+proc macports::strip_portgroup_filepath {entries} {
+    return [lmap pg $entries {lrange $pg 0 1}]
 }
 
 # Get actual number of parallel jobs based on buildmakejobs, which may

--- a/src/macports1.0/tests/macports.test
+++ b/src/macports1.0/tests/macports.test
@@ -938,7 +938,145 @@ test GetVCSUpdateCmd-none {
 
 # test updatevcs
 # test mportsync
-# test mportsearch
+
+test mportsearch_portgroups {
+    Test mportsearch with portgroups field.
+
+    Exercises both the legacy glob semantics ("*name*" patterns against the
+    portgroups field, which is what action_search auto-wildcards into) and
+    the new per-entry matching (exact name match, NAME@VERSION filtering,
+    version-only filtering) that mportsearch now performs when searching
+    the portgroups field.
+} -setup {
+    # Create a temporary source directory with a crafted PortIndex. Include
+    # multiple ports using different versions of the same PortGroup so that
+    # we can exercise the NAME@VERSION filter.
+    set tmpdir [makeDirectory mportsearch_test_source $pwd/tmpdir]
+    set portinfo1 {description {A test port} portgroups {{python 1.0} {github 1.0}} homepage https://example.com epoch 0 platforms darwin name testport1 maintainers nomaintainer license MIT long_description {A test port} categories devel version 1.0 revision 0 portdir test/testport1}
+    set portinfo2 {description {Another test port} portgroups {{golang 1.0}} homepage https://example.com epoch 0 platforms darwin name testport2 maintainers nomaintainer license BSD long_description {Another test port} categories net version 2.0 revision 0 portdir test/testport2}
+    set portinfo3 {description {Port without portgroups} homepage https://example.com epoch 0 platforms darwin name testport3 maintainers nomaintainer license GPL-2 long_description {Port without portgroups} categories sysutils version 3.0 revision 0 portdir test/testport3}
+    set portinfo4 {description {Newer python port} portgroups {{python 1.1}} homepage https://example.com epoch 0 platforms darwin name testport4 maintainers nomaintainer license MIT long_description {Newer python port} categories devel version 1.0 revision 0 portdir test/testport4}
+    set portinfo5 {description {Newest python port} portgroups {{python 2.0}} homepage https://example.com epoch 0 platforms darwin name testport5 maintainers nomaintainer license MIT long_description {Newest python port} categories devel version 1.0 revision 0 portdir test/testport5}
+
+    set fd [open $tmpdir/PortIndex w]
+    puts $fd "testport1 [expr {[string length $portinfo1] + 1}]"
+    puts $fd $portinfo1
+    puts $fd "testport2 [expr {[string length $portinfo2] + 1}]"
+    puts $fd $portinfo2
+    puts $fd "testport3 [expr {[string length $portinfo3] + 1}]"
+    puts $fd $portinfo3
+    puts $fd "testport4 [expr {[string length $portinfo4] + 1}]"
+    puts $fd $portinfo4
+    puts $fd "testport5 [expr {[string length $portinfo5] + 1}]"
+    puts $fd $portinfo5
+    close $fd
+
+    # Save original sources and set up test source
+    set save_sources $macports::sources
+    set save_prefix_map $macports::porturl_prefix_map
+    set macports::sources [list "file://${tmpdir}"]
+    dict set macports::porturl_prefix_map "file://${tmpdir}" "file://${tmpdir}"
+
+    # Helper: return the sorted list of port names from an mportsearch result.
+    proc _names {results} {
+        set names [list]
+        foreach {name info} $results {
+            lappend names $name
+        }
+        return [lsort $names]
+    }
+} -body {
+    # --- Legacy glob semantics: "*name*" pattern, as produced by auto-
+    # wildcarding in action_search, should still match by portgroup name.
+    set names [_names [mportsearch "*python*" no glob portgroups]]
+    if {$names ne {testport1 testport4 testport5}} {
+        return "FAIL: glob '*python*' expected testport1/4/5, got $names"
+    }
+
+    set names [_names [mportsearch "*golang*" no glob portgroups]]
+    if {$names ne {testport2}} {
+        return "FAIL: glob '*golang*' expected testport2, got $names"
+    }
+
+    set names [_names [mportsearch "*github*" no glob portgroups]]
+    if {$names ne {testport1}} {
+        return "FAIL: glob '*github*' expected testport1, got $names"
+    }
+
+    set names [_names [mportsearch "*nonexistent*" no glob portgroups]]
+    if {$names ne {}} {
+        return "FAIL: glob '*nonexistent*' expected no matches, got $names"
+    }
+
+    # --- New exact name-match semantics: a bare portgroup name should
+    # match every port that uses that portgroup, regardless of version.
+    set names [_names [mportsearch python no exact portgroups]]
+    if {$names ne {testport1 testport4 testport5}} {
+        return "FAIL: exact 'python' expected testport1/4/5, got $names"
+    }
+
+    set names [_names [mportsearch github no exact portgroups]]
+    if {$names ne {testport1}} {
+        return "FAIL: exact 'github' expected testport1, got $names"
+    }
+
+    # --- NAME@VERSION: restrict to a specific portgroup version.
+    set names [_names [mportsearch python@1.0 no exact portgroups]]
+    if {$names ne {testport1}} {
+        return "FAIL: exact 'python@1.0' expected testport1, got $names"
+    }
+
+    set names [_names [mportsearch python@1.1 no exact portgroups]]
+    if {$names ne {testport4}} {
+        return "FAIL: exact 'python@1.1' expected testport4, got $names"
+    }
+
+    set names [_names [mportsearch python@2.0 no exact portgroups]]
+    if {$names ne {testport5}} {
+        return "FAIL: exact 'python@2.0' expected testport5, got $names"
+    }
+
+    set names [_names [mportsearch python@9.9 no exact portgroups]]
+    if {$names ne {}} {
+        return "FAIL: exact 'python@9.9' expected no matches, got $names"
+    }
+
+    # --- @VERSION-only: match any portgroup whose version is given.
+    set names [_names [mportsearch @1.0 no exact portgroups]]
+    if {$names ne {testport1 testport2}} {
+        return "FAIL: exact '@1.0' expected testport1/2, got $names"
+    }
+
+    # --- Regression guard: a bare version number should NOT match every
+    # port as it did under the old serialized-list matching (which would
+    # match '1.0' against 'python 1.0 github 1.0').
+    set names [_names [mportsearch 1.0 no exact portgroups]]
+    if {$names ne {}} {
+        return "FAIL: exact '1.0' should not match any portgroup name, got $names"
+    }
+
+    # --- NAME@VERSION under glob matchstyle with wildcards on each half,
+    # as action_search emits when the user types --portgroup python@1 on
+    # the command line.
+    set names [_names [mportsearch "*python*@*1.0*" no glob portgroups]]
+    if {$names ne {testport1}} {
+        return "FAIL: glob '*python*@*1.0*' expected testport1, got $names"
+    }
+
+    set names [_names [mportsearch "*python*@*1*" no glob portgroups]]
+    if {$names ne {testport1 testport4}} {
+        return "FAIL: glob '*python*@*1*' expected testport1/4, got $names"
+    }
+
+    return "mportsearch portgroups successful."
+} -cleanup {
+    set macports::sources $save_sources
+    set macports::porturl_prefix_map $save_prefix_map
+    rename _names {}
+    file delete -force $tmpdir
+} -result "mportsearch portgroups successful."
+
+
 # test mportlookup
 # test mportlistall
 # test _mports_load_quickindex

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -134,6 +134,7 @@ proc map_friendly_field_names { field } {
         variant -
         platform -
         maintainer -
+        portgroup -
         subport {
             set field "${field}s"
         }
@@ -1160,6 +1161,8 @@ proc element { resname } {
         ^(revision):(.*)         -
         ^(subport):(.*)          -
         ^(subports):(.*)         -
+        ^(portgroup):(.*)        -
+        ^(portgroups):(.*)       -
         ^(license):(.*)          { # Handle special port selectors
             advance
 
@@ -1751,6 +1754,7 @@ proc action_info { action portlist opts } {
             platforms       {", "  ", "  ","}
             variants        {", "  ", "  ","}
             conflicts       {", "  ", "  ","}
+            portgroups      {", "  ", "  ","}
             subports        {", "  ", "  ","}
             patchfiles      {", "  ", "  ","}
         }]
@@ -1774,6 +1778,7 @@ proc action_info { action portlist opts } {
             maintainers Maintainers
             license     License
             conflicts   "Conflicts with"
+            portgroups  "Port Groups"
             replaced_by "Replaced by"
             subports    "Sub-ports"
             patchfiles  "Patchfiles"
@@ -1797,6 +1802,7 @@ proc action_info { action portlist opts } {
             platforms 22
             license 22
             conflicts 22
+            portgroups 22
             maintainers 22
             subports 22
             patchfiles 22
@@ -1889,6 +1895,7 @@ proc action_info { action portlist opts } {
                 ports_info_depends_lib ports_info_depends_run
                 ports_info_depends_test
                 ports_info_conflicts
+                ports_info_portgroups
                 ports_info_platforms ports_info_license
                 ports_info_maintainers
             }
@@ -1946,6 +1953,13 @@ proc action_info { action portlist opts } {
                 if {!$pretty_print} {
                     set inf [string map {"\n" {\n}} $inf]
                 }
+            }
+
+            # Live-parsed portinfo includes the portgroup filepath as a third
+            # element; PortIndex-sourced portinfo is already stripped. Normalize
+            # both sources to {name version} for display.
+            if {$ropt eq "portgroups"} {
+                set inf [macports::strip_portgroup_filepath $inf]
             }
 
             # Add "(" "or" ")" "and" for human-readable output
@@ -3576,12 +3590,41 @@ proc action_search { action portlist opts } {
     foreach portname $portlist {
         puts -nonewline $separator
 
-        set searchstring $portname
+        set searchstring_default $portname
+        # For the portgroups filter the pattern has an optional NAME@VERSION
+        # form. mportsearch splits on @ and matches each half against its
+        # corresponding component of every portgroup entry, so auto-
+        # wildcarding has to be applied to each half independently — a
+        # single *...* wrapper spanning the @ would leak into the opposite
+        # half's match.
+        set searchstring_portgroups $portname
         set matchstyle $filter_matchstyle
         if {$matchstyle eq "none"} {
             # Guess if the given string was a glob expression, if not do a substring search
             if {[string first "*" $portname] == -1 && [string first "?" $portname] == -1} {
-                set searchstring "*$portname*"
+                set searchstring_default "*$portname*"
+            }
+            set at_idx [string last @ $portname]
+            if {$at_idx >= 0} {
+                set name_part [string range $portname 0 $at_idx-1]
+                set version_part [string range $portname $at_idx+1 end]
+            } else {
+                set name_part $portname
+                set version_part ""
+            }
+            set wrapped [list]
+            foreach part [list $name_part $version_part] {
+                if {$part ne "" && [string first "*" $part] == -1
+                        && [string first "?" $part] == -1} {
+                    lappend wrapped "*$part*"
+                } else {
+                    lappend wrapped $part
+                }
+            }
+            if {$at_idx >= 0} {
+                set searchstring_portgroups "[lindex $wrapped 0]@[lindex $wrapped 1]"
+            } else {
+                set searchstring_portgroups [lindex $wrapped 0]
             }
             set matchstyle glob
         }
@@ -3591,6 +3634,12 @@ proc action_search { action portlist opts } {
         foreach opt [dict keys $filters] {
             # Map from friendly name
             set opt [map_friendly_field_names $opt]
+
+            if {$opt eq "portgroups"} {
+                set searchstring $searchstring_portgroups
+            } else {
+                set searchstring $searchstring_default
+            }
 
             if {[catch {set matches [mportsearch $searchstring $filter_case $matchstyle $opt]} result]} {
                 ui_debug $::errorInfo
@@ -4276,6 +4325,7 @@ set cmd_opts_array [dict create {*}{
                  depends description epoch fullname heading homepage index license
                  line long_description
                  maintainer maintainers name patchfiles platform platforms portdir
+                 portgroup portgroups
                  pretty replaced_by revision subports variant variants version}
     contents    {size {units 1}}
     deps        {index no-build no-test}
@@ -4286,7 +4336,8 @@ set cmd_opts_array [dict create {*}{
                  depends_build depends_lib depends_run depends_test
                  depends description epoch exact glob homepage line
                  long_description maintainer maintainers name platform
-                 platforms portdir regex revision variant variants version}
+                 platforms portdir portgroup portgroups
+                 regex revision variant variants version}
     selfupdate  {migrate no-sync nosync rsync}
     space       {{units 1} total}
     activate    {no-exec}

--- a/src/port/portindex.tcl
+++ b/src/port/portindex.tcl
@@ -67,6 +67,11 @@ proc _index_from_portinfo {portinfo {is_subport no}} {
         dict set keep_portinfo subports [dict get $portinfo subports]
     }
 
+    if {[dict exists $keep_portinfo portgroups]} {
+        dict set keep_portinfo portgroups \
+            [macports::strip_portgroup_filepath [dict get $keep_portinfo portgroups]]
+    }
+
     set len [expr {[string length $keep_portinfo] + 1}]
     return [list [dict get $portinfo name] $len $keep_portinfo]
 }
@@ -442,7 +447,7 @@ set keepkeys [dict create]
 foreach key {categories depends_fetch depends_extract depends_patch \
              depends_build depends_lib depends_run depends_test \
              description epoch homepage long_description maintainers \
-             name platforms revision variants version portdir \
+             name platforms portgroups revision variants version portdir \
              replaced_by license installs_libs conflicts known_fail} {
     dict set keepkeys $key 1
 }


### PR DESCRIPTION
Enable searching, filtering, and displaying ports by which PortGroups they use. The portgroups field was already populated during port parsing but was not stored in the PortIndex.

- Add portgroups to PortIndex keepkeys, stripping filepath from entries
- Add portgroup:/portgroups: pseudo-portname selector
- Add --portgroup/--portgroups options to port search and port info
- Show Port Groups in default port info output
- Strip filepath from portgroups in port info display (live-parsed data includes filepath, but it is not relevant for display)
- Add mportsearch_portgroups unit test
- Document portgroup selector and options in man pages
- Document previously undocumented selectors: depends_*, replaced_by, subport/subports, subportof

Closes: https://trac.macports.org/ticket/51092