### PR TITLE
port sync: initialize verboseflag before use in HTTPS tarball extract

### DIFF
--- a/src/macports1.0/macports.tcl
+++ b/src/macports1.0/macports.tcl
@@ -4039,6 +4039,7 @@ proc mportsync {{options {}}} {
 
                 global macports::portverbose macports::ui_options
                 set progressflag {}
+                set verboseflag ""
                 if {$portverbose} {
                     set progressflag [list --progress builtin]
                     set verboseflag v


### PR DESCRIPTION
### Description

`mportsync`'s http/https/ftp tarball sync branch uses `${verboseflag}` in the tar extract command:

```tcl
system -W $destdir "$tar $striparg -x${extflag}${kflag}${verboseflag}f [macports::shellescape $tarpath]"
```

but `verboseflag` is only *set* inside the verbose and progress-download branches:

```tcl
set progressflag {}
if {$portverbose} {
    set progressflag [list --progress builtin]
    set verboseflag v
} elseif {[info exists ui_options(progress_download)]} {
    set progressflag [list --progress $ui_options(progress_download)]
    set verboseflag ""
}
```

A non-verbose `port sync` with no download-progress UI takes neither branch, so `verboseflag` is undefined and the extract fails:

```
can't read "verboseflag": no such variable
```

### Reproduction

Configure an **https tarball** ports source in `sources.conf`, e.g. `https://example.com/ports.tar.gz`, then run a plain `sudo port sync`. It errors while extracting the tarball and leaves an empty tree (which then makes subsequent syncs report "No updates" and skip). `sudo port -v sync` works, because `-v` sets `verboseflag`. Reproduces on 2.12.x / current master; the rsync sync path is unaffected (its extract command doesn't reference `verboseflag`).

In practice this hits the first sync and every sync that extracts a newer tarball (i.e. the upgrade case) for any https/ftp tarball ports source.

### Fix

Default `verboseflag` to `""` next to `progressflag`, mirroring how `progressflag` is already initialized just above. One line, no behavior change for the verbose/progress paths.
