### PR TITLE
Fix possible PortIndex rsync update failure.

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -3968,7 +3968,10 @@ proc mportsync {{options {}}} {
                         set index_source $source
                     }
                     set remote_indexdir "${index_source}PortIndex_${os_platform}_${os_major}_${os_arch}/"
-                    set rsync_commandline "$rsync_path $rsync_options $include_option $remote_indexdir $destdir"
+                    # Under some circumstances, there may be a preexisting PortIndex with the correct length
+                    # and mtime, but incorrect content.  So we add the -I option to suppress skipping
+                    # based on length and time.  Comparison based on content alone isn't very expensive here.
+                    set rsync_commandline "$rsync_path $rsync_options -I $include_option $remote_indexdir $destdir"
                     macports_try -pass_signal {
                         macports::run_unprivileged {system -W $destdir $rsync_commandline}
                         


### PR DESCRIPTION
When attempting to update the local PortIndex from the precomputed version for the current OS/arch, there is sometimes a preexisting version with the correct mtime and size, but not the correct content. With the default options, rsync fails to update it.  This change suppresses skipping based on size and time (for the index-related files, not the tarball).

This bug has no obvious user-visible effect, since the bad PortIndex fails the signature check and is then regenerated, costing extra time but not malfunctioning.  It's visible in the debug output.

TESTED:
Now correctly uses the downloaded index in a formerly failing case.