### PR TITLE
make: skip autoconf regeneration for clean/distclean goals

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,6 +16,11 @@ include Mk/macports.autoconf.mk
 
 all:: Mk/macports.autoconf.mk
 
+# Skip the auto-regeneration rules when the only goals are clean/distclean.
+# Otherwise GNU Make tries to remake the included Mk/macports.autoconf.mk,
+# which cascades through config.status -> configure and even runs "make
+# clean" again as a side effect.
+ifneq (,$(filter-out clean distclean,$(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)))
 Mk/macports.autoconf.mk: Mk/macports.autoconf.mk.in src/config.h.in Makefile.in doc/Makefile.in src/Makefile.in src/cregistry/Makefile.in src/darwintracelib1.0/Makefile.in src/darwintracelib1.0/tests/Makefile.in src/machista1.0/Makefile.in src/macports1.0/Makefile.in src/mpcommon1.0/Makefile.in src/package1.0/Makefile.in src/pextlib1.0/Makefile.in src/portlist1.0/Makefile.in src/port/Makefile.in src/port1.0/Makefile.in src/programs/Makefile.in src/programs/daemondo/Makefile.in src/registry2.0/Makefile.in tests/Makefile.in vendor/Makefile.in config.status
 	./config.status
 	"$(MAKE)" clean
@@ -28,6 +33,7 @@ config.status: configure
 		set -x ;						\
 		echo "Source tree not configured. Use ./configure" ; \
 	fi
+endif
 
 include $(srcdir)/Mk/macports.subdir.mk
 


### PR DESCRIPTION
GNU Make tries to remake any included makefile, so `include Mk/macports.autoconf.mk` causes the top-level `Mk/macports.autoconf.mk:` rule to fire. That rule depends on `config.status`, whose rule re-runs `./config.status --recheck` (effectively `./configure`), and the autoconf.mk recipe then runs `make clean` as a side effect.

The result: `make clean` and `make distclean` both trigger a configure run before cleaning, which is wasteful and surprising.

Skip the regeneration rules entirely when the only goals on the command line are clean or distclean. Any other goal (or the default build) still picks up configuration changes as before.