### PR TITLE
port: add 'source' subcommand for managing sources.conf

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -79,6 +79,7 @@ MAN1=	\
 		port-setrequested.1 \
 		port-setunrequested.1 \
 		port-snapshot.1 \
+		port-source.1 \
 		port-space.1 \
 		port-sync.1 \
 		port-test.1 \

--- a/doc/port-source.1
+++ b/doc/port-source.1
@@ -1,0 +1,265 @@
+'\" t
+.TH "PORT\-SOURCE" "1" "2\&.12\&.99" "MacPorts 2\&.12\&.99" "MacPorts Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+port-source \- List, add, remove, and manage MacPorts port tree sources
+.SH "SYNOPSIS"
+.sp
+.nf
+\fBport\fR [\fB\-dv\fR] \fBsource\fR [\-\-list]
+.fi
+.sp
+.nf
+\fBsudo\fR \fBport\fR [\fB\-dv\fR] \fBsource\fR \fB\-\-add\fR [\fB\-\-first\fR] [\fB\-\-no\-sync\fR] [\fB\-\-default\fR] \fIurl\fR
+.fi
+.sp
+.nf
+\fBsudo\fR \fBport\fR [\fB\-dv\fR] \fBsource\fR \fB\-\-remove\fR \fIurl\fR
+.fi
+.sp
+.nf
+\fBsudo\fR \fBport\fR [\fB\-dv\fR] \fBsource\fR \fB\-\-set\-default\fR \fIurl\fR
+.fi
+.sp
+.nf
+\fBsudo\fR \fBport\fR [\fB\-dv\fR] \fBsource\fR \fB\-\-unset\-default\fR \fIurl\fR
+.fi
+.SH "DESCRIPTION"
+.sp
+\fBport source\fR manages the list of port tree sources configured in \fBsources.conf\fR(5)\&. Port tree sources tell MacPorts where to find port definitions (Portfiles)\&.
+.sp
+\fBport source\fR has five modes of operation: listing the currently configured sources, adding a new source, removing an existing source, marking a source as the explicit default, and removing that explicit default flag\&. See \fBOPTIONS\fR below for details\&. Changes made by \fB\-\-add\fR, \fB\-\-remove\fR, \fB\-\-set\-default\fR, and \fB\-\-unset\-default\fR take effect the next time \fBport\fR is invoked\&.
+.sp
+A local directory path beginning with \fI/\fR or \fI~\fR is automatically expanded to a \fIfile://\fR URL by \fB\-\-add\fR, \fB\-\-remove\fR, \fB\-\-set\-default\fR, and \fB\-\-unset\-default\fR, making it convenient to manage local checkouts of the MacPorts ports tree without needing to type the full \fIfile://\fR URL\&. Local paths containing spaces are supported\&. Non\-\fIfile://\fR URLs must already be valid URIs; encode spaces as \fI%20\fR rather than using literal whitespace\&.
+.sp
+Exactly one of \fB\-\-list\fR, \fB\-\-add\fR, \fB\-\-remove\fR, \fB\-\-set\-default\fR, or \fB\-\-unset\-default\fR may be specified at a time\&. The \fB\-\-first\fR, \fB\-\-no\-sync\fR, and \fB\-\-default\fR modifiers are valid only with \fB\-\-add\fR\&.
+.SH "OPTIONS"
+.PP
+\fB\-\-list\fR
+.RS 4
+Print the currently configured sources, one per line, in the same format used by
+\fBsources.conf\fR(5)\&. This is the default when no option is given\&.
+\fB\-\-list\fR
+does not accept a URL argument\&.
+.RE
+.PP
+\fB\-\-add\fR [\fB\-\-first\fR] [\fB\-\-no\-sync\fR] [\fB\-\-default\fR] \fIurl\fR
+.RS 4
+Add
+\fIurl\fR
+to the list of port tree sources\&. If
+\fIurl\fR
+begins with
+\fI/\fR
+or
+\fI~\fR, it is interpreted as a local directory path; it will be normalised and prefixed with
+\fIfile://\fR\&. Local paths with spaces are written literally in the resulting
+\fIfile://\fR
+URL\&.
+.sp
+By default the new source is appended to the end of
+\fBsources.conf\fR(5)\&. Use
+\fB\-\-first\fR
+to insert it before the first existing source entry, which is useful for a local port tree that should shadow the default remote source\&.
+.sp
+Use
+\fB\-\-no\-sync\fR
+to add the
+\fI[nosync]\fR
+flag to the entry, preventing
+\fBport sync\fR
+from attempting to update this source\&. This is recommended for local development checkouts that are managed independently\&. To change the nosync flag on an existing source, remove and re\-add it\&.
+.sp
+Use
+\fB\-\-default\fR
+to add the
+\fI[default]\fR
+flag to the new entry and remove any existing explicit
+\fI[default]\fR
+flag from other source entries\&.
+.sp
+This command requires write access to
+\fBsources.conf\fR(5)
+and must typically be run with
+\fBsudo\fR\&.
+.RE
+.PP
+\fB\-\-remove\fR \fIurl\fR
+.RS 4
+Remove the source with the given URL from
+\fBsources.conf\fR(5)\&. If
+\fIurl\fR
+begins with
+\fI/\fR
+or
+\fI~\fR, it is normalised to a
+\fIfile://\fR
+URL in the same way as
+\fB\-\-add\fR\&. Comments and other entries are preserved\&. For local paths, the directory need not still exist on disk\&. If the removed source was marked
+\fI[default]\fR, a warning is printed; use
+\fB\-\-set\-default\fR
+to explicitly designate another source as the default\&.
+.sp
+This command requires write access to
+\fBsources.conf\fR(5)
+and must typically be run with
+\fBsudo\fR\&.
+.RE
+.PP
+\fB\-\-set\-default\fR \fIurl\fR
+.RS 4
+Mark the given source as the explicit default in
+\fBsources.conf\fR(5)\&. Any existing explicit
+\fI[default]\fR
+flag is removed from the other source entries\&. If
+\fIurl\fR
+begins with
+\fI/\fR
+or
+\fI~\fR, it is normalised in the same way as
+\fB\-\-remove\fR\&.
+.sp
+This command requires write access to
+\fBsources.conf\fR(5)
+and must typically be run with
+\fBsudo\fR\&.
+.RE
+.PP
+\fB\-\-unset\-default\fR \fIurl\fR
+.RS 4
+Remove the explicit
+\fI[default]\fR
+flag from the given source in
+\fBsources.conf\fR(5)\&. If this leaves no explicit default source, MacPorts warns and continues using the last listed source as the effective default\&. If
+\fIurl\fR
+begins with
+\fI/\fR
+or
+\fI~\fR, it is normalised in the same way as
+\fB\-\-remove\fR\&.
+.sp
+This command requires write access to
+\fBsources.conf\fR(5)
+and must typically be run with
+\fBsudo\fR\&.
+.RE
+.SH "GLOBAL OPTIONS"
+.sp
+Please see the section \fBGLOBAL OPTIONS\fR in the \fBport\fR(1) man page for a description of global port options\&.
+.SH "EXAMPLES"
+.sp
+List the currently configured sources:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+port source
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Add a local checkout of the MacPorts ports tree for Portfile development, placing it first so it shadows the default remote source and marking it so that \fBport sync\fR leaves it alone:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+sudo port source \-\-add \-\-first \-\-no\-sync ~/src/macports\-ports
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Add a local checkout first, mark it as the explicit default, and disable sync:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+sudo port source \-\-add \-\-first \-\-no\-sync \-\-default ~/src/macports\-ports
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Add a remote rsync source:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+sudo port source \-\-add rsync://rsync\&.macports\&.org/macports/release/tarballs/ports\&.tar
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Mark an existing source as the explicit default:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+sudo port source \-\-set\-default ~/src/macports\-ports
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Remove a source by path:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+sudo port source \-\-remove ~/src/macports\-ports
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Remove a source by URL:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+sudo port source \-\-remove rsync://rsync\&.macports\&.org/macports/release/tarballs/ports\&.tar
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+\fBport\fR(1), \fBport-sync\fR(1), \fBsources.conf\fR(5)
+.SH "AUTHORS"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+(C) 2025 The MacPorts Project
+.fi
+.if n \{\
+.RE
+.\}

--- a/doc/port-source.1.txt
+++ b/doc/port-source.1.txt
@@ -1,0 +1,154 @@
+// vim: set et sw=4 ts=8 ft=asciidoc tw=80:
+port-source(1)
+==============
+
+NAME
+----
+port-source - List, add, remove, and manage MacPorts port tree sources
+
+SYNOPSIS
+--------
+[cmdsynopsis]
+*port* [*-dv*] *source* [--list]
+
+[cmdsynopsis]
+*sudo* *port* [*-dv*] *source* *--add* [*--first*] [*--no-sync*] [*--default*] 'url'
+
+[cmdsynopsis]
+*sudo* *port* [*-dv*] *source* *--remove* 'url'
+
+[cmdsynopsis]
+*sudo* *port* [*-dv*] *source* *--set-default* 'url'
+
+[cmdsynopsis]
+*sudo* *port* [*-dv*] *source* *--unset-default* 'url'
+
+DESCRIPTION
+-----------
+*port source* manages the list of port tree sources configured in
+man:sources.conf[5]. Port tree sources tell MacPorts where to find port
+definitions (Portfiles).
+
+*port source* has five modes of operation: listing the currently configured
+sources, adding a new source, removing an existing source, marking a source as
+the explicit default, and removing that explicit default flag. See *OPTIONS*
+below for details. Changes made by *--add*, *--remove*, *--set-default*, and
+*--unset-default* take effect the next time *port* is invoked.
+
+A local directory path beginning with '/' or '~' is automatically expanded to a
+'file://' URL by *--add*, *--remove*, *--set-default*, and *--unset-default*,
+making it convenient to manage local checkouts of the MacPorts ports tree
+without needing to type the full 'file://' URL. Local paths containing spaces
+are supported. Non-'file://' URLs must already be valid URIs; encode spaces as
+'%20' rather than using literal whitespace.
+
+Exactly one of *--list*, *--add*, *--remove*, *--set-default*, or
+*--unset-default* may be specified at a time. The *--first*, *--no-sync*, and
+*--default* modifiers are valid only with *--add*.
+
+OPTIONS
+-------
+*--list*::
+    Print the currently configured sources, one per line, in the same format
+    used by man:sources.conf[5]. This is the default when no option is given.
+    *--list* does not accept a URL argument.
+
+*--add* [*--first*] [*--no-sync*] [*--default*] 'url'::
+    Add 'url' to the list of port tree sources. If 'url' begins with '/' or
+    '~', it is interpreted as a local directory path; it will be normalised and
+    prefixed with 'file://'. Local paths with spaces are written literally in
+    the resulting 'file://' URL.
++
+By default the new source is appended to the end of man:sources.conf[5].
+Use *--first* to insert it before the first existing source entry, which is
+useful for a local port tree that should shadow the default remote source.
++
+Use *--no-sync* to add the '[nosync]' flag to the entry, preventing
+*port sync* from attempting to update this source. This is recommended for
+local development checkouts that are managed independently. To change the
+nosync flag on an existing source, remove and re-add it.
++
+Use *--default* to add the '[default]' flag to the new entry and remove any
+existing explicit '[default]' flag from other source entries.
++
+This command requires write access to man:sources.conf[5] and must typically
+be run with *sudo*.
+
+*--remove* 'url'::
+    Remove the source with the given URL from man:sources.conf[5]. If 'url'
+    begins with '/' or '~', it is normalised to a 'file://' URL in the same
+    way as *--add*. Comments and other entries are preserved. For local paths,
+    the directory need not still exist on disk. If the removed source was
+    marked '[default]', a warning is printed; use *--set-default* to
+    explicitly designate another source as the default.
++
+This command requires write access to man:sources.conf[5] and must typically
+be run with *sudo*.
+
+*--set-default* 'url'::
+    Mark the given source as the explicit default in man:sources.conf[5]. Any
+    existing explicit '[default]' flag is removed from the other source
+    entries. If 'url' begins with '/' or '~', it is normalised in the same way
+    as *--remove*.
++
+This command requires write access to man:sources.conf[5] and must typically
+be run with *sudo*.
+
+*--unset-default* 'url'::
+    Remove the explicit '[default]' flag from the given source in
+    man:sources.conf[5]. If this leaves no explicit default source, MacPorts
+    warns and continues using the last listed source as the effective default.
+    If 'url' begins with '/' or '~', it is normalised in the same way as
+    *--remove*.
++
+This command requires write access to man:sources.conf[5] and must typically
+be run with *sudo*.
+
+include::global-flags.txt[]
+
+EXAMPLES
+--------
+List the currently configured sources:
+----
+port source
+----
+
+Add a local checkout of the MacPorts ports tree for Portfile development,
+placing it first so it shadows the default remote source and marking it so
+that *port sync* leaves it alone:
+----
+sudo port source --add --first --no-sync ~/src/macports-ports
+----
+
+Add a local checkout first, mark it as the explicit default, and disable sync:
+----
+sudo port source --add --first --no-sync --default ~/src/macports-ports
+----
+
+Add a remote rsync source:
+----
+sudo port source --add rsync://rsync.macports.org/macports/release/tarballs/ports.tar
+----
+
+Mark an existing source as the explicit default:
+----
+sudo port source --set-default ~/src/macports-ports
+----
+
+Remove a source by path:
+----
+sudo port source --remove ~/src/macports-ports
+----
+
+Remove a source by URL:
+----
+sudo port source --remove rsync://rsync.macports.org/macports/release/tarballs/ports.tar
+----
+
+SEE ALSO
+--------
+man:port[1], man:port-sync[1], man:sources.conf[5]
+
+AUTHORS
+-------
+ (C) 2025 The MacPorts Project

--- a/doc/port.1
+++ b/doc/port.1
@@ -789,6 +789,48 @@ sudo port \-d sync
 If any of the ports tree(s) uses a file: URL that points to a local subversion working copy, sync will perform an svn update on the working copy with the user set to the owner of the working copy\&.
 .RE
 .PP
+source
+.RS 4
+List, add, remove, or manage the explicit default port tree source in
+\fBsources.conf\fR(5)\&. Without a flag,
+\fBport source\fR
+lists the currently configured sources\&. A local path beginning with
+\fI/\fR
+or
+\fI~\fR
+is automatically converted to a
+\fIfile://\fR
+URL for
+\fB\-\-add\fR,
+\fB\-\-remove\fR,
+\fB\-\-set\-default\fR, and
+\fB\-\-unset\-default\fR\&. Local paths with spaces are supported\&. Non\-\fIfile://\fR
+URLs must already be valid URIs, so spaces must be encoded as
+\fI%20\fR\&. The
+\fB\-\-first\fR,
+\fB\-\-no\-sync\fR, and
+\fB\-\-default\fR
+modifiers are valid only with
+\fB\-\-add\fR\&.
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+port source
+sudo port source \-\-add \-\-first \-\-no\-sync \-\-default ~/src/macports\-ports
+sudo port source \-\-set\-default ~/src/macports\-ports
+sudo port source \-\-remove ~/src/macports\-ports
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+See
+\fBport-source\fR(1)
+for full details\&.
+.RE
+.PP
 outdated
 .RS 4
 Lists the installed ports which need an

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -369,6 +369,25 @@ subversion working copy, sync will perform an svn update on the working
 copy with the user set to the owner of the working copy.
 +
 
+source::
+    List, add, remove, or manage the explicit default port tree source in
+    man:sources.conf[5]. Without a flag, *port source* lists the currently
+    configured sources. A local path beginning with '/' or '~' is
+    automatically converted to a 'file://' URL for *--add*, *--remove*,
+    *--set-default*, and *--unset-default*. Local paths with spaces are
+    supported. Non-'file://' URLs must already be valid URIs, so spaces must
+    be encoded as '%20'. The *--first*, *--no-sync*, and *--default* modifiers
+    are valid only with *--add*.
++
+--------
+port source
+sudo port source --add --first --no-sync --default ~/src/macports-ports
+sudo port source --set-default ~/src/macports-ports
+sudo port source --remove ~/src/macports-ports
+--------
++
+See man:port-source[1] for full details.
+
 outdated::
     Lists the installed ports which need an 'upgrade'.
 

--- a/doc/sources.conf.5
+++ b/doc/sources.conf.5
@@ -23,13 +23,13 @@
 sources.conf \- port definition configuration file of the MacPorts system
 .SH "DESCRIPTION"
 .sp
-\fBsources\&.conf\fR is the configuration file used by the MacPorts system to locate its port definitions\&. The file is read by the \fBport\fR command to find available ports and how to install them\&. Lines beginning with \fI#\fR are comments, empty lines are ignored\&. Entries in this file are URIs optionally followed by flags in square brackets\&. Each source specification is given on a separate line\&. A grammar in EBNF is given below:
+\fBsources\&.conf\fR is the configuration file used by the MacPorts system to locate its port definitions\&. The file is read by the \fBport\fR command to find available ports and how to install them\&. Lines beginning with \fI#\fR are comments, empty lines are ignored\&. Entries in this file are URIs optionally followed by flags in square brackets\&. Each source specification is given on a separate line\&. The supported interface for editing this file is \fBport-source\fR(1)\&. A grammar in EBNF is given below:
 .sp
 .if n \{\
 .RS 4
 .\}
 .nf
-line  = URI, [ \*(Aq[\*(Aq, flag, { space, flag }, \*(Aq]\*(Aq ] ;
+line  = URI, [ space, \*(Aq[\*(Aq, flag, { \*(Aq,\*(Aq, flag }, \*(Aq]\*(Aq ] ;
 flag  = \*(Aqdefault\*(Aq | \*(Aqnosync\*(Aq ;
 space = \*(Aq \*(Aq | \*(Aq\et\*(Aq ;
 .fi
@@ -64,7 +64,10 @@ slashes at the beginning of the URI) to a local directory that should be used as
 tag to avoid this behavior\&.
 
 NOTE: The MacPorts user (usually called
-\fImacports\fR) needs to be able to read and write to this location\&. This usually means your home directory is not a suitable place for a port tree, unless you adjust permissions accordingly\&.
+\fImacports\fR) needs to be able to read and write to this location\&. This usually means your home directory is not a suitable place for a port tree, unless you adjust permissions accordingly\&. Literal spaces are supported in
+\fIfile://\fR
+source entries, including entries written by
+\fBport-source\fR(1)\&.
 .PP
 \fBExample\fR
 .RS 4
@@ -81,6 +84,10 @@ none
 \fIhttp://\fR, \fIhttps://\fR and \fIftp://\fR
 .RS 4
 Followed by a server name and a path on this server, this URI instructs MacPorts to download a tarball snapshot of a ports tree from the URI and extract it to a path of its choice\&. This possibility is provided as a fallback to users that can use neither rsync nor subversion to sync the MacPorts port tree\&.
+
+These values must be valid URIs\&. Literal spaces are not supported; use
+\fI%20\fR
+where necessary\&.
 
 If the tarball contains a pre\-built PortIndex and PortIndex\&.quick file at PortIndex_${platform}_${os_major}_${os_arch}/, those will be used as default\&. If it does not, MacPorts will build a suitable port index for the local system automatically\&.
 .RE
@@ -108,14 +115,15 @@ command for sources marked with this flag\&.
 .RS 4
 Mark this source as the default\&. The default source is used as a fallback to load additional files (such as PortGroups and mirror definitions) from the
 \fI_resources/port1\&.0\fR
-directory\&.
+directory\&. If no source is explicitly marked as
+\fIdefault\fR, MacPorts warns and uses the last listed source as the effective default\&.
 .RE
 .SH "FILES"
 .sp
 The path of the \fIsources\&.conf\fR file is specified in the \fBsources_conf\fR option of \fBmacports.conf\fR(5)\&. It defaults to \fI${prefix}/etc/macports/sources\&.conf\fR\&. There is no user\-specific \fIsources\&.conf\fR file, but support for this can be emulated by setting \fIsources\&.conf\fR in the user\-specific \fBmacports.conf\fR(5) file\&.
 .SH "SEE ALSO"
 .sp
-\fBport\fR(1), \fBport-selfupdate\fR(1), \fBport-sync\fR(1), \fBportindex\fR(1), \fBmacports.conf\fR(5)
+\fBport\fR(1), \fBport-source\fR(1), \fBport-selfupdate\fR(1), \fBport-sync\fR(1), \fBportindex\fR(1), \fBmacports.conf\fR(5)
 .SH "AUTHORS"
 .sp
 .if n \{\

--- a/doc/sources.conf.5.txt
+++ b/doc/sources.conf.5.txt
@@ -12,10 +12,11 @@ DESCRIPTION
 its port definitions. The file is read by the *port* command to find available
 ports and how to install them. Lines beginning with '#' are comments, empty
 lines are ignored. Entries in this file are URIs optionally followed by flags in
-square brackets. Each source specification is given on a separate line.
+square brackets. Each source specification is given on a separate line. The
+supported interface for editing this file is man:port-source[1].
 A grammar in EBNF is given below:
 --------
-line  = URI, [ '[', flag, { space, flag }, ']' ] ;
+line  = URI, [ space, '[', flag, { ',', flag }, ']' ] ;
 flag  = 'default' | 'nosync' ;
 space = ' ' | '\t' ;
 --------
@@ -53,6 +54,8 @@ MacPorts supports a number of different protocols as source descriptions.
     NOTE: The MacPorts user (usually called 'macports') needs to be able to read
     and write to this location. This usually means your home directory is not
     a suitable place for a port tree, unless you adjust permissions accordingly.
+    Literal spaces are supported in 'file://' source entries, including entries
+    written by man:port-source[1].
     +
     *Example*;;
         file:///opt/dports [nosync,default]
@@ -65,6 +68,9 @@ MacPorts supports a number of different protocols as source descriptions.
     extract it to a path of its choice. This possibility is provided as
     a fallback to users that can use neither rsync nor subversion to sync the
     MacPorts port tree.
+    +
+    These values must be valid URIs. Literal spaces are not supported; use
+    '%20' where necessary.
     +
     If the tarball contains a pre-built PortIndex and PortIndex.quick file at
     PortIndex_$\{platform\}_$\{os_major\}_$\{os_arch\}/, those will be used as
@@ -101,7 +107,9 @@ a source:
 'default'::
     Mark this source as the default. The default source is used as a fallback to
     load additional files (such as PortGroups and mirror definitions) from the
-    '_resources/port1.0' directory.
+    '_resources/port1.0' directory. If no source is explicitly marked as
+    'default', MacPorts warns and uses the last listed source as the effective
+    default.
 
 FILES
 -----
@@ -113,8 +121,8 @@ file.
 
 SEE ALSO
 --------
-man:port[1], man:port-selfupdate[1], man:port-sync[1], man:portindex[1],
-man:macports.conf[5]
+man:port[1], man:port-source[1], man:port-selfupdate[1], man:port-sync[1],
+man:portindex[1], man:macports.conf[5]
 
 AUTHORS
 -------

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -1295,17 +1295,22 @@ proc mportinit {{up_ui_options {}} {up_options {}} {up_variations {}}} {
     }
     # Precompute mapping of source URLs to prefix to use for porturls (used in mportlookup etc)
     set porturl_prefix_map [dict create]
-    set sources_conf_comment_re {^\s*#|^$}
-    set sources_conf_source_re {^([\w-]+://\S+)(?:\s+\[(\w+(?:,\w+)*)\])?$}
-    set fd [open $sources_conf r]
-    while {[gets $fd line] >= 0} {
-        set line [string trimright $line]
-        if {![regexp $sources_conf_comment_re $line]} {
-            if {[regexp $sources_conf_source_re $line _ url flags]} {
-                set flags [split $flags ,]
+    set source_records [macports::source_read_conf]
+    foreach record $source_records {
+        switch -- [dict get $record type] {
+            blank -
+            comment {
+                continue
+            }
+            invalid {
+                ui_warn "$sources_conf specifies invalid source '[dict get $record raw]', ignored."
+            }
+            source {
+                set url [dict get $record url]
+                set flags [dict get $record flags]
                 foreach flag $flags {
                     if {$flag ni [list nosync default]} {
-                        ui_warn "$sources_conf source '$line' specifies invalid flag '$flag'"
+                        ui_warn "$sources_conf source '[dict get $record raw]' specifies invalid flag '$flag'"
                     }
                     if {$flag eq "default"} {
                         if {[info exists sources_default]} {
@@ -1334,12 +1339,9 @@ Please edit sources.conf and change '$url' to '[string range $url 0 26]macports/
                     }
                 }
                 lappend sources [concat [list $url] $flags]
-            } else {
-                ui_warn "$sources_conf specifies invalid source '$line', ignored."
             }
         }
     }
-    close $fd
 
     if {![info exists sources]} {
         return -code error "No sources defined in $sources_conf"
@@ -3486,6 +3488,461 @@ proc macports::getindex {source} {
     }
 
     return [file join [macports::getsourcepath $source] PortIndex]
+}
+
+##
+# Parse a comma-separated list of source flags.
+#
+# @param flag_string Source flag list without surrounding brackets.
+# @return            List of unique flag names in their original order.
+# @error             If the flag list syntax is invalid.
+proc macports::source_parse_flags {flag_string} {
+    set flags {}
+    foreach flag [split $flag_string ,] {
+        set flag [string trim $flag]
+        if {$flag eq "" || ![regexp {^\w+$} $flag]} {
+            return -code error "Invalid source flag list '$flag_string'"
+        }
+        if {[lsearch -exact $flags $flag] < 0} {
+            lappend flags $flag
+        }
+    }
+    return $flags
+}
+
+##
+# Return a stable rendering order for source flags.
+#
+# Managed flags are rendered first in the order [nosync,default], followed by
+# any other flags in their original order.
+#
+# @param flags Source flags.
+# @return      Ordered flag list with duplicates removed.
+proc macports::source_order_flags {flags} {
+    set unique_flags {}
+    foreach flag $flags {
+        if {[lsearch -exact $unique_flags $flag] < 0} {
+            lappend unique_flags $flag
+        }
+    }
+
+    set ordered_flags {}
+    foreach managed_flag {nosync default} {
+        if {[lsearch -exact $unique_flags $managed_flag] >= 0} {
+            lappend ordered_flags $managed_flag
+        }
+    }
+    foreach flag $unique_flags {
+        if {$flag ni {nosync default}} {
+            lappend ordered_flags $flag
+        }
+    }
+    return $ordered_flags
+}
+
+##
+# Render a source line in sources.conf syntax.
+#
+# @param url   Source URL.
+# @param flags Source flag list.
+# @return      Rendered sources.conf line.
+proc macports::source_render_line {url flags} {
+    set flags [macports::source_order_flags $flags]
+    if {[llength $flags] > 0} {
+        return "$url \[[join $flags ,]\]"
+    }
+    return $url
+}
+
+##
+# Validate a source URL.
+#
+# @param url             Source URL to validate.
+# @param require_exists  Whether file:// URLs must point to an existing
+#                        directory.
+# @return                The validated URL.
+# @error                 If the URL is invalid.
+proc macports::source_validate_url {url {require_exists 0}} {
+    if {[regexp {^file://(.*)$} $url _ path]} {
+        if {$path eq ""} {
+            return -code error "Invalid source URL '$url' — must be of the form <scheme>://<path>"
+        }
+        if {$require_exists && ![file isdirectory $path]} {
+            return -code error "Local path '$path' is not a directory"
+        }
+        return $url
+    }
+
+    if {[regexp {\s} $url] || ![regexp {^[\w-]+://\S+$} $url]} {
+        return -code error "Invalid source URL '$url' — must be of the form <scheme>://<path>"
+    }
+
+    return $url
+}
+
+##
+# Parse a single sources.conf line.
+#
+# @param line sources.conf line without trailing newline.
+# @return     A dict describing the parsed line.
+proc macports::source_parse_line {line} {
+    if {[regexp {^\s*$} $line]} {
+        return [dict create type blank raw $line]
+    }
+    if {[regexp {^\s*#} $line]} {
+        return [dict create type comment raw $line]
+    }
+
+    # Match the historical parser, which trimmed trailing whitespace before
+    # classifying a line. raw keeps the original text so untouched records are
+    # still rewritten verbatim.
+    set trimmed [string trimright $line]
+    set url $trimmed
+    set flags {}
+    if {[regexp {^(.*\S)\s+\[([^\[\]]+)\]$} $trimmed _ parsed_url flag_string]} {
+        if {[catch {set flags [macports::source_parse_flags $flag_string]} err]} {
+            return [dict create type invalid raw $line error $err]
+        }
+        set url $parsed_url
+    }
+
+    if {[catch {macports::source_validate_url $url 0} err]} {
+        return [dict create type invalid raw $line error $err]
+    }
+
+    return [dict create type source raw $line url $url flags $flags]
+}
+
+##
+# Read and parse sources.conf.
+#
+# @return List of parsed record dicts.
+proc macports::source_read_conf {} {
+    variable sources_conf
+
+    set fd [open $sources_conf r]
+    set content [read $fd]
+    close $fd
+
+    if {$content eq ""} {
+        return {}
+    }
+
+    set lines [split $content \n]
+    if {[string index $content end] eq "\n"} {
+        set lines [lrange $lines 0 end-1]
+    }
+
+    set records {}
+    foreach line $lines {
+        lappend records [macports::source_parse_line $line]
+    }
+    return $records
+}
+
+##
+# Render a parsed sources.conf record back to text.
+#
+# Source records are rendered from structured data only when they are new or
+# have been marked touched; all other records are returned verbatim.
+#
+# @param record Parsed sources.conf record.
+# @return       Serialized line.
+proc macports::source_render_record {record} {
+    if {[dict get $record type] eq "source" && [dict exists $record touched]} {
+        return [macports::source_render_line [dict get $record url] [dict get $record flags]]
+    }
+    return [dict get $record raw]
+}
+
+##
+# Atomically rewrite sources.conf from parsed records.
+#
+# @param records Parsed sources.conf records.
+proc macports::source_write_conf {records} {
+    variable sources_conf
+
+    set tmpfile "${sources_conf}.tmp.[pid]"
+    set rendered_lines {}
+    foreach record $records {
+        lappend rendered_lines [macports::source_render_record $record]
+    }
+
+    set content [join $rendered_lines \n]
+    if {[llength $rendered_lines] > 0} {
+        append content \n
+    }
+
+    set fd [open $tmpfile w]
+    puts -nonewline $fd $content
+    close $fd
+    file rename -force $tmpfile $sources_conf
+}
+
+##
+# Normalise a source URL or local path into a canonical URL.
+#
+# A bare local path beginning with / or ~ is expanded with [file tildeexpand],
+# then canonicalised with [file normalize] and prefixed with file://. Any other
+# value is validated as a scheme://path URL and returned unchanged. file:// URLs
+# are only required to point to an existing directory when require_exists is
+# true.
+#
+# @param url             Source URL or local path to normalise.
+# @param require_exists  Whether local paths must exist.
+# @return                Canonical URL string.
+# @error                 If url is invalid.
+proc macports::source_normalize_url {url {require_exists 1}} {
+    if {[string index $url 0] in {/ ~}} {
+        set path [file normalize [file tildeexpand $url]]
+        if {$require_exists && ![file isdirectory $path]} {
+            return -code error "Local path '$url' is not a directory"
+        }
+        return "file://$path"
+    }
+
+    return [macports::source_validate_url $url $require_exists]
+}
+
+##
+# Add a source to sources.conf.
+#
+# @param url          Source URL, or a local path starting with / or ~/
+# @param first        If true, insert before the first existing source.
+# @param nosync       If true, append the [nosync] flag to the entry.
+# @param make_default If true, mark this source as [default] and clear the
+#                     explicit default flag from all other sources.
+# @return             Canonical URL string.
+# @error "duplicate" if url is already present in sources.conf.
+# @error "Insufficient privileges..." if sources.conf is not writable.
+# @error Propagates errors from source_normalize_url for invalid URLs.
+proc macports::source_add {url {first 0} {nosync 0} {make_default 0}} {
+    variable sources_conf
+
+    set url [macports::source_normalize_url $url 1]
+
+    if {![file writable $sources_conf]} {
+        return -code error "Insufficient privileges to write to ${sources_conf}"
+    }
+
+    set records [macports::source_read_conf]
+
+    foreach record $records {
+        if {[dict get $record type] eq "source" && [dict get $record url] eq $url} {
+            return -code error "duplicate"
+        }
+    }
+
+    if {$make_default} {
+        set updated_records {}
+        foreach record $records {
+            if {[dict get $record type] eq "source"} {
+                set flags [dict get $record flags]
+                if {[lsearch -exact $flags default] >= 0} {
+                    set new_flags {}
+                    foreach flag $flags {
+                        if {$flag ne "default"} {
+                            lappend new_flags $flag
+                        }
+                    }
+                    dict set record flags $new_flags
+                    dict set record touched 1
+                }
+            }
+            lappend updated_records $record
+        }
+        set records $updated_records
+    }
+
+    set new_flags {}
+    if {$nosync} {
+        lappend new_flags nosync
+    }
+    if {$make_default} {
+        lappend new_flags default
+    }
+    set new_record [dict create type source url $url flags $new_flags touched 1]
+
+    set insert_idx [llength $records]
+    if {$first} {
+        for {set i 0} {$i < [llength $records]} {incr i} {
+            if {[dict get [lindex $records $i] type] eq "source"} {
+                set insert_idx $i
+                break
+            }
+        }
+    }
+    set records [linsert $records $insert_idx $new_record]
+
+    macports::source_write_conf $records
+    return $url
+}
+
+##
+# Remove a source from sources.conf by URL.
+#
+# Local paths starting with ~ or / are normalised to file:// URLs, but they do
+# not have to exist. No automatic default-promotion is performed; if the
+# removed source carried the [default] flag, the caller is responsible for
+# warning the user.
+#
+# @param url Source URL, or a local path starting with / or ~/
+# @return    A dict with keys: url (canonical URL), removed_default (boolean
+#            indicating the removed source carried [default]),
+#            has_remaining_default (boolean indicating whether any remaining
+#            source still carries an explicit [default] flag).
+# @error "not-found" if url is not present in sources.conf.
+# @error "Insufficient privileges..." if sources.conf is not writable.
+# @error Propagates errors from source_normalize_url for invalid URLs.
+proc macports::source_remove {url} {
+    variable sources_conf
+
+    set url [macports::source_normalize_url $url 0]
+
+    if {![file writable $sources_conf]} {
+        return -code error "Insufficient privileges to write to ${sources_conf}"
+    }
+
+    set records [macports::source_read_conf]
+
+    set updated_records {}
+    set removed 0
+    set removed_default 0
+    foreach record $records {
+        if {[dict get $record type] eq "source" && [dict get $record url] eq $url} {
+            set removed 1
+            if {[lsearch -exact [dict get $record flags] default] >= 0} {
+                set removed_default 1
+            }
+            continue
+        }
+        lappend updated_records $record
+    }
+
+    if {!$removed} {
+        return -code error "not-found"
+    }
+
+    set has_remaining_default 0
+    if {$removed_default} {
+        foreach record $updated_records {
+            if {[dict get $record type] eq "source"
+                && [lsearch -exact [dict get $record flags] default] >= 0} {
+                set has_remaining_default 1
+                break
+            }
+        }
+    }
+
+    macports::source_write_conf $updated_records
+    return [dict create url $url removed_default $removed_default \
+        has_remaining_default $has_remaining_default]
+}
+
+##
+# Mark a source as the explicit default in sources.conf.
+#
+# @param url Source URL, or a local path starting with / or ~/
+# @return    Canonical URL string.
+# @error "not-found" if url is not present in sources.conf.
+# @error "Insufficient privileges..." if sources.conf is not writable.
+proc macports::source_set_default {url} {
+    variable sources_conf
+
+    set url [macports::source_normalize_url $url 0]
+
+    if {![file writable $sources_conf]} {
+        return -code error "Insufficient privileges to write to ${sources_conf}"
+    }
+
+    set records [macports::source_read_conf]
+
+    set found 0
+    set touched 0
+    set updated_records {}
+    foreach record $records {
+        if {[dict get $record type] eq "source"} {
+            set flags [dict get $record flags]
+            set is_target [expr {[dict get $record url] eq $url}]
+            if {$is_target} {
+                set found 1
+                if {[lsearch -exact $flags default] < 0} {
+                    lappend flags default
+                    dict set record flags $flags
+                    dict set record touched 1
+                    set touched 1
+                }
+            } elseif {[lsearch -exact $flags default] >= 0} {
+                set new_flags {}
+                foreach flag $flags {
+                    if {$flag ne "default"} {
+                        lappend new_flags $flag
+                    }
+                }
+                dict set record flags $new_flags
+                dict set record touched 1
+                set touched 1
+            }
+        }
+        lappend updated_records $record
+    }
+
+    if {!$found} {
+        return -code error "not-found"
+    }
+    if {$touched} {
+        macports::source_write_conf $updated_records
+    }
+    return $url
+}
+
+##
+# Remove the explicit default flag from a source in sources.conf.
+#
+# @param url Source URL, or a local path starting with / or ~/
+# @return    Canonical URL string.
+# @error "not-found" if url is not present in sources.conf.
+# @error "Insufficient privileges..." if sources.conf is not writable.
+proc macports::source_unset_default {url} {
+    variable sources_conf
+
+    set url [macports::source_normalize_url $url 0]
+
+    if {![file writable $sources_conf]} {
+        return -code error "Insufficient privileges to write to ${sources_conf}"
+    }
+
+    set records [macports::source_read_conf]
+
+    set found 0
+    set touched 0
+    set updated_records {}
+    foreach record $records {
+        if {[dict get $record type] eq "source" && [dict get $record url] eq $url} {
+            set found 1
+            set flags [dict get $record flags]
+            if {[lsearch -exact $flags default] >= 0} {
+                set new_flags {}
+                foreach flag $flags {
+                    if {$flag ne "default"} {
+                        lappend new_flags $flag
+                    }
+                }
+                dict set record flags $new_flags
+                dict set record touched 1
+                set touched 1
+            }
+        }
+        lappend updated_records $record
+    }
+
+    if {!$found} {
+        return -code error "not-found"
+    }
+    if {$touched} {
+        macports::source_write_conf $updated_records
+    }
+    return $url
 }
 
 # macports::VCSPrepare

--- a/src/macports1.0/tests/sources.test
+++ b/src/macports1.0/tests/sources.test
@@ -1,0 +1,615 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+package require tcltest 2
+namespace import tcltest::*
+::tcltest::configure {*}$::argv
+
+set pwd [file dirname [file normalize $argv0]]
+
+source ../macports_test_autoconf.tcl
+package require macports 1.0
+
+proc extract_tcl_block {lines pattern} {
+    set collecting 0
+    set depth 0
+    set body {}
+
+    foreach line $lines {
+        if {!$collecting} {
+            if {[string match $pattern $line]} {
+                set collecting 1
+            } else {
+                continue
+            }
+        }
+
+        append body $line \n
+        incr depth [expr {[llength [regexp -all -inline {\{} $line]]
+                          - [llength [regexp -all -inline {\}} $line]]}]
+        if {$depth <= 0} {
+            break
+        }
+    }
+
+    if {$body eq {}} {
+        error "Could not extract block matching '$pattern'"
+    }
+    return $body
+}
+
+# Load source-management helpers from local macports.tcl so the tests exercise
+# the rebased implementation even before it is installed.
+set _fd [open ../macports.tcl r]
+set _macports_lines [split [read $_fd] \n]
+close $_fd
+foreach _proc {
+    source_parse_flags
+    source_order_flags
+    source_render_line
+    source_validate_url
+    source_parse_line
+    source_read_conf
+    source_render_record
+    source_write_conf
+    source_normalize_url
+    source_add
+    source_remove
+    source_set_default
+    source_unset_default
+} {
+    eval [extract_tcl_block $_macports_lines "proc macports::${_proc} *"]
+}
+
+# Load the frontend action and option registration from local port.tcl.
+set _fd [open ../../port/port.tcl r]
+set _port_lines [split [read $_fd] \n]
+close $_fd
+eval [extract_tcl_block $_port_lines "proc action_source *"]
+eval [extract_tcl_block $_port_lines "set cmd_opts_array *"]
+
+unset -nocomplain _fd _macports_lines _port_lines _proc
+
+# Shared setup: temporary in-tree prefix, ui_options, and mportinit.
+source $macports::autoconf::top_srcdir/src/macports1.0/tests/test_setup.tcl
+
+# Create real directories for file:// URL tests.
+file mkdir $pwd/tmpdir/source_a
+file mkdir $pwd/tmpdir/source_b
+
+set default_source_url "rsync://rsync.macports.org/macports/release/tarballs/ports.tar"
+set encoded_remote_url "https://example.com/path%20with%20space.tar"
+set invalid_remote_url "https://example.com/path with space.tar"
+
+proc conf_text {lines} {
+    return "[join $lines \n]\n"
+}
+
+proc source_line {url {flags {}}} {
+    return [macports::source_render_line $url $flags]
+}
+
+proc default_conf {} {
+    global default_source_url
+    return [conf_text [list \
+        "# MacPorts sources" \
+        "# another comment" \
+        "" \
+        [source_line $default_source_url {default}]]]
+}
+
+proc read_conf {} {
+    set fd [open $macports::sources_conf r]
+    set content [read $fd]
+    close $fd
+    return $content
+}
+
+proc write_conf {content} {
+    set fd [open $macports::sources_conf w]
+    puts -nonewline $fd $content
+    close $fd
+}
+
+proc run_action_source {portlist opts} {
+    array set saved_commands {}
+    foreach name {ui_msg ui_warn ui_error ui_debug} {
+        if {[llength [info commands ::$name]] > 0} {
+            rename ::$name ::__saved_$name
+            set saved_commands($name) 1
+        }
+    }
+
+    set ::captured_ui(msg) {}
+    set ::captured_ui(warn) {}
+    set ::captured_ui(error) {}
+    set ::captured_ui(debug) {}
+    proc ::ui_msg {message} {
+        lappend ::captured_ui(msg) $message
+    }
+    proc ::ui_warn {message} {
+        lappend ::captured_ui(warn) $message
+    }
+    proc ::ui_error {message} {
+        lappend ::captured_ui(error) $message
+    }
+    proc ::ui_debug {message} {
+        lappend ::captured_ui(debug) $message
+    }
+
+    set code [catch {action_source source $portlist $opts} result options]
+    set payload [dict create \
+        code $code \
+        result $result \
+        options $options \
+        msg $::captured_ui(msg) \
+        warn $::captured_ui(warn) \
+        error $::captured_ui(error) \
+        debug $::captured_ui(debug)]
+
+    rename ::ui_msg {}
+    rename ::ui_warn {}
+    rename ::ui_error {}
+    rename ::ui_debug {}
+    catch {unset ::captured_ui}
+
+    foreach name {ui_msg ui_warn ui_error ui_debug} {
+        if {[info exists saved_commands($name)]} {
+            rename ::__saved_$name ::$name
+        }
+    }
+
+    return $payload
+}
+
+set setup_sources {
+    set saved_sources_conf ${macports::sources_conf}
+    set saved_sources ${macports::sources}
+
+    set temp_conf [makeFile [default_conf] sources_test.conf]
+    set macports::sources_conf $temp_conf
+    set macports::sources [list [list $default_source_url default]]
+}
+
+set cleanup_sources {
+    set macports::sources_conf $saved_sources_conf
+    set macports::sources $saved_sources
+    removeFile sources_test.conf
+}
+
+test source_add_append_preserves_structure {
+    source_add appends through the rewrite path while preserving comments, blank
+    lines, and a single trailing newline.
+} -setup $setup_sources -body {
+    macports::source_add $encoded_remote_url
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        "# another comment" \
+        "" \
+        [source_line $default_source_url {default}] \
+        [source_line $encoded_remote_url]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: appended sources.conf did not match expected contents"
+    }
+    return "append rewrite preserved structure."
+} -cleanup $cleanup_sources -result "append rewrite preserved structure."
+
+test source_add_first_preserves_leading_comments {
+    source_add with first=1 inserts before the first source entry, but not above
+    leading comments or blank lines.
+} -setup $setup_sources -body {
+    set local_source "file://[file normalize $pwd/tmpdir/source_a]"
+    macports::source_add $local_source 1 0
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        "# another comment" \
+        "" \
+        [source_line $local_source] \
+        [source_line $default_source_url {default}]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: first insertion did not preserve leading structure"
+    }
+    return "first insertion preserved comments."
+} -cleanup $cleanup_sources -result "first insertion preserved comments."
+
+test source_add_default_and_nosync {
+    source_add writes managed flags in stable order and clears any existing
+    explicit default.
+} -setup $setup_sources -body {
+    set local_source "file://[file normalize $pwd/tmpdir/source_b]"
+    macports::source_add $local_source 0 1 1
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        "# another comment" \
+        "" \
+        [source_line $default_source_url] \
+        [source_line $local_source {nosync default}]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: add with nosync/default produced unexpected contents"
+    }
+    return "managed flags written in stable order."
+} -cleanup $cleanup_sources -result "managed flags written in stable order."
+
+test source_parse_line_tolerates_trailing_whitespace {
+    source_parse_line trims trailing whitespace before classifying a line, matching
+    the historical mportinit parser, while preserving the original text verbatim in
+    the raw field.
+} -body {
+    set record [macports::source_parse_line "http://example.com/ports   "]
+    if {[dict get $record type] ne "source"} {
+        return "FAIL: trailing-whitespace source line classified as [dict get $record type]"
+    }
+    if {[dict get $record url] ne "http://example.com/ports"} {
+        return "FAIL: url not trimmed: '[dict get $record url]'"
+    }
+    if {[dict get $record raw] ne "http://example.com/ports   "} {
+        return "FAIL: raw text not preserved verbatim"
+    }
+    set record [macports::source_parse_line "http://example.com/ports \[nosync\]\t"]
+    if {[dict get $record type] ne "source" || [dict get $record flags] ne "nosync"} {
+        return "FAIL: trailing whitespace after flags mishandled"
+    }
+    return "trailing whitespace tolerated."
+} -result "trailing whitespace tolerated."
+
+test source_add_preserves_trailing_whitespace_lines {
+    A pre-existing source line with trailing whitespace is retained rather than
+    dropped as invalid, and is rewritten verbatim when an unrelated source is added.
+} -setup $setup_sources -body {
+    write_conf "# MacPorts sources\n[source_line $default_source_url {default}]   \n"
+    macports::source_add $encoded_remote_url
+    set expected "# MacPorts sources\n[source_line $default_source_url {default}]   \n[source_line $encoded_remote_url]\n"
+    if {[read_conf] ne $expected} {
+        return "FAIL: trailing-whitespace line not preserved verbatim"
+    }
+    return "trailing-whitespace line preserved."
+} -cleanup $cleanup_sources -result "trailing-whitespace line preserved."
+
+test source_add_local_path_with_spaces {
+    source_add accepts a local path containing spaces and writes it as a file://
+    source without encoding the spaces.
+} -setup $setup_sources -body {
+    set local_dir [file join $pwd/tmpdir "Source With Spaces"]
+    file mkdir $local_dir
+    macports::source_add $local_dir
+    set written_url "file://[file normalize $local_dir]"
+    if {[string first [source_line $written_url] [read_conf]] < 0} {
+        return "FAIL: local path with spaces was not written as a file:// source"
+    }
+    return "local path with spaces added."
+} -cleanup {
+    file delete -force [file join $pwd/tmpdir "Source With Spaces"]
+    eval $cleanup_sources
+} -result "local path with spaces added."
+
+test source_add_tilde_path_tcl9 {
+    source_add expands a tilde path with file tildeexpand before normalize,
+    which is required on Tcl 9.
+} -setup $setup_sources -body {
+    set test_dir [file join $macports::portdbpath home "test ports"]
+    file mkdir $test_dir
+    macports::source_add "~/test ports"
+    set expected_url "file://[file normalize $test_dir]"
+    if {[string first [source_line $expected_url] [read_conf]] < 0} {
+        return "FAIL: tilde path was not normalized as expected"
+    }
+    return "tilde path expanded correctly."
+} -cleanup {
+    file delete -force [file join $macports::portdbpath home "test ports"]
+    eval $cleanup_sources
+} -result "tilde path expanded correctly."
+
+test source_add_rejects_nonfile_spaces {
+    source_add rejects literal spaces in non-file URLs instead of silently
+    auto-encoding them.
+} -setup $setup_sources -body {
+    set rc [catch {macports::source_add $invalid_remote_url} err]
+    if {$rc == 0} {
+        return "FAIL: non-file URL with spaces unexpectedly succeeded"
+    }
+    if {![string match "*Invalid source URL*" $err]} {
+        return "FAIL: unexpected error for invalid remote URL: $err"
+    }
+    return "non-file URL with spaces rejected."
+} -cleanup $cleanup_sources -result "non-file URL with spaces rejected."
+
+test source_add_accepts_encoded_nonfile_url {
+    source_add accepts an already-encoded non-file URL unchanged.
+} -setup $setup_sources -body {
+    macports::source_add $encoded_remote_url
+    if {[string first [source_line $encoded_remote_url] [read_conf]] < 0} {
+        return "FAIL: encoded remote URL was not preserved verbatim"
+    }
+    return "encoded remote URL preserved."
+} -cleanup $cleanup_sources -result "encoded remote URL preserved."
+
+test source_add_duplicate {
+    source_add returns the duplicate sentinel for an already-listed source.
+} -setup $setup_sources -body {
+    set rc [catch {macports::source_add $default_source_url} err]
+    if {$rc == 0} {
+        return "FAIL: duplicate source unexpectedly succeeded"
+    }
+    if {$err ne "duplicate"} {
+        return "FAIL: expected duplicate sentinel, got '$err'"
+    }
+    return "duplicate source rejected."
+} -cleanup $cleanup_sources -result "duplicate source rejected."
+
+test source_remove_deleted_local_path {
+    source_remove accepts a bare local path even after the underlying directory
+    has been deleted.
+} -setup $setup_sources -body {
+    set stale_dir [file join $pwd/tmpdir stale_source]
+    file mkdir $stale_dir
+    set stale_url "file://[file normalize $stale_dir]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default}] \
+        [source_line $stale_url]]]
+    file delete -force $stale_dir
+    macports::source_remove $stale_dir
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default}]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: stale local source was not removed correctly"
+    }
+    return "stale local path removed."
+} -cleanup $cleanup_sources -result "stale local path removed."
+
+test source_remove_default_reports_removed_default {
+    source_remove returns removed_default=1 when removing the only default source
+    and does not auto-promote another source.
+} -setup $setup_sources -body {
+    set local_dir [file join $pwd/tmpdir local_default_source]
+    file mkdir $local_dir
+    set local_url "file://[file normalize $local_dir]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $local_url {default}] \
+        [source_line $encoded_remote_url]]]
+    set result [macports::source_remove $local_dir]
+    if {![dict get $result removed_default]} {
+        return "FAIL: removed_default was not set"
+    }
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $encoded_remote_url]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: remaining source was unexpectedly modified"
+    }
+    return "remove reported removed_default without promotion."
+} -cleanup {
+    file delete -force [file join $pwd/tmpdir local_default_source]
+    eval $cleanup_sources
+} -result "remove reported removed_default without promotion."
+
+test source_remove_default_with_remaining_default {
+    source_remove returns has_remaining_default=1 when another source still
+    carries the default flag.
+} -setup $setup_sources -body {
+    set secondary_url "file://[file normalize $pwd/tmpdir/source_a]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default}] \
+        [source_line $secondary_url {default}]]]
+    set result [macports::source_remove $default_source_url]
+    if {![dict get $result removed_default]} {
+        return "FAIL: removed_default was not set"
+    }
+    if {![dict get $result has_remaining_default]} {
+        return "FAIL: has_remaining_default was not set"
+    }
+    return "remove detected remaining default."
+} -cleanup $cleanup_sources -result "remove detected remaining default."
+
+test source_set_default_preserves_unknown_flags {
+    source_set_default clears the explicit default from other sources while
+    preserving any unknown flags on all rewritten lines.
+} -setup $setup_sources -body {
+    set secondary_url "file://[file normalize $pwd/tmpdir/source_a]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default shadow}] \
+        [source_line $secondary_url {custom}]]]
+    macports::source_set_default $secondary_url
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {shadow}] \
+        [source_line $secondary_url {default custom}]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: set-default did not preserve unknown flags as expected"
+    }
+    return "set-default preserved unknown flags."
+} -cleanup $cleanup_sources -result "set-default preserved unknown flags."
+
+test source_unset_default_preserves_other_flags {
+    source_unset_default removes only the explicit default flag from the target
+    source.
+} -setup $setup_sources -body {
+    set target_url "file://[file normalize $pwd/tmpdir/source_b]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default}] \
+        [source_line $target_url {nosync default shadow}]]]
+    macports::source_unset_default $target_url
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default}] \
+        [source_line $target_url {nosync shadow}]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: unset-default removed more than the default flag"
+    }
+    return "unset-default preserved other flags."
+} -cleanup $cleanup_sources -result "unset-default preserved other flags."
+
+test source_remove_not_found {
+    source_remove returns the not-found sentinel for an unlisted source.
+} -setup $setup_sources -body {
+    set rc [catch {macports::source_remove "rsync://example.org/missing"} err]
+    if {$rc == 0} {
+        return "FAIL: removing a missing source unexpectedly succeeded"
+    }
+    if {$err ne "not-found"} {
+        return "FAIL: expected not-found sentinel, got '$err'"
+    }
+    return "missing source rejected."
+} -cleanup $cleanup_sources -result "missing source rejected."
+
+test port_source_cmd_opts_include_new_flags {
+    The source action accepts the new frontend flags and subcommands.
+} -body {
+    set source_opts [dict get $cmd_opts_array source]
+    foreach opt {list add remove set-default unset-default first no-sync default} {
+        if {[lsearch -exact $source_opts $opt] < 0} {
+            return "FAIL: source option '$opt' missing from cmd_opts_array"
+        }
+    }
+    return "source action options updated."
+} -result "source action options updated."
+
+test action_source_rejects_invalid_invocations {
+    action_source rejects invalid flag combinations and malformed argument
+    counts.
+} -setup $setup_sources -body {
+    set cases [list \
+        [list [list extra] [dict create ports_source_list 1] {Usage: port source [--list]}] \
+        [list [list $default_source_url] [dict create ports_source_first 1] "--first may only be used with --add."] \
+        [list [list $default_source_url] [dict create ports_source_default 1] "--default may only be used with --add."] \
+        [list [list $default_source_url $encoded_remote_url] [dict create ports_source_add 1] {Usage: port source --add [--first] [--no-sync] [--default] <url>}] \
+        [list [list $default_source_url] [dict create ports_source_add 1 ports_source_remove 1] "Only one source operation may be specified at a time."]]
+
+    foreach case $cases {
+        lassign $case portlist opts expected
+        set response [run_action_source $portlist $opts]
+        if {[dict get $response code] != 0 || [dict get $response result] != 1} {
+            return "FAIL: invalid invocation did not return status 1"
+        }
+        if {[string first $expected [join [dict get $response error] \n]] < 0} {
+            return "FAIL: expected error '$expected', got '[join [dict get $response error] { | }]'"
+        }
+    }
+    return "invalid invocations rejected."
+} -cleanup $cleanup_sources -result "invalid invocations rejected."
+
+test action_source_add_remove_path_with_spaces {
+    action_source can add and remove a local path containing spaces, including
+    managed flags written through the backend rewrite helper.
+} -setup $setup_sources -body {
+    set local_dir [file join $pwd/tmpdir "Frontend Source With Spaces"]
+    file mkdir $local_dir
+
+    set add_response [run_action_source [list $local_dir] \
+        [dict create ports_source_add 1 ports_source_first 1 ports_source_no-sync 1 ports_source_default 1]]
+    if {[dict get $add_response code] != 0 || [dict get $add_response result] != 0} {
+        return "FAIL: action_source add did not succeed"
+    }
+
+    set local_url "file://[file normalize $local_dir]"
+    set expected_after_add [conf_text [list \
+        "# MacPorts sources" \
+        "# another comment" \
+        "" \
+        [source_line $local_url {nosync default}] \
+        [source_line $default_source_url]]]
+    if {[read_conf] ne $expected_after_add} {
+        return "FAIL: action_source add wrote unexpected sources.conf contents"
+    }
+
+    set remove_response [run_action_source [list $local_dir] [dict create ports_source_remove 1]]
+    if {[dict get $remove_response code] != 0 || [dict get $remove_response result] != 0} {
+        return "FAIL: action_source remove did not succeed"
+    }
+    if {[string first $local_url [read_conf]] >= 0} {
+        return "FAIL: action_source remove left the local source behind"
+    }
+    return "action_source add/remove handled spaced path."
+} -cleanup {
+    file delete -force [file join $pwd/tmpdir "Frontend Source With Spaces"]
+    eval $cleanup_sources
+} -result "action_source add/remove handled spaced path."
+
+test action_source_remove_warns_on_default_removal {
+    action_source warns when removing the only source marked as default and does
+    not auto-promote another source.
+} -setup $setup_sources -body {
+    set local_dir [file join $pwd/tmpdir "Frontend Default Source"]
+    file mkdir $local_dir
+    set local_url "file://[file normalize $local_dir]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $local_url {default}] \
+        [source_line $encoded_remote_url]]]
+
+    set response [run_action_source [list $local_dir] [dict create ports_source_remove 1]]
+    if {[dict get $response code] != 0 || [dict get $response result] != 0} {
+        return "FAIL: action_source remove did not succeed"
+    }
+    if {[string first "No source is now explicitly marked as the default" \
+            [join [dict get $response warn] \n]] < 0} {
+        return "FAIL: action_source remove did not warn about missing default"
+    }
+
+    set expected [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $encoded_remote_url]]]
+    if {[read_conf] ne $expected} {
+        return "FAIL: remaining source was unexpectedly modified"
+    }
+    return "action_source remove warned about default removal."
+} -cleanup {
+    file delete -force [file join $pwd/tmpdir "Frontend Default Source"]
+    eval $cleanup_sources
+} -result "action_source remove warned about default removal."
+
+test action_source_set_and_unset_default {
+    action_source exposes the new default-management commands and preserves
+    non-managed flags.
+} -setup $setup_sources -body {
+    set secondary_url "file://[file normalize $pwd/tmpdir/source_a]"
+    write_conf [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url {default}] \
+        [source_line $secondary_url {shadow}]]]
+
+    set set_response [run_action_source [list $secondary_url] [dict create ports_source_set-default 1]]
+    if {[dict get $set_response code] != 0 || [dict get $set_response result] != 0} {
+        return "FAIL: action_source set-default did not succeed"
+    }
+    set expected_after_set [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url] \
+        [source_line $secondary_url {default shadow}]]]
+    if {[read_conf] ne $expected_after_set} {
+        return "FAIL: action_source set-default wrote unexpected contents"
+    }
+
+    set unset_response [run_action_source [list $secondary_url] [dict create ports_source_unset-default 1]]
+    if {[dict get $unset_response code] != 0 || [dict get $unset_response result] != 0} {
+        return "FAIL: action_source unset-default did not succeed"
+    }
+    set expected_after_unset [conf_text [list \
+        "# MacPorts sources" \
+        [source_line $default_source_url] \
+        [source_line $secondary_url {shadow}]]]
+    if {[read_conf] ne $expected_after_unset} {
+        return "FAIL: action_source unset-default wrote unexpected contents"
+    }
+    return "action_source set/unset default succeeded."
+} -cleanup $cleanup_sources -result "action_source set/unset default succeeded."
+
+test action_source_rejects_nonfile_url_with_spaces {
+    action_source surfaces backend validation errors for non-file URLs with
+    literal spaces.
+} -setup $setup_sources -body {
+    set response [run_action_source [list $invalid_remote_url] [dict create ports_source_add 1]]
+    if {[dict get $response code] != 0 || [dict get $response result] != 1} {
+        return "FAIL: invalid add invocation did not return status 1"
+    }
+    if {[string first "Invalid source URL" [join [dict get $response error] \n]] < 0} {
+        return "FAIL: expected invalid source URL error, got '[join [dict get $response error] { | }]'"
+    }
+    return "action_source rejected invalid remote URL."
+} -cleanup $cleanup_sources -result "action_source rejected invalid remote URL."
+
+cleanupTests

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -3870,6 +3870,175 @@ proc action_portcmds { action portlist opts } {
 }
 
 
+proc action_source { action portlist opts } {
+    global macports::sources_conf macports::sources
+
+    set usage_lines {
+        {  port source \[--list\]}
+        {  port source --add \[--first\] \[--no-sync\] \[--default\] <url>}
+        {  port source --remove <url>}
+        {  port source --set-default <url>}
+        {  port source --unset-default <url>}
+    }
+
+    # Determine which subcommand was requested; default to list.
+    set subcmds {}
+    foreach cmd {list add remove set-default unset-default} {
+        if {[dict exists $opts ports_source_$cmd]} {
+            lappend subcmds $cmd
+        }
+    }
+    if {[llength $subcmds] == 0} {
+        set command list
+    } elseif {[llength $subcmds] > 1} {
+        ui_error "Only one source operation may be specified at a time."
+        return 1
+    } else {
+        set command [lindex $subcmds 0]
+    }
+
+    set first [dict exists $opts ports_source_first]
+    set nosync [dict exists $opts ports_source_no-sync]
+    set make_default [dict exists $opts ports_source_default]
+
+    if {$command ne "add"} {
+        if {$first} {
+            ui_error "--first may only be used with --add."
+            return 1
+        }
+        if {$nosync} {
+            ui_error "--no-sync may only be used with --add."
+            return 1
+        }
+        if {$make_default} {
+            ui_error "--default may only be used with --add."
+            return 1
+        }
+    }
+
+    switch -- $command {
+        list {
+            if {[llength $portlist] != 0} {
+                ui_error "Usage: port source \[--list\]"
+                return 1
+            }
+            foreach src ${macports::sources} {
+                set url   [lindex $src 0]
+                set flags [lrange $src 1 end]
+                if {[llength $flags] > 0} {
+                    ui_msg "$url \[[join $flags ,]\]"
+                } else {
+                    ui_msg $url
+                }
+            }
+            return 0
+        }
+
+        add {
+            if {[llength $portlist] != 1} {
+                ui_error "Usage: port source --add \[--first\] \[--no-sync\] \[--default\] <url>"
+                return 1
+            }
+            set url [lindex $portlist 0]
+            if {[catch {macports::source_add $url $first $nosync $make_default} err]} {
+                ui_debug $::errorInfo
+                if {$err eq "duplicate"} {
+                    ui_error "Source '$url' is already listed in ${macports::sources_conf}."
+                } elseif {[string match "Insufficient privileges*" $err]} {
+                    ui_error $err
+                    ui_msg "Try running this command with sudo."
+                } else {
+                    ui_error $err
+                }
+                return 1
+            }
+            ui_msg "Source '$url' added to ${macports::sources_conf}."
+            ui_msg "Changes take effect the next time 'port' is invoked."
+            return 0
+        }
+
+        remove {
+            if {[llength $portlist] != 1} {
+                ui_error "Usage: port source --remove <url>"
+                return 1
+            }
+            set url [lindex $portlist 0]
+            if {[catch {set result [macports::source_remove $url]} err]} {
+                ui_debug $::errorInfo
+                if {$err eq "not-found"} {
+                    ui_error "Source '$url' not found in ${macports::sources_conf}."
+                } elseif {[string match "Insufficient privileges*" $err]} {
+                    ui_error $err
+                    ui_msg "Try running this command with sudo."
+                } else {
+                    ui_error $err
+                }
+                return 1
+            }
+            ui_msg "Source '$url' removed from ${macports::sources_conf}."
+            if {[dict get $result removed_default] && ![dict get $result has_remaining_default]} {
+                ui_warn "The removed source was marked as the default. No source is now explicitly marked as the default in ${macports::sources_conf}."
+            }
+            ui_msg "Changes take effect the next time 'port' is invoked."
+            return 0
+        }
+
+        set-default {
+            if {[llength $portlist] != 1} {
+                ui_error "Usage: port source --set-default <url>"
+                return 1
+            }
+            set url [lindex $portlist 0]
+            if {[catch {macports::source_set_default $url} err]} {
+                ui_debug $::errorInfo
+                if {$err eq "not-found"} {
+                    ui_error "Source '$url' not found in ${macports::sources_conf}."
+                } elseif {[string match "Insufficient privileges*" $err]} {
+                    ui_error $err
+                    ui_msg "Try running this command with sudo."
+                } else {
+                    ui_error $err
+                }
+                return 1
+            }
+            ui_msg "Source '$url' set as the default in ${macports::sources_conf}."
+            ui_msg "Changes take effect the next time 'port' is invoked."
+            return 0
+        }
+
+        unset-default {
+            if {[llength $portlist] != 1} {
+                ui_error "Usage: port source --unset-default <url>"
+                return 1
+            }
+            set url [lindex $portlist 0]
+            if {[catch {macports::source_unset_default $url} err]} {
+                ui_debug $::errorInfo
+                if {$err eq "not-found"} {
+                    ui_error "Source '$url' not found in ${macports::sources_conf}."
+                } elseif {[string match "Insufficient privileges*" $err]} {
+                    ui_error $err
+                    ui_msg "Try running this command with sudo."
+                } else {
+                    ui_error $err
+                }
+                return 1
+            }
+            ui_msg "Explicit default flag removed from source '$url' in ${macports::sources_conf}."
+            ui_msg "Changes take effect the next time 'port' is invoked."
+            return 0
+        }
+
+        default {
+            ui_error "Unknown source command '$command'."
+            foreach line $usage_lines {
+                ui_msg $line
+            }
+            return 1
+        }
+    }
+}
+
 proc action_sync { action portlist opts } {
     global global_options
     set status 0
@@ -4153,6 +4322,7 @@ set action_array [dict create \
     deactivate  [list action_deactivate     $action_args::PORTS] \
     \
     select      [list action_select         $action_args::STRINGS] \
+    source      [list action_source         $action_args::STRINGS] \
     \
     sync        [list action_sync           $action_args::NONE] \
     selfupdate  [list action_selfupdate     $action_args::NONE] \
@@ -4315,6 +4485,7 @@ set cmd_opts_array [dict create {*}{
     mirror      {new}
     lint        {nitpick}
     select      {list set show summary}
+    source      {list add remove set-default unset-default first no-sync default}
     log         {{phase 1} {level 1}}
     upgrade     {force enforce-variants no-replace no-rev-upgrade}
     rev-upgrade {id-loadcmd-check}


### PR DESCRIPTION
Add `port source` to list, add, remove, and manage default-flag state
of entries in sources.conf.

--add supports --first (insert before existing sources), --no-sync
(append [nosync] flag), and --default (mark as the explicit default,
clearing it from other sources).

--set-default and --unset-default toggle the [default] flag on
existing entries.

--remove warns if the removed source was the only explicit default.

Bare local paths starting with / or ~ are automatically normalized and
converted to file:// URLs; local paths with spaces are supported.

Write operations are atomic (write to temp file, then rename), check
for write permission, and emit a sudo hint on failure.

Business logic uses a structured read-parse-modify-write pipeline in
macports1.0/macports.tcl: source_read_conf / source_parse_line /
source_write_conf / source_render_record handle round-tripping the
file while preserving comments and blank lines. port.tcl contains the
thin UI wrapper (action_source).

Uses file tildeexpand before file normalize for Tcl 9 compatibility,
where file normalize no longer performs tilde expansion.

Includes 22 tcltest unit tests (sources.test), a new port-source(1)
man page (port-source.1.txt), and updates to port(1) and
sources.conf(5).

Fixes: https://trac.macports.org/ticket/73683