### PR TITLE
Add  unprivileged --local / -L Portfile development build mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@
 ###
 
 Release 2.13.0 (unreleased)
+    - Added --local (-L) developer build mode, which runs non-installing
+      phases as a regular user using work, distfiles, and logs under the
+      Portfile directory without modifying the MacPorts installation.
+      (perry)
+
     - Added a -T flag to prepend ISO 8601 timestamps to each line of
       output, and elapsed time logging for each phase.
       (#2020, herbygillot in 037d168)

--- a/doc/port.1
+++ b/doc/port.1
@@ -24,7 +24,7 @@ port \- Command line interface for MacPorts
 .SH "SYNOPSIS"
 .sp
 .nf
-\fBport\fR [\fB\-bcdfknNopqRstuvy\fR] [\fB\-D\fR \fIportdir\fR|\fIportname\fR] [\fB\-F\fR \fIcmdfile\fR] [\fIaction\fR] [\fIactionflags\fR]
+\fBport\fR [\fB\-bcdfkLnNopqRstTuvy\fR] [\fB\-D\fR \fIportdir\fR|\fIportname\fR] [\fB\-F\fR \fIcmdfile\fR] [\fIaction\fR] [\fIactionflags\fR]
      [[\fIportname\fR | \fIpseudo\-portname\fR | \fIport\-expressions\fR | \fIport\-url\fR]]
      [[\fI@version\fR] [+/\-variant \&...] \&... [option=value \&...]]
 .fi
@@ -524,6 +524,20 @@ Despite any errors encountered, proceed to process multiple ports and commands\&
 .RE
 .PP
 \fBDevelopment\fR
+.PP
+\-L, \-\-local
+.RS 4
+Run developer local build mode from a Portfile directory\&. This mode is intended for non\-root testing of edited Portfiles\&. It stores mutable build state, fetched distfiles, and logs under ${portpath}/work, uses the registry only to verify that dependencies are already installed and active, and does not install missing dependencies or modify the MacPorts installation\&. Supported actions are
+\fBfetch\fR,
+\fBchecksum\fR,
+\fBextract\fR,
+\fBpatch\fR,
+\fBconfigure\fR,
+\fBbuild\fR,
+\fBtest\fR,
+\fBdestroot\fR, and
+\fBclean\fR\&.
+.RE
 .PP
 \-o
 .RS 4

--- a/doc/port.1.txt
+++ b/doc/port.1.txt
@@ -9,7 +9,7 @@ port - Command line interface for MacPorts
 SYNOPSIS
 --------
 [cmdsynopsis]
-*port* [*-bcdfknNopqRstuvy*] [*-D* 'portdir'|'portname'] [*-F* 'cmdfile'] ['action'] ['actionflags']
+*port* [*-bcdfkLnNopqRstTuvy*] [*-D* 'portdir'|'portname'] [*-F* 'cmdfile'] ['action'] ['actionflags']
      [['portname' | 'pseudo-portname' | 'port-expressions' | 'port-url']]
      [['@version'] [+/-variant ...] ... [option=value ...]]
 
@@ -176,6 +176,15 @@ The port command recognizes several global flags and options.
     commands.
 
 .Development
+-L, --local::
+    Run developer local build mode from a Portfile directory. This mode is
+    intended for non-root testing of edited Portfiles. It stores mutable build
+    state, fetched distfiles, and logs under $\{portpath\}/work, uses the
+    registry only to verify that dependencies are already installed and active,
+    and does not install missing dependencies or modify the MacPorts
+    installation. Supported actions are *fetch*, *checksum*, *extract*, *patch*,
+    *configure*, *build*, *test*, *destroot*, and *clean*.
+
 -o::
     Honor state files even if the Portfile was modified. This flag is called -o
     because it used to mean "older".

--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -236,6 +236,10 @@ proc macports::set_global_options {opts} {
     }
 }
 
+proc macports::local_mode_registry_write {args} {
+    return -code error "--local does not permit registry writes"
+}
+
 
 proc macports::init_logging {mport} {
     if {[getuid] == 0 && [geteuid] != 0} {
@@ -2001,6 +2005,9 @@ match macports.conf.default."
     # init registry
     set db_path [file join ${registry.path} registry registry.db]
     set db_exists [file exists $db_path]
+    if {[macports::global_option_isset ports_local] && !$db_exists} {
+        error "--local could not read installed dependency state because the registry does not exist."
+    }
     registry::open $db_path
 
     # convert any flat receipts if we just created a new db
@@ -2165,6 +2172,7 @@ proc macports::worker_init {workername portpath porturl portbuildpath options va
     $workername alias macports_create_thread macports::create_thread
     $workername alias getportbuildpath macports::getportbuildpath
     $workername alias getportworkpath_from_buildpath macports::getportworkpath_from_buildpath
+    $workername alias getportworkpath_from_portdir macports::getportworkpath_from_portdir
     $workername alias getportresourcepath macports::getportresourcepath
     $workername alias getportlogpath macports::getportlogpath
     $workername alias getdefaultportresourcepath macports::getdefaultportresourcepath
@@ -2184,22 +2192,36 @@ proc macports::worker_init {workername portpath porturl portbuildpath options va
     $workername alias _mport_supports_archs macports::_mport_supports_archs
 
     # New Registry/Receipts stuff
-    $workername alias registry_new registry::new_entry
+    set local_mode [expr {[dict exists $options ports_local] && [string is true -strict [dict get $options ports_local]]}]
+    if {$local_mode} {
+        $workername alias registry_new macports::local_mode_registry_write
+        $workername alias registry_write macports::local_mode_registry_write
+        $workername alias registry_prop_store macports::local_mode_registry_write
+        $workername alias registry_activate macports::local_mode_registry_write
+        $workername alias registry_deactivate macports::local_mode_registry_write
+        $workername alias registry_deactivate_composite macports::local_mode_registry_write
+        $workername alias registry_install macports::local_mode_registry_write
+        $workername alias registry_uninstall macports::local_mode_registry_write
+        $workername alias registry_register_deps macports::local_mode_registry_write
+        $workername alias registry_bulk_register_files macports::local_mode_registry_write
+    } else {
+        $workername alias registry_new registry::new_entry
+        $workername alias registry_write registry::write_entry
+        $workername alias registry_prop_store registry::property_store
+        $workername alias registry_activate portimage::activate
+        $workername alias registry_deactivate portimage::deactivate
+        $workername alias registry_deactivate_composite portimage::deactivate_composite
+        $workername alias registry_install portimage::install
+        $workername alias registry_uninstall registry_uninstall::uninstall
+        $workername alias registry_register_deps registry::register_dependencies
+        $workername alias registry_bulk_register_files registry::register_bulk_files
+    }
     $workername alias registry_open registry::open_entry
-    $workername alias registry_write registry::write_entry
-    $workername alias registry_prop_store registry::property_store
     $workername alias registry_prop_retr registry::property_retrieve
     $workername alias registry_exists registry::entry_exists
     $workername alias registry_exists_for_name registry::entry_exists_for_name
-    $workername alias registry_activate portimage::activate
-    $workername alias registry_deactivate portimage::deactivate
-    $workername alias registry_deactivate_composite portimage::deactivate_composite
-    $workername alias registry_install portimage::install
-    $workername alias registry_uninstall registry_uninstall::uninstall
-    $workername alias registry_register_deps registry::register_dependencies
     $workername alias registry_fileinfo_for_index registry::fileinfo_for_index
     $workername alias registry_fileinfo_for_file registry::fileinfo_for_file
-    $workername alias registry_bulk_register_files registry::register_bulk_files
     $workername alias registry_active registry::active
     $workername alias registry_file_registered registry::file_registered
     $workername alias registry_port_registered registry::port_registered
@@ -3036,10 +3058,167 @@ proc macports::async_fetch_mport {target mport} {
     }
 }
 
+proc macports::_local_check_dependencies {mport target} {
+    set workername [ditem_key $mport workername]
+    set portinfo [mportinfo $mport]
+    set required_archs [$workername eval [list get_canonical_archs]]
+    set depends_skip_archcheck [_mportkey $mport depends_skip_archcheck]
+
+    foreach deptype [macports::_deptypes_for_target $target $workername] {
+        if {![dict exists $portinfo $deptype]} {
+            continue
+        }
+        foreach depspec [dict get $portinfo $deptype] {
+            set present [_mportispresent $mport $depspec]
+            set dep_portname [$workername eval [list _get_dep_port $depspec]]
+            if {$dep_portname eq ""} {
+                set dep_portname [lindex [split $depspec :] end]
+            }
+            if {!$present} {
+                ui_error "Dependency $dep_portname is not installed and active."
+                ui_error "--local does not install missing dependencies."
+                ui_error "Install the dependency separately, then rerun the --local build."
+                return 1
+            }
+            if {$dep_portname ne ""
+                && [_portnameactive $dep_portname]
+                && [macports::_deptype_needs_archcheck $deptype]
+                && [lsearch -exact -nocase $depends_skip_archcheck $dep_portname] == -1
+                && ![macports::_active_supports_archs $dep_portname $required_archs]} {
+                ui_error "Dependency $dep_portname is installed and active, but does not support the required archs '$required_archs'."
+                ui_error "--local does not reinstall dependencies with different variants or archs."
+                return 1
+            }
+        }
+    }
+    return 0
+}
+
+proc macports::_mportexec_install_dependencies {mport target} {
+    variable ui_prefix
+    variable no_build_targets
+
+    set workername [ditem_key $mport workername]
+    set dlist [list]
+    set locked no
+    set result {}
+
+    try {
+        registry::exclusive_lock
+        set locked yes
+
+        # see if we actually need to build this port
+        if {![dict exists $no_build_targets $target] ||
+            ![$workername eval {registry_exists $subport $version $revision $portvariants}]} {
+
+            # upgrade dependencies that are already installed
+            if {![macports::global_option_isset ports_nodeps]} {
+                macports::_upgrade_mport_deps $mport $target
+            }
+        }
+
+        ui_msg -nonewline "$ui_prefix Computing dependencies for [_mportkey $mport subport]"
+        if {[macports::ui_isset ports_debug]} {
+            # play nice with debug messages
+            ui_msg {}
+        }
+        if {[mportdepends $mport $target 1 1 0 dlist] != 0} {
+            foreach ditem $dlist {
+                catch {mportclose $ditem}
+            }
+            return failed
+        }
+        if {![macports::ui_isset ports_debug]} {
+            ui_msg {}
+        }
+
+        # print the dep list
+        if {[llength $dlist] > 0} {
+            ##
+            # User Interaction Question
+            # Asking before installing dependencies
+            variable ui_options
+            if {[info exists ui_options(questions_yesno)]} {
+                set deplist [list]
+                foreach ditem $dlist {
+                    set depstring [ditem_key $ditem provides]
+                    set portinfo [mportinfo $ditem]
+                    if {[dict exists $portinfo canonical_active_variants]} {
+                        append depstring " [dict get $portinfo canonical_active_variants]"
+                    }
+                    lappend deplist $depstring
+                }
+                set retvalue [$ui_options(questions_yesno) "The following dependencies will be installed: " "TestCase#2" [lsort $deplist] {y} 0]
+                if {$retvalue == 1} {
+                    foreach ditem $dlist {
+                        mportclose $ditem
+                    }
+                    return declined
+                }
+            } else {
+                set depstring "$ui_prefix Dependencies to be installed:"
+                foreach ditem $dlist {
+                    append depstring " [ditem_key $ditem provides]"
+                }
+                ui_msg $depstring
+            }
+        }
+
+        # Start background fetch of files
+        set result [dlist_eval $dlist _mportinstalled [list macports::async_fetch_mport activate]]
+        if {$result ne ""} {
+            ui_debug "Error starting asynchronous file fetch: $dlist_eval_reason"
+        }
+        macports::async_fetch_mport $target $mport
+
+        # install them
+        set result [dlist_eval $dlist _mportactive [list _mportexec activate]]
+    } finally {
+        if {$locked} {
+            if {[getuid] == 0 && [geteuid] != 0} {
+                seteuid 0; setegid 0
+            }
+
+            registry::exclusive_unlock
+        }
+    }
+
+    if {$result ne ""} {
+        ##
+        # When this happens, the failing port usually already printed an error
+        # message. Don't print another here to avoid cluttering the output and
+        # hiding the *real* problem, unless the problem appears to be a
+        # circular dependency, which won't have produced an error message yet.
+
+        if {$dlist_eval_reason eq "unmet_deps"} {
+            set errstring "The following dependencies were not installed\
+                because all of them have unmet dependencies (likely due\
+                to a dependency cycle):"
+            foreach ditem $result {
+                append errstring " [ditem_key $ditem provides]"
+            }
+            ui_error $errstring
+            foreach ditem $result {
+                ui_debug "[ditem_key $ditem provides] requires: [ditem_key $ditem requires]"
+            }
+        }
+        foreach ditem $dlist {
+            catch {mportclose $ditem}
+        }
+        return failed
+    }
+
+    # Close the dependencies; we're done installing them.
+    foreach ditem $dlist {
+        mportclose $ditem
+    }
+    return ok
+}
+
 # mportexec
 # Execute the specified target of the given mport.
 proc mportexec {mport target} {
-    global macports::ui_prefix macports::portautoclean
+    global macports::portautoclean
     set workername [ditem_key $mport workername]
 
     # check for existence of macportsuser and use fallback if necessary
@@ -3075,121 +3254,35 @@ proc mportexec {mport target} {
     }
 
     # Before we build the port, we must build its dependencies.
-    set dlist [list]
     if {[macports::_target_needs_deps $target] && [macports::_mport_has_deptypes $mport [macports::_deptypes_for_target $target $workername]]} {
-        registry::exclusive_lock
-        global macports::no_build_targets
-        # see if we actually need to build this port
-        if {![dict exists $no_build_targets $target] ||
-            ![$workername eval {registry_exists $subport $version $revision $portvariants}]} {
-
-            # upgrade dependencies that are already installed
-            if {![macports::global_option_isset ports_nodeps]} {
-                macports::_upgrade_mport_deps $mport $target
-            }
-        }
-
-        ui_msg -nonewline "$ui_prefix Computing dependencies for [_mportkey $mport subport]"
-        if {[macports::ui_isset ports_debug]} {
-            # play nice with debug messages
-            ui_msg {}
-        }
-        if {[mportdepends $mport $target 1 1 0 dlist] != 0} {
-            if {$log_needs_pop} {
-                macports::pop_log
-            }
-            foreach ditem $dlist {
-                catch {mportclose $ditem}
-            }
-            return 1
-        }
-        if {![macports::ui_isset ports_debug]} {
-            ui_msg {}
-        }
-
-        # print the dep list
-        if {[llength $dlist] > 0} {
-            ##
-            # User Interaction Question
-            # Asking before installing dependencies
-            global macports::ui_options
-            if {[info exists ui_options(questions_yesno)]} {
-                set deplist [list]
-                foreach ditem $dlist {
-                    set depstring [ditem_key $ditem provides]
-                    set portinfo [mportinfo $ditem]
-                    if {[dict exists $portinfo canonical_active_variants]} {
-                        append depstring " [dict get $portinfo canonical_active_variants]"
-                    }
-                    lappend deplist $depstring
+        if {[macports::global_option_isset ports_local]} {
+            if {[macports::_local_check_dependencies $mport $target]} {
+                if {$log_needs_pop} {
+                    macports::pop_log
                 }
-                set retvalue [$ui_options(questions_yesno) "The following dependencies will be installed: " "TestCase#2" [lsort $deplist] {y} 0]
-                if {$retvalue == 1} {
+                return 1
+            }
+            macports::async_fetch_mport $target $mport
+        } else {
+            set dep_status [macports::_mportexec_install_dependencies $mport $target]
+            switch -- $dep_status {
+                ok {}
+                failed {
                     if {$log_needs_pop} {
                         macports::pop_log
                     }
-                    foreach ditem $dlist {
-                        mportclose $ditem
+                    return 1
+                }
+                declined {
+                    if {$log_needs_pop} {
+                        macports::pop_log
                     }
                     return 0
                 }
-            } else {
-                set depstring "$ui_prefix Dependencies to be installed:"
-                foreach ditem $dlist {
-                    append depstring " [ditem_key $ditem provides]"
-                }
-                ui_msg $depstring
-            }
-        }
-
-        # Start background fetch of files
-        set result [dlist_eval $dlist _mportinstalled [list macports::async_fetch_mport activate]]
-        if {$result ne ""} {
-            ui_debug "Error starting asynchronous file fetch: $dlist_eval_reason"
-        }
-        macports::async_fetch_mport $target $mport
-
-        # install them
-        set result [dlist_eval $dlist _mportactive [list _mportexec activate]]
-
-        if {[getuid] == 0 && [geteuid] != 0} {
-            seteuid 0; setegid 0
-        }
-
-        registry::exclusive_unlock
-
-        if {$result ne ""} {
-            ##
-            # When this happens, the failing port usually already printed an
-            # error message. Don't print another here to avoid cluttering the
-            # output and hiding the *real* problem, unless the problem
-            # appears to be a circular dependency, which won't have produced
-            # an error message yet.
-
-            if {$dlist_eval_reason eq "unmet_deps"} {
-                set errstring "The following dependencies were not installed\
-                    because all of them have unmet dependencies (likely due\
-                    to a dependency cycle):"
-                foreach ditem $result {
-                    append errstring " [ditem_key $ditem provides]"
-                }
-                ui_error $errstring
-                foreach ditem $result {
-                    ui_debug "[ditem_key $ditem provides] requires: [ditem_key $ditem requires]"
+                default {
+                    error "Internal error: unexpected dependency install result '$dep_status'"
                 }
             }
-            foreach ditem $dlist {
-                catch {mportclose $ditem}
-            }
-            if {$log_needs_pop} {
-                macports::pop_log
-            }
-            return 1
-        }
-
-        # Close the dependencies; we're done installing them.
-        foreach ditem $dlist {
-            mportclose $ditem
         }
     } else {
         # No dependencies, but we still need to check for conflicts.
@@ -3436,8 +3529,15 @@ proc macports::getportbuildpath {id {portname {}}} {
     return [file normalize [file join $portdbpath build ${portname}-${path_hash}]]
 }
 
+proc macports::getportlocalworkpath_from_portdir {portpath} {
+    return [file normalize [file join $portpath work]]
+}
+
 proc macports::getportlogpath {id {portname {}}} {
     variable portdbpath
+    if {[macports::global_option_isset ports_local]} {
+        return [file join [macports::getportlocalworkpath_from_portdir $id] logs $portname]
+    }
     set port_path [string map {:// . / _} $id]
     return [file join $portdbpath logs $port_path $portname]
 }
@@ -3447,6 +3547,9 @@ proc macports::getportworkpath_from_buildpath {portbuildpath} {
 }
 
 proc macports::getportworkpath_from_portdir {portpath {portname {}}} {
+    if {[macports::global_option_isset ports_local]} {
+        return [macports::getportlocalworkpath_from_portdir $portpath]
+    }
     return [macports::getportworkpath_from_buildpath [macports::getportbuildpath $portpath $portname]]
 }
 

--- a/src/port/port.tcl
+++ b/src/port/port.tcl
@@ -51,7 +51,7 @@ package require portlist
 proc print_usage {{verbose 1}} {
     global cmdname
     set syntax {
-        [-bcdfknNopqRstTuvy] [-D portdir|portname] [-F cmdfile] action [actionflags]
+        [-bcdfkLnNopqRstTuvy] [-D portdir|portname] [-F cmdfile] action [actionflags]
         [[portname|pseudo-portname|port-url] [@version] [+-variant]... [option=value]...]...
     }
 
@@ -80,6 +80,64 @@ proc fatal_softcontinue s {
     } else {
         fatal $s
     }
+}
+
+set local_allowed_actions [list fetch checksum extract patch configure build test destroot clean]
+
+proc local_mode_enabled {} {
+    global global_options
+    return [expr {[info exists global_options(ports_local)] && [string is true -strict $global_options(ports_local)]}]
+}
+
+proc local_mode_error {msg} {
+    if {[llength [info commands ui_error]] > 0} {
+        ui_error $msg
+    } else {
+        puts stderr "Error: $msg"
+    }
+}
+
+proc local_mode_refuse_root {} {
+    if {[geteuid] == 0} {
+        local_mode_error "--local may not be used as root."
+        local_mode_error "Run this command as the user who owns the checkout."
+        exit 1
+    }
+}
+
+proc validate_local_mode_action {action} {
+    global local_allowed_actions
+    if {$action ni $local_allowed_actions} {
+        local_mode_error "--local does not support '$action' because it may modify the MacPorts installation."
+        local_mode_error "Supported --local actions are: [join $local_allowed_actions {, }]."
+        return 1
+    }
+    return 0
+}
+
+proc validate_local_mode_command_list {args} {
+    set argc [llength $args]
+    set argn 0
+    while {$argn < $argc} {
+        set action [lindex $args $argn]
+        incr argn
+        if {$action eq ";"} {
+            continue
+        }
+        if {[string index $action 0] eq "#"} {
+            break
+        }
+        set actions [find_action $action]
+        if {[llength $actions] == 1} {
+            if {[validate_local_mode_action [lindex $actions 0]]} {
+                return 1
+            }
+        }
+        while {$argn < $argc && [lindex $args $argn] ne ";"} {
+            incr argn
+        }
+    }
+    return 0
 }
 
 
@@ -4353,6 +4411,14 @@ proc parse_options { action ui_options_name global_options_name } {
                 }
                 default {
                     set key [string range $arg 2 end]
+                    if {$key eq "local"} {
+                        if {$action ne "global"} {
+                            return -code error "${action} does not accept --local; specify --local before the action"
+                        }
+                        set global_options(ports_local) yes
+                        advance
+                        continue
+                    }
                     set kopts [cmd_option_matches $action $key]
                     if {[llength $kopts] == 0} {
                         return -code error "${action} does not accept --${key}"
@@ -4437,6 +4503,12 @@ proc parse_options { action ui_options_name global_options_name } {
                     k {
                         set global_options(ports_autoclean) no
                     }
+                    L {
+                        if {$action ne "global"} {
+                            return -code error "${action} does not accept -L; specify -L before the action"
+                        }
+                        set global_options(ports_local) yes
+                    }
                     t {
                         set global_options(ports_trace) yes
                     }
@@ -4484,6 +4556,9 @@ proc lock_reg_if_needed {action} {
         upgrade -
         uninstall -
         install {
+            if {[local_mode_enabled]} {
+                return -code error "Internal error: --local attempted to take the registry write lock for '$action'."
+            }
             registry::exclusive_lock
             return 1
         }
@@ -4519,15 +4594,7 @@ proc process_cmd { argv } {
             break
         }
 
-        try {
-            set locked [lock_reg_if_needed $action]
-        } trap {POSIX SIG SIGINT} {} {
-            set action_status 1
-            break
-        } trap {POSIX SIG SIGTERM} {} {
-            set action_status 1
-            break
-        }
+        set locked 0
         # Always start out processing an action in current_portdir
         cd $current_portdir
 
@@ -4562,6 +4629,14 @@ proc process_cmd { argv } {
             break
         }
 
+        if {[local_mode_enabled]} {
+            local_mode_refuse_root
+            if {[validate_local_mode_action $action]} {
+                set action_status 1
+                break
+            }
+        }
+
         # Merge new options into the macports API options
         array unset mp_global_options
         array set mp_global_options $mp_global_options_base
@@ -4575,6 +4650,20 @@ proc process_cmd { argv } {
 
         # Some options could change verbosity, so re-init ui channels
         macports::ui_init_all
+
+        try {
+            set locked [lock_reg_if_needed $action]
+        } trap {POSIX SIG SIGINT} {} {
+            set action_status 1
+            break
+        } trap {POSIX SIG SIGTERM} {} {
+            set action_status 1
+            break
+        } on error {result} {
+            ui_error $result
+            set action_status 1
+            break
+        }
 
         # What kind of arguments does the command expect?
         set expand [action_needs_portlist $action]
@@ -5599,6 +5688,9 @@ if {[catch {parse_options "global" ui_options global_options} result]} {
     print_usage
     exit 1
 }
+if {[local_mode_enabled]} {
+    local_mode_refuse_root
+}
 
 if {[isatty stderr]
     && $portclient::progress::hasTermAnsiSend eq "yes"
@@ -5622,6 +5714,10 @@ set ui_options(notifications_system) portclient::notifications::system_append
 
 # Get arguments remaining after option processing
 set remaining_args [lrange $cmd_argv $cmd_argn end]
+
+if {[local_mode_enabled] && [validate_local_mode_command_list $remaining_args]} {
+    exit 1
+}
 
 # If we have no arguments remaining after option processing then force
 # shell mode

--- a/src/port1.0/portclean.tcl
+++ b/src/port1.0/portclean.tcl
@@ -49,18 +49,24 @@ namespace eval portclean {
 set_ui_prefix
 
 proc portclean::clean_start {args} {
-    global UI_PREFIX
+    global UI_PREFIX ports_local
 
     ui_notice "$UI_PREFIX [format [msgcat::mc "Cleaning %s"] [option subport]]"
 
-    if {[getuid] == 0 && [geteuid] != 0} {
+    if {![tbool ports_local] && [getuid] == 0 && [geteuid] != 0} {
         elevateToRoot "clean"
     }
 }
 
 proc portclean::clean_main {args} {
     global UI_PREFIX ports_clean_dist ports_clean_work ports_clean_logs \
-           ports_clean_archive ports_clean_all keeplogs
+           ports_clean_archive ports_clean_all keeplogs ports_local
+
+    if {[tbool ports_local]} {
+        ui_info "$UI_PREFIX [format [msgcat::mc "Removing local work directory for %s"] [option subport]]"
+        clean_work
+        return 0
+    }
 
     if {[info exists ports_clean_all] && $ports_clean_all eq "yes" || \
         [info exists ports_clean_dist] && $ports_clean_dist eq "yes"} {
@@ -175,7 +181,22 @@ proc portclean::clean_dist {args} {
 }
 
 proc portclean::clean_work {args} {
-    global portbuildpath subbuildpath worksymlink subport
+    global portbuildpath subbuildpath worksymlink subport ports_local workpath
+
+    if {[tbool ports_local]} {
+        if {[file isdirectory $workpath]} {
+            ui_debug "Removing local work directory: ${workpath}"
+            macports_try -pass_signal {
+                delete $workpath
+            } on error {eMessage} {
+                ui_debug "$::errorInfo"
+                ui_error "$eMessage"
+            }
+        } else {
+            ui_debug "No local work directory found at ${workpath}"
+        }
+        return 0
+    }
 
     if {[file isdirectory $subbuildpath]} {
         ui_debug "Removing directory: ${subbuildpath}"

--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -99,7 +99,12 @@ proc portmain::get_subbuildpath {} {
     set subdir [expr {$subport ne "" ? $subport : [file tail $portpath]}]
     return [getportbuildpath $portpath $subdir]
 }
-default workpath {[getportworkpath_from_buildpath $subbuildpath]}
+proc portmain::get_workpath {} {
+    global portpath subport
+    set subdir [expr {$subport ne "" ? $subport : [file tail $portpath]}]
+    return [getportworkpath_from_portdir $portpath $subdir]
+}
+default workpath {[portmain::get_workpath]}
 default prefix /opt/local
 default applications_dir /Applications/MacPorts
 default frameworks_dir {${prefix}/Library/Frameworks}
@@ -162,7 +167,14 @@ set euid [geteuid]
 set egid [getegid]
 
 default worksymlink {[file normalize [file join $portpath work]]}
-default distpath {[file normalize [file join $portdbpath distfiles ${dist_subdir}]]}
+proc portmain::get_distpath {} {
+    global ports_local workpath portdbpath dist_subdir
+    if {[tbool ports_local]} {
+        return [file normalize [file join $workpath distfiles ${dist_subdir}]]
+    }
+    return [file normalize [file join $portdbpath distfiles ${dist_subdir}]]
+}
+default distpath {[portmain::get_distpath]}
 
 default use_xcode {[expr {${build.type} eq "xcode" || !([file exists /usr/lib/libxcselect.dylib] || ${os.major} >= 20) || ![file executable /Library/Developer/CommandLineTools/usr/bin/make]}]}
 

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -1742,7 +1742,12 @@ proc portutil::get_oldbuildpath {} {
 }
 
 proc portutil::create_workpath {} {
-    global workpath subbuildpath subport
+    global workpath subbuildpath subport ports_local
+    if {[tbool ports_local]} {
+        file mkdir $workpath/.home $workpath/.tmp
+        file attributes $workpath -permissions 0755
+        return
+    }
     if {[getuid] == 0 && [geteuid] != 0} {
         elevateToRoot create_workpath
     }
@@ -1860,7 +1865,9 @@ proc open_statefile {args} {
             if {[tbool portfile_changed]} {
                 if {![tbool ports_dryrun]} {
                     ui_notice "Portfile for $subport changed since last build; discarding previous state."
-                    chownAsRoot $subbuildpath
+                    if {![tbool ports_local]} {
+                        chownAsRoot $subbuildpath
+                    }
                     delete $workpath
                     file mkdir $workpath
                     set fresh_build yes

--- a/tests/test.tcl.in
+++ b/tests/test.tcl.in
@@ -7,6 +7,7 @@ set test_suite {
     dependencies-d
     dependencies-e
     envvariables
+    local-mode
     setuid
     site-tags
     statefile-unknown-version

--- a/tests/test/library.tcl.in
+++ b/tests/test/library.tcl.in
@@ -9,6 +9,9 @@ set work_dir "work"
 # constraint indicating whether the platform supports trace mode
 ::tcltest::testConstraint tracemode_support [expr {@TRACEMODE_SUPPORT@ != 0}]
 
+# constraint indicating whether tests are running as a non-root user
+::tcltest::testConstraint nonRoot [expr {[exec id -u] != 0}]
+
 # In-tree test interpreter and source paths
 set test_tclsh "@TEST_TCLSH@"
 set top_srcdir "@abs_top_srcdir@"

--- a/tests/test/local-mode/DESCRIPTION
+++ b/tests/test/local-mode/DESCRIPTION
@@ -1,0 +1,1 @@
+This test checks --local build mode paths and safety checks.

--- a/tests/test/local-mode/Portfile
+++ b/tests/test/local-mode/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem      1.0
+
+name            local-mode
+version         1
+categories      test
+maintainers     nomaintainer
+description     Test port for --local mode
+long_description ${description}
+homepage        https://www.macports.org/
+platforms       any
+supported_archs noarch
+
+distfiles
+use_configure   no
+
+variant missingdep {
+    depends_build-append port:local-mode-missingdep
+}
+
+variant bindep {
+    depends_build-append bin:sh:local-mode-missingdep
+}
+
+build {
+    set fd [open ${workpath}/build.marker w]
+    puts $fd ${workpath}
+    close $fd
+}
+
+destroot {
+    xinstall -d ${destroot}${prefix}/share/${name}
+    set fd [open ${destroot}${prefix}/share/${name}/result w]
+    puts $fd local
+    close $fd
+}

--- a/tests/test/local-mode/test.tcl
+++ b/tests/test/local-mode/test.tcl
@@ -1,0 +1,241 @@
+package require tcltest 2
+namespace import tcltest::*
+
+source [file dirname $argv0]/../library.tcl
+
+set path [file dirname [file normalize $argv0]]
+makeFile "" $output_file
+
+load_variables $path
+set_dir
+set fd [open $portsrc a]
+puts $fd "sandbox_enable no"
+close $fd
+
+proc port_local {args} {
+    global output_file path portsrc test_tclsh top_srcdir
+
+    set back [pwd]
+    cd $path
+    set result [catch {
+        without_darwintrace_env {
+            with_portsrc $portsrc {
+                exec -ignorestderr ${test_tclsh} ${top_srcdir}/src/port/port.tcl -D $path --local {*}$args >$output_file 2>@1
+            }
+        }
+    }]
+    cd $back
+    return $result
+}
+
+proc port_normal_info {} {
+    global output_file path portsrc test_tclsh top_srcdir
+
+    set back [pwd]
+    cd $path
+    set result [catch {
+        without_darwintrace_env {
+            with_portsrc $portsrc {
+                exec -ignorestderr ${test_tclsh} ${top_srcdir}/src/port/port.tcl -D $path info >$output_file 2>@1
+            }
+        }
+    }]
+    cd $back
+    return $result
+}
+
+proc port_normal_installed {} {
+    global output_file path portsrc test_tclsh top_srcdir
+
+    set back [pwd]
+    cd $path
+    set result [catch {
+        without_darwintrace_env {
+            with_portsrc $portsrc {
+                exec -ignorestderr ${test_tclsh} ${top_srcdir}/src/port/port.tcl installed local-mode >$output_file 2>@1
+            }
+        }
+    }]
+    cd $back
+    return $result
+}
+
+proc registry_db_path {} {
+    global test_root
+    return [file join $test_root opt/local/var/macports/registry/registry.db]
+}
+
+proc ensure_registry {} {
+    if {![file exists [registry_db_path]] && [port_normal_info] != 0} {
+        return 1
+    }
+    return 0
+}
+
+proc local_mode_destroot {} {
+    global path test_root output_file
+
+    file delete -force ${path}/work
+    if {[ensure_registry]} {
+        return "FAIL: could not initialize test registry"
+    }
+    if {[port_local destroot] != 0} {
+        return "FAIL: destroot failed"
+    }
+    if {![file exists ${path}/work/build.marker]} {
+        return "FAIL: build marker not in local workpath"
+    }
+    set destroot_result [file normalize "${path}/work/destroot[file normalize $test_root]/opt/local/share/local-mode/result"]
+    if {![file exists $destroot_result]} {
+        return "FAIL: destroot result not in local workpath"
+    }
+    if {![file exists ${path}/work/logs/local-mode/main.log]} {
+        return "FAIL: log not in local workpath"
+    }
+    if {[llength [glob -nocomplain -directory ${test_root}/opt/local/var/macports/build *]] != 0} {
+        return "FAIL: global build path was used"
+    }
+    if {[port_normal_installed] != 0} {
+        return "FAIL: could not query installed ports"
+    }
+    set line [get_line $output_file "*none of the specified ports are installed*"]
+    if {$line eq "-1"} {
+        return "FAIL: local destroot wrote an installed registry entry"
+    }
+
+    return "Local destroot successful."
+}
+
+proc local_mode_clean {} {
+    global path test_root
+
+    if {[ensure_registry]} {
+        return "FAIL: could not initialize test registry"
+    }
+    file mkdir ${path}/work
+    close [open ${path}/work/clean.marker w]
+    file mkdir ${test_root}/opt/local/var/macports/distfiles/local-mode
+    close [open ${test_root}/opt/local/var/macports/distfiles/local-mode/keep w]
+
+    if {[port_local clean --dist] != 0} {
+        return "FAIL: clean failed"
+    }
+    if {[file exists ${path}/work]} {
+        return "FAIL: local workpath not removed"
+    }
+    if {![file exists ${test_root}/opt/local/var/macports/distfiles/local-mode/keep]} {
+        return "FAIL: global distfile was removed"
+    }
+
+    return "Local clean successful."
+}
+
+proc local_mode_reject_install {} {
+    global output_file
+
+    if {[port_local install] == 0} {
+        return "FAIL: install was accepted"
+    }
+    set line [get_line $output_file "*--local does not support 'install'*"]
+    if {$line eq "-1"} {
+        return "FAIL: missing install rejection"
+    }
+    return "Local install rejection successful."
+}
+
+proc local_mode_missing_dependency {} {
+    global output_file
+    global path
+
+    file delete -force ${path}/work
+    if {[ensure_registry]} {
+        return "FAIL: could not initialize test registry"
+    }
+    if {[port_local build +missingdep] == 0} {
+        return "FAIL: missing dependency was accepted"
+    }
+    set line [get_line $output_file "*dependency local-mode-missingdep is not installed and active*"]
+    if {$line eq "-1"} {
+        return "FAIL: missing dependency was not reported"
+    }
+    return "Local dependency rejection successful."
+}
+
+proc local_mode_satisfied_file_dependency {} {
+    global path
+
+    file delete -force ${path}/work
+    if {[ensure_registry]} {
+        return "FAIL: could not initialize test registry"
+    }
+
+    set regdb [registry_db_path]
+    set regdir [file dirname $regdb]
+    set regdb_perms [file attributes $regdb -permissions]
+    set regdir_perms [file attributes $regdir -permissions]
+    try {
+        file attributes $regdb -permissions 0444
+        file attributes $regdir -permissions 0555
+        if {[port_local build +bindep] != 0} {
+            return "FAIL: satisfied bin dependency was rejected"
+        }
+        if {![file exists ${path}/work/build.marker]} {
+            return "FAIL: build did not run"
+        }
+    } finally {
+        file attributes $regdir -permissions $regdir_perms
+        file attributes $regdb -permissions $regdb_perms
+    }
+    return "Local satisfied file dependency successful."
+}
+
+test local_mode_destroot {
+    Local mode keeps build artifacts and logs under the Portfile directory.
+} -constraints {
+    nonRoot
+} -body {
+    local_mode_destroot
+} -cleanup {
+    file delete -force ${path}/work
+} -result "Local destroot successful."
+
+test local_mode_clean {
+    Local mode clean removes only the local work directory.
+} -constraints {
+    nonRoot
+} -body {
+    local_mode_clean
+} -cleanup {
+    file delete -force ${path}/work
+} -result "Local clean successful."
+
+test local_mode_reject_install {
+    Local mode rejects installation actions.
+} -constraints {
+    nonRoot
+} -body {
+    local_mode_reject_install
+} -result "Local install rejection successful."
+
+test local_mode_missing_dependency {
+    Local mode reports missing dependencies without installing them.
+} -constraints {
+    nonRoot
+} -body {
+    local_mode_missing_dependency
+} -cleanup {
+    file delete -force ${path}/work
+} -result "Local dependency rejection successful."
+
+test local_mode_satisfied_file_dependency {
+    Local mode accepts bin/path/lib dependencies satisfied outside the registry.
+} -constraints {
+    nonRoot
+} -body {
+    local_mode_satisfied_file_dependency
+} -cleanup {
+    file delete -force ${path}/work
+} -result "Local satisfied file dependency successful."
+
+cleanup
+cleanupTests


### PR DESCRIPTION
## Summary

This adds a new `--local` / `-L` mode to `port` for Portfile development for doing development builds of ports without root privileges.

Local mode runs non-installing phases (and only non-installing phases) using the normal MacPorts phase machinery, but redirects the build state into a user-owned `./work` directory under the effective Portfile directory instead of to a symlink into a root-owned directory. It is intended for workflows such as:

```sh
cd devel/foo
port --local build
port --local destroot
port --local clean
```

or:

```sh
port -D ~/src/macports-ports/devel/foo -L build
```

## Behavior

In local mode, MacPorts now:

- allows only `fetch`, `checksum`, `extract`, `patch`, `configure`, `build`, `test`, `destroot`, and `clean`
- rejects installing or registry-mutating actions before phase work begins, you need to have all the dependencies for a port installed already.
- refuses to run as root
- uses `${portdir}/work` for build state
- uses local paths under `work` for distfiles, logs, `HOME`, `TMPDIR`, and destroot output
- avoids taking the registry write lock (and can't because it doesn't run as root).
- requires dependencies be installed and active
- fails clearly rather than installing missing dependencies

This mode is not intended to install software, create archives, etc. It's not a substitute for a real mechanism for doing unprivileged builds, which MacPorts could of course use. This is just a developer/sandbox mode for validating Portfile build machinery. When you're ready to actually produce a package or install locally, you need to do that as root.

## Tests

Added `tests/test/local-mode` coverage for:

- local destroot/build output under the Portfile directory
- local logs
- local clean removing only local `./work`
- rejected `install`
- missing dependency failure
- satisfied `bin:` dependency behavior against a read-only registry file

Validation run locally:

```sh
../tests/test-tclsh test.tcl -t local-mode -nocolor
make test
git diff --check
tests/test-tclsh src/port/port -D ~/src/macports-ports/sysutils/tree -L clean
```
