### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+## Contributing to MacPorts
+
+The preferred method for contributing changes to the MacPorts code bases
+is by opening a pull request on GitHub. Alternatively, patches may be
+attached to a ticket on our [Trac][1] instance.
+
+You are responsible for your contribution. In particular, by making a
+contribution you are certifying that you have the legal right to do so,
+and that the material in your contribution can be distributed under the
+project's license.
+
+[1]: https://trac.macports.org/
+
+## Use of automated tools
+
+If an LLM or other automated tool was used to generate a contribution
+in whole or part, an `Assisted-by:` tag in the format recommended by
+the Linux kernel developers must be present in the Git commit message.
+
+`Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]`
+
+If contributing via Trac, include this information in the ticket. Please
+see the [kernel documentation][2] for more details.
+
+Bear in mind that using tools does not diminish your responsibility for
+your contributions.
+
+Please do not use agents or similar software to open pull requests or
+tickets without human supervision.
+
+[2]: https://docs.kernel.org/process/coding-assistants.html#attribution


### PR DESCRIPTION
The first section is mostly codifying things that have always been implicit. The second section adopts what appears to be the emerging de facto standard for tagging AI use.

There's obviously a lot more that could be said, but I've tried to keep it minimal so people are likely to read the whole thing. Please discuss on macports-dev in order to reach a wider audience.