### PR TITLE
port: add depends_bump

### DIFF
--- a/src/port1.0/portdepends.tcl
+++ b/src/port1.0/portdepends.tcl
@@ -37,9 +37,9 @@ namespace eval portdepends {
 }
 
 # define options
-options depends_fetch depends_extract depends_patch depends_build depends_run depends_lib depends_test depends
+options depends_fetch depends_extract depends_patch depends_build depends_run depends_lib depends_test depends_bump depends
 # Export options via PortInfo
-options_export depends_fetch depends_extract depends_patch depends_build depends_lib depends_run depends_test
+options_export depends_fetch depends_extract depends_patch depends_build depends_lib depends_run depends_test depends_bump
 
 option_proc depends_fetch portdepends::validate_depends_options
 option_proc depends_extract portdepends::validate_depends_options
@@ -48,6 +48,7 @@ option_proc depends_build portdepends::validate_depends_options
 option_proc depends_run portdepends::validate_depends_options
 option_proc depends_lib portdepends::validate_depends_options
 option_proc depends_test portdepends::validate_depends_options
+option_proc depends_bump portdepends::validate_depends_options
 
 # New option for the new dependency. We generate a warning because we don't handle this yet.
 option_proc depends portdepends::validate_depends_options_new

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1458,6 +1458,7 @@ proc target_run {ditem} {
                     switch $target {
                         fetch       -
                         checksum    { set deptypes [list depends_fetch] }
+                        bump        { set deptypes [list depends_bump] }
                         extract     { set deptypes [list depends_fetch depends_extract] }
                         patch       { set deptypes [list depends_fetch depends_extract depends_patch] }
                         configure   -


### PR DESCRIPTION
Small change to add support for `depends_bump`. This will be useful especially for being able to support external utilities to help in bumping Portfiles with more complicated checksums or logic like the `cargo` portgroup's `cargo.crates`.

@jmroot, this is a minuscule change. Can we simply merge?