### PR TITLE
portconfigure: sync CCACHE_DIR env before exec ccache -M

### DIFF
--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -420,8 +420,12 @@ proc portconfigure::configure_start {args} {
         }
         dropPrivileges
 
-        # Initialize ccache directory with the given maximum size
+        # Initialize ccache directory with the given maximum size.
+        # Sync env(CCACHE_DIR) to the (possibly port-overridden) ccache_dir so
+        # that the ccache binary targets the same directory that was just created
+        # above rather than the process-level default set in macports.tcl.
         if {${configure.ccache}} {
+            set env(CCACHE_DIR) ${ccache_dir}
             if {[catch {
                 exec ccache -M ${ccache_size} >/dev/null
             } result]} {


### PR DESCRIPTION
## Problem

`macports.tcl` sets `env(CCACHE_DIR)` once at startup to the global `ccache_dir` default (`$portdbpath/build/.ccache`, typically `/opt/local/var/macports/build/.ccache`).

A Portfile can override the Tcl variable `ccache_dir` to a per-build workpath — `py-pytorch` does this:

```tcl
set ccache_dir ${workpath}/.ccache
```

`portconfigure.tcl` (`configure_start`) correctly picks up the overridden Tcl variable and creates/chowns that per-build directory. However the subsequent `exec ccache -M ${ccache_size}` inherits the **stale process-level `CCACHE_DIR`** that still points at the never-created, root-owned default path. The result is:

```
Warning: ccache_dir .../work/.ccache could not be initialized; disabling ccache:
ccache: error: Failed to create directory .../build/.ccache: Permission denied
```

ccache is silently disabled for the entire build even though the port set things up correctly.

## Root cause

`portconfigure.tcl` lines 423–431 (excerpt):

```tcl
# Initialize ccache directory with the given maximum size
if {${configure.ccache}} {
    if {[catch {
        exec ccache -M ${ccache_size} >/dev/null   ;# ← uses env(CCACHE_DIR), not ${ccache_dir}
    } result]} {
        ui_warn "ccache_dir ${ccache_dir} could not be initialized; disabling ccache: $result"
```

`env(CCACHE_DIR)` is never updated to match the current (possibly overridden) `${ccache_dir}` before `exec ccache` runs.

## Fix

One line added immediately before the `exec`:

```tcl
set env(CCACHE_DIR) ${ccache_dir}
```

This syncs the environment to whatever `ccache_dir` was resolved to (global default or per-build override) so the `ccache -M` call targets the directory that was just prepared with `file mkdir` / `file attributes`.

## Verification

Reproduced on MacPorts 2.12.5, ccache 4.13.1, macOS 26 (Darwin 25.5.0) with `py314-pytorch`.  Applying the patch and rebuilding eliminates the warning and ccache works correctly for the build.

## Workaround (until this lands)

```bash
sudo mkdir /opt/local/var/macports/build/.ccache
sudo chown macports:macports /opt/local/var/macports/build/.ccache
```

This is fragile — the directory is wiped by `sudo port clean --all`.