### PR TITLE
portlib: make delete handle read-only directories

### DIFF
--- a/src/portlib1.0/portlib.tcl
+++ b/src/portlib1.0/portlib.tcl
@@ -1669,9 +1669,39 @@ namespace eval portlib {
             file copy {*}$args
         }
 
+        # make_deletable
+        # Add write permission to $path and every directory below it, so their
+        # entries can be unlinked. Symlinks are not followed.
+        proc make_deletable {path} {
+            # lstat, so a symlink reports as one rather than as its target.
+            if {[catch {file lstat $path st}] || $st(type) ne "directory"} {
+                return
+            }
+            # w to unlink entries, rx to list and descend.
+            catch {file attributes $path -permissions u+rwx}
+            # Let glob build the paths: [file join $dir ~name] yields ~name,
+            # which Tcl 8 reads as a home directory. -nocomplain is a no-op
+            # under Tcl 9 but is still needed under Tcl 8.
+            foreach entry [glob -nocomplain -directory $path -- * .*] {
+                if {[file tail $entry] in {. ..}} {
+                    continue
+                }
+                make_deletable $entry
+            }
+        }
+
         # delete
         # Wrapper for file delete -force
         proc delete {args} {
+            if {![catch {file delete -force -- {*}$args}]} {
+                return
+            }
+            # -force clears the read-only bit on files but not on directories,
+            # and unlinking an entry needs write permission on the directory
+            # holding it. Take that permission and retry once.
+            foreach path $args {
+                make_deletable $path
+            }
             file delete -force -- {*}$args
         }
 

--- a/src/portlib1.0/tests/portlib.test
+++ b/src/portlib1.0/tests/portlib.test
@@ -66,4 +66,114 @@ test supportedArchiveTypes {
 } -result "Supported archives successful."
 
 
+test delete_readonly_directories {
+    delete must remove a tree whose directories are read-only. Unlinking an
+    entry needs write permission on the directory holding it, and
+    `file delete -force` only clears the read-only bit on files.
+} -setup {
+    file mkdir $pwd/deltest/work/sub
+    close [open $pwd/deltest/work/sub/f w]
+    file attributes $pwd/deltest/work/sub/f -permissions 0444
+    file attributes $pwd/deltest/work/sub -permissions 0555
+    file attributes $pwd/deltest/work -permissions 0555
+} -body {
+    portlib::util::delete $pwd/deltest/work
+    if {[file exists $pwd/deltest/work]} {
+        return "FAIL: work directory still present"
+    }
+    return "Delete of read-only directories successful."
+} -cleanup {
+    catch {exec chmod -R u+w $pwd/deltest}
+    file delete -force $pwd/deltest
+} -result "Delete of read-only directories successful."
+
+
+test make_deletable_does_not_follow_symlinks {
+    make_deletable must not descend through a symlink, which would change
+    permissions outside the tree. Called directly: `file delete -force` chmods
+    a symlink it fails to remove, so going through delete would measure Tcl.
+} -setup {
+    file mkdir $pwd/deltest/outside
+    close [open $pwd/deltest/outside/precious w]
+    file attributes $pwd/deltest/outside -permissions 0555
+    set outside_perms [file attributes $pwd/deltest/outside -permissions]
+    file mkdir $pwd/deltest/tree/sub
+    file link -symbolic $pwd/deltest/tree/sub/link $pwd/deltest/outside
+    file attributes $pwd/deltest/tree/sub -permissions 0555
+} -body {
+    portlib::util::make_deletable $pwd/deltest/tree
+    if {[file attributes $pwd/deltest/outside -permissions] ne $outside_perms} {
+        return "FAIL: permissions changed through the symlink"
+    }
+    if {![file exists $pwd/deltest/outside/precious]} {
+        return "FAIL: symlink target was disturbed"
+    }
+    return "Symlink handling successful."
+} -cleanup {
+    catch {exec chmod -R u+w $pwd/deltest}
+    file delete -force $pwd/deltest
+} -result "Symlink handling successful."
+
+
+test delete_preserves_symlink_targets {
+    delete must remove a tree containing symlinks without deleting what those
+    symlinks point at.
+} -setup {
+    file mkdir $pwd/deltest/outside
+    close [open $pwd/deltest/outside/precious w]
+    file mkdir $pwd/deltest/tree/sub
+    file link -symbolic $pwd/deltest/tree/sub/link $pwd/deltest/outside
+    # Nested, because `file delete -force` chmods the top-level path itself:
+    # a read-only tree/ would succeed first try and skip the recovery path.
+    file attributes $pwd/deltest/tree/sub -permissions 0555
+} -body {
+    portlib::util::delete $pwd/deltest/tree
+    if {[file exists $pwd/deltest/tree]} {
+        return "FAIL: tree still present"
+    }
+    if {![file exists $pwd/deltest/outside]} {
+        return "FAIL: symlink target was deleted"
+    }
+    if {![file exists $pwd/deltest/outside/precious]} {
+        return "FAIL: symlink target contents were deleted"
+    }
+    return "Symlink handling successful."
+} -cleanup {
+    catch {exec chmod -R u+w $pwd/deltest}
+    file delete -force $pwd/deltest
+} -result "Symlink handling successful."
+
+
+test delete_tilde_named_entries {
+    An entry named "~" must be treated as a plain filename. Under Tcl 8,
+    [file join $dir ~name] yields ~name, so building child paths that way
+    would walk into a home directory instead of staying in the tree.
+} -setup {
+    # A stand-in home under our own control, so the test neither depends on
+    # HOME nor can touch the real one. Tcl 8 resolves a bare "~" through HOME.
+    set saved_home [expr {[info exists ::env(HOME)] ? $::env(HOME) : ""}]
+    file mkdir $pwd/deltest/fakehome
+    file attributes $pwd/deltest/fakehome -permissions 0555
+    set home_perms [file attributes $pwd/deltest/fakehome -permissions]
+    set ::env(HOME) $pwd/deltest/fakehome
+    file mkdir $pwd/deltest/tree/~
+    close [open $pwd/deltest/tree/~/f w]
+    file attributes $pwd/deltest/tree/~ -permissions 0555
+    file attributes $pwd/deltest/tree -permissions 0555
+} -body {
+    portlib::util::delete $pwd/deltest/tree
+    if {[file exists $pwd/deltest/tree]} {
+        return "FAIL: tree still present"
+    }
+    if {[file attributes $pwd/deltest/fakehome -permissions] ne $home_perms} {
+        return "FAIL: home directory permissions were modified"
+    }
+    return "Tilde handling successful."
+} -cleanup {
+    set ::env(HOME) $saved_home
+    catch {exec chmod -R u+w $pwd/deltest}
+    file delete -force $pwd/deltest
+} -result "Tilde handling successful."
+
+
 cleanupTests


### PR DESCRIPTION
file delete -force clears the read-only bit on files but not on
directories, and unlinking an entry requires write permission on the
directory containing it. It also chmods only the top-level path, not
nested ones. A tree with read-only subdirectories therefore cannot be
removed except by root, which bypasses the check.

Go's module cache creates its directories mode 0555, so this breaks the
automatic work directory wipe: when a Portfile changes, open_statefile
drops privileges and deletes workpath as the macports user, which fails.
The clean target survives only because it elevates to root first.

Take the needed permissions and retry once. Doing this rather than
elevating keeps it working for unprivileged installs, where there is no
root to fall back on, and covers any source of read-only directories
rather than one ecosystem.

Symlinks are not followed, so permissions outside the tree are untouched,
and child paths come from glob rather than file join, which would turn an
entry named ~foo into a home directory reference under Tcl 8.

Assisted-by: Claude:claude-opus-5

