### PR TITLE
sip_copy_proc: Don't choke on EINTR

### DIFF
--- a/src/pextlib1.0/sip_copy_proc.c
+++ b/src/pextlib1.0/sip_copy_proc.c
@@ -468,7 +468,14 @@ static int resign(const char *filepath) {
         goto resign_out;
     }
 
-    if (pid != waitpid(pid, &exitstatus, 0)) {
+    while (pid != waitpid(pid, &exitstatus, 0)) {
+        if (errno == EINTR) {
+            /* We cannot assume SA_RESTART since we don't know whether the
+             * binary that this is loaded into has it enabled, and we also
+             * can't touch the setting; so we have to expect EINTR and
+             * handle it by re-starting the system call. */
+            continue;
+        }
         if (errno == ECHILD) {
             /* The child vanished before we could waitpid(2) it. This shouldn't
              * happen, but apparently occasionally does in practice, and we


### PR DESCRIPTION
Since this code runs in darwintrace.dylib, which is preloaded into various processes at runtime, we cannot assume that SA_RESTART is set, and we also can't modify the processes' state to enable that. As a consequence, we must expect system calls to fail with EINTR and restart them. Notably, this happened for me during installation of texlive-common with the waitpid() system call for the re-signing operation.

Address this by doing the waitpid in a loop and restarting it on EINTR.